### PR TITLE
Remove calls to super() from GenServer

### DIFF
--- a/apps/debugger/lib/debugger/output.ex
+++ b/apps/debugger/lib/debugger/output.ex
@@ -48,8 +48,4 @@ defmodule ElixirLS.Debugger.Output do
     send(event(seq, event, body))
     {:reply, :ok, seq + 1}
   end
-
-  def handle_call(message, from, s) do
-    super(message, from, s)
-  end
 end

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -108,10 +108,6 @@ defmodule ElixirLS.Debugger.Server do
     {:noreply, state}
   end
 
-  def handle_info(msg, state) do
-    super(msg, state)
-  end
-
   def terminate(reason, _state) do
     if reason != :normal do
       IO.puts(:standard_error, "(Debugger) Terminating because #{Exception.format_exit(reason)}")

--- a/apps/elixir_ls_utils/test/support/packet_capture.ex
+++ b/apps/elixir_ls_utils/test/support/packet_capture.ex
@@ -31,10 +31,6 @@ defmodule ElixirLS.Utils.PacketCapture do
     handle_output(to_string(module.apply(fun, args)), from, reply_as, parent)
   end
 
-  def handle_info(msg, s) do
-    super(msg, s)
-  end
-
   defp handle_output(str, from, reply_as, parent) do
     case extract_packet(str) do
       nil ->

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -184,11 +184,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     {:noreply, state}
   end
 
-  def handle_info(msg, state) do
-    super(msg, state)
-  end
-
-  def terminate(reason, state) do
+  def terminate(reason, _state) do
     if reason != :normal do
       JsonRpc.show_message(
         :error,
@@ -196,8 +192,6 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
           "\"elixirLS.dialyzerEnabled\" to false in settings.json to disable it"
       )
     end
-
-    super(reason, state)
   end
 
   ## Helpers

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -104,10 +104,6 @@ defmodule ElixirLS.LanguageServer.Server do
     end
   end
 
-  def handle_call(msg, from, state) do
-    super(msg, from, state)
-  end
-
   def handle_cast({:build_finished, {status, diagnostics}}, state)
       when status in [:ok, :noop, :error] and is_list(diagnostics) do
     {:noreply, handle_build_result(status, diagnostics, state)}
@@ -147,10 +143,6 @@ defmodule ElixirLS.LanguageServer.Server do
 
   def handle_cast(:rebuild, state) do
     {:noreply, trigger_build(state)}
-  end
-
-  def handle_cast(msg, state) do
-    super(msg, state)
   end
 
   def handle_info(:send_file_watchers, state) do
@@ -208,10 +200,6 @@ defmodule ElixirLS.LanguageServer.Server do
       end
 
     {:noreply, state}
-  end
-
-  def handle_info(info, state) do
-    super(info, state)
   end
 
   ## Helpers


### PR DESCRIPTION
These were deprecated in 1.7 and are not needed