### PR TITLE
Start the beam instance with the ability to cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- Automatically cluster beam nodes to allow for easier debugging
+
 ### v0.2.26: 4 Sept 2019
 
 - Dialyxir new 1.0-rc formatting support

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Basic troubleshooting steps:
 
 If your code doesn't compile in ElixirLS, it may be because ElixirLS compiles code with `MIX_ENV=test` (by default). So if you are missing some configuration in the test environment, your code may not compile.
 
+ElixirLS automatically starts up a node that you can connect to if you want to debug the server. Simply run the following in an iEX session (note if there's multiple ElixirLS instances running you may need to connect to a higher number than 0, see the server logs for the specific node name):
+
+    {:ok, hostname} = :inet.gethostname()
+    Node.connect(:"elixirls-0@#{hostname}")
+
+Then you can run `:observer.start()` (make sure to use the "Nodes" menu to change to the ElixirLS node) or any tracing commands.
+
 ## Building and running
 
 Run `mix compile`, then `mix elixir_ls.release -o <release_dir>`. This builds the language server and debugger as a set of `.ez` archives and creates `.sh` and `.bat` scripts to launch them.

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -27,12 +27,13 @@ defmodule ElixirLS.LanguageServer.CLI do
         start_node(number + 1)
 
       {:ok, _pid} ->
-        IO.puts("Started node with name #{inspect(node_name)}")
-        Node.set_cookie(node_name, :cookie)
+        IO.puts(
+          "Started node with name #{inspect(node_name)}. Connect with Node.connect(#{
+            inspect(node_name)
+          })"
+        )
 
-        for num <- Range.new(0, number) do
-          Node.connect(node_name(num))
-        end
+        Node.set_cookie(node_name, :cookie)
     end
   end
 


### PR DESCRIPTION
This probably isn't good to merge as-is. I'm thinking that auto-clustering should be opt-in based on a configuration settings file. Does anyone have thoughts about this? Another option is that I could just keep this as a patch locally for my own debugging.

EDIT: Updated to not auto-cluster but still start up distribution