### PR TITLE
Enforce no warnings in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ script:
   - MIX_ENV=test mix compile --force --warnings-as-errors
   - mix format --check-formatted
   - mix test
+env:
+  global:
+    - MIX_HOME=$HOME/.mix
+cache:
+  directories:
+  - $HOME/.mix
+  - deps
+  - _build
 matrix:
   include:
     - otp_release: 20.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: elixir
 script:
+  - MIX_ENV=test mix compile --force --warnings-as-errors
   - mix format --check-formatted
   - mix test
 matrix:


### PR DESCRIPTION
Travis caching config partially taken from:
https://github.com/sasa1977/boundaries/blob/ede277f536cc54e8204acc069f9511c0a2d2cf38/.travis.yml