### PR TITLE
Fix Map.drop deprecation warning in Elixir 1.9.1

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -310,7 +310,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         stale_modules = dependent_modules(changed_modules ++ removed_modules, mod_deps)
 
         # Remove modules that need analysis from mod_deps and PLT
-        mod_deps = Map.drop(mod_deps, stale_modules)
+        mod_deps = Map.drop(mod_deps, MapSet.to_list(stale_modules))
         for module <- stale_modules, do: :dialyzer_plt.delete_module(active_plt, module)
 
         # For changed modules, we look at erlang AST to find referenced modules that aren't analyzed


### PR DESCRIPTION
Example warning:
```
warning: Map.drop/2 with an Enumerable of keys that is not a list is deprecated.  Use a list of keys instead.

  (elixir) lib/map.ex:695: Map.drop/2
  (language_server) lib/language_server/dialyzer.ex:313: anonymous fn/7 in ElixirLS.LanguageServer.Dialyzer.compile/2
  (stdlib) timer.erl:166: :timer.tc/1
  (language_server) lib/language_server/dialyzer.ex:288: ElixirLS.LanguageServer.Dialyzer.compile/2
```