### PR TITLE
Move .elixir_ls folder inside of _build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Starting in Elixir 1.6, Mix compilers adhere to the [Mix.Task.Compiler](https://
 
 ## Dialyzer integration
 
-If you're using Erlang >= OTP 20, ElixirLS will automatically analyze your project with Dialyzer after each successful build. It maintains a "manifest" file in `.elixir_ls/dialyzer_manifest` that stores the results of the analysis. The initial analysis for a project can take a few minutes, but after that's completed, modules are re-analyzed only if necessary, so subsequent analyses are typically very fast -- often less than a second. It also looks at your modules' abstract code to determine whether they reference any modules that haven't been analyzed and includes them automatically.
+If you're using Erlang >= OTP 20, ElixirLS will automatically analyze your project with Dialyzer after each successful build. It maintains a "manifest" file in `_build/.elixir_ls/dialyzer_manifest` that stores the results of the analysis. The initial analysis for a project can take a few minutes, but after that's completed, modules are re-analyzed only if necessary, so subsequent analyses are typically very fast -- often less than a second. It also looks at your modules' abstract code to determine whether they reference any modules that haven't been analyzed and includes them automatically.
 
 You can control which warnings are shown using the `elixirLS.dialyzerWarnOpts` setting in your project or IDE's `settings.json`. To disable it completely, set `elixirLS.dialyzerEnabled` to false.
 

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -14,7 +14,7 @@ defmodule ElixirLS.Debugger.Server do
   use GenServer
   use Protocol
 
-  @temp_beam_dir ".elixir_ls/temp_beams"
+  @temp_beam_dir "_build/.elixir_ls/temp_beams"
 
   defstruct client_info: nil,
             config: %{},

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -122,7 +122,7 @@ defmodule ElixirLS.LanguageServer.Build do
       Mix.Task.clear()
 
       # Override build directory to avoid interfering with other dev tools
-      Mix.ProjectStack.post_config(build_path: ".elixir_ls/build")
+      Mix.ProjectStack.post_config(build_path: "_build/.elixir_ls/build")
 
       # If using Elixir 1.6 or higher, we can get diagnostics if Mixfile fails to load
       {status, diagnostics} =

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -262,7 +262,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   defp temp_file_path(root_path, file) do
-    Path.join([root_path, ".elixir_ls/dialyzer_tmp", file])
+    Path.join([root_path, "_build/.elixir_ls/dialyzer_tmp", file])
   end
 
   defp write_temp_file(root_path, file_path, content) do

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -152,7 +152,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   defp manifest_path(root_path) do
     Path.join([
       root_path,
-      ".elixir_ls/dialyzer_manifest_#{otp_vsn()}_elixir-#{System.version()}_#{Mix.env()}"
+      "_build/.elixir_ls/dialyzer_manifest_#{otp_vsn()}_elixir-#{System.version()}_#{Mix.env()}"
     ])
   end
 


### PR DESCRIPTION
## Background

This is a straight port of JakeBecker/elixir-ls#166. See that PR for more details, but essentially it moves .elixir_ls under the top-level `_build` directory which I think makes more sense than a separate directory.