### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### v0.2.26: 4 Sept 2019
 
 - Dialyxir new 1.0-rc formatting support
 - `can_format/2` now case-insensitive (fixes formatting on Mac OS X)

--- a/apps/debugger/mix.exs
+++ b/apps/debugger/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirLS.Debugger.Mixfile do
   def project do
     [
       app: :debugger,
-      version: "0.2.24",
+      version: "0.2.26",
       build_path: "../../_build",
       config_path: "config/config.exs",
       deps_path: "../../deps",

--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirLS.Utils.Mixfile do
   def project do
     [
       app: :elixir_ls_utils,
-      version: "0.2.24",
+      version: "0.2.26",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
   def project do
     [
       app: :language_server,
-      version: "0.2.24",
+      version: "0.2.26",
       elixir: ">= 1.7.0",
       build_path: "../../_build",
       config_path: "config/config.exs",


### PR DESCRIPTION
In preparation for publishing v0.2.26 of vscode-elixir-ls.  Once this is merged I can make the version update and submodule ref update, and publish to the vscode marketplace.