### PR TITLE
Update elixir sense to get typespec support

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "c7ed928ad1c0e2ddf94a951fabe93b7af9b6a78a", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "3faac98c402b8a402adac99fe6c94c176616dadd", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.2", "cb0e6878fdf86dc63509eaf2233a71fa73fc383c8362c8ff8e8b6f0c2bb7017c", [:mix], [], "hexpm"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Adds support for this branch: https://github.com/elixir-lsp/elixir_sense/pull/16

Also brings in a commit from @msaraiva that adds typespec support to elixir-ls