### PR TITLE
Annotate tool-versions file and upgrade elixir and OTP versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,7 @@
-elixir 1.7.4-otp-21
-erlang 21.3.8
+# This file contains the recommended versions for developing and running
+# elixir-ls. However, elixir-ls supports a minumum version of Elixir 1.7.0 with
+# OTP 19 and should work with any later releases.
+# Using asdf to manage your elixir and OTP versions is not required, you can
+# use the system-installed version instead.
+elixir 1.9.1-otp-22
+erlang 22.0.7


### PR DESCRIPTION
This makes it more clear why we have a `.tool-versions` file in the repository and tells you that you can ignore it if you'd like.