### PR TITLE
Fix debugger process on Elixir 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+- Fix debugger tasks not continuing to run on Elixir 1.9 (thanks to [joshua-andrassy](https://github.com/joshua-andrassy) for doing the legwork)
+  - Fixes [JakeBecker/elixir-ls#194](https://github.com/JakeBecker/elixir-ls/issues/194) and [JakeBecker/elixir-ls#185](https://github.com/JakeBecker/elixir-ls/issues/185)
+
 VSCode:
 
 - Add syntax rules for function calls [vscode-elixir-ls #15](https://github.com/elixir-lsp/vscode-elixir-ls/pull/15) (thanks [CaiqueMitsuoka](https://github.com/CaiqueMitsuoka))

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -561,6 +561,11 @@ defmodule ElixirLS.Debugger.Server do
 
   defp launch_task(task, args) do
     Mix.Task.run(task, args)
+
+    # Starting from Elixir 1.9 Mix.Task.run will return so we need to sleep our
+    # process so that the code keeps running (Note: process is expected to be
+    # killed by stopping the debugger)
+    Process.sleep(:infinity)
   end
 
   # Interpreting modules defined in .exs files requires that we first load the file and save any


### PR DESCRIPTION
Ensure debugger process continues to run, adapts to the new behavior in Elixir 1.9 that changed `Mix.Task.run` to return instead of sleeping indefinitely:
https://github.com/elixir-lang/elixir/commit/3673849e36f0182c6c7f410b0f59e6252da11942

- Fixes https://github.com/JakeBecker/elixir-ls/issues/194
- Fixes https://github.com/JakeBecker/elixir-ls/issues/185