### PR TITLE
Bump Erlang/OTP minimum version to OTP 20

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # This file contains the recommended versions for developing and running
 # elixir-ls. However, elixir-ls supports a minumum version of Elixir 1.7.0 with
-# OTP 19 and should work with any later releases.
+# OTP 20 and should work with any later releases.
 # Using asdf to manage your elixir and OTP versions is not required, you can
 # use the system-installed version instead.
 elixir 1.9.1-otp-22

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - mix test
 matrix:
   include:
-    - otp_release: 19.3
+    - otp_release: 20.3
       elixir: 1.7.4
     - otp_release: 21.3
       elixir: 1.8.1

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Elixir:
 
 Erlang:
 
-- OTP 19 minimum
-- \>= OTP 20 recommended
+- OTP 20 minimum
 
 You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.
 
@@ -96,7 +95,7 @@ If your code doesn't compile in ElixirLS, it may be because ElixirLS compiles co
 
 Run `mix compile`, then `mix elixir_ls.release -o <release_dir>`. This builds the language server and debugger as a set of `.ez` archives and creates `.sh` and `.bat` scripts to launch them.
 
-If you're packaging these archives in an IDE plugin, make sure to build using Erlang/OTP 19, not OTP 20, because OTP 20 beam files are not backwards-compatible with earlier Erlang versions. Alternatively, you can use a [precompiled release](https://github.com/JakeBecker/elixir-ls/releases).
+If you're packaging these archives in an IDE plugin, make sure to build using the minimum supported OTP version for the best backwards-compatibility. Alternatively, you can use a [precompiled release](https://github.com/JakeBecker/elixir-ls/releases).
 
 ## Acknowledgements and related projects
 

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -531,9 +531,9 @@ defmodule ElixirLS.Debugger.Server do
   defp check_erlang_version do
     version = String.to_integer(to_string(:erlang.system_info(:otp_release)))
 
-    if version < 19 do
+    if version < 20 do
       IO.warn(
-        "Erlang version >= OTP 19 is required to debug Elixir. " <>
+        "Erlang version >= OTP 20 is required to debug Elixir. " <>
           "(Current version: #{version})\n"
       )
     end

--- a/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
+++ b/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
@@ -39,9 +39,9 @@ defmodule Mix.Tasks.ElixirLs.Release do
   defp version_warning do
     {otp_version, _} = Integer.parse(to_string(:erlang.system_info(:otp_release)))
 
-    if otp_version > 19 do
+    if otp_version > 20 do
       IO.warn(
-        "Building with Erlang/OTP #{otp_version}. Make sure to build with OTP 19 if " <>
+        "Building with Erlang/OTP #{otp_version}. Make sure to build with OTP 20 if " <>
           "publishing the compiled packages because modules built with higher versions are not " <>
           "backwards-compatible.",
         []


### PR DESCRIPTION
This is because the dialyzer implementation relies on `dialyzer_utils:get_core_from_beam/1` which was added in OTP 20 along with the Dbgi chunk in:

https://github.com/erlang/otp/commit/dfb899c0229f7ff7dbfad34d496e0429562728bf

I think after this we should not try to increase the minimum OTP versions for a while (6 months to a year). My thinking is I don't want to add code to add support for lower OTP versions that were not previously working, but in some cases it is okay to add code to continue support of older OTP versions.