### PR TITLE
Fix Manifest race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix debugger tasks not continuing to run on Elixir 1.9 (thanks to [joshua-andrassy](https://github.com/joshua-andrassy) for doing the legwork)
   - Fixes [JakeBecker/elixir-ls#194](https://github.com/JakeBecker/elixir-ls/issues/194) and [JakeBecker/elixir-ls#185](https://github.com/JakeBecker/elixir-ls/issues/185)
+- Improve supervision tree when writing dialyzer manifest files 
 
 VSCode:
 

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -110,7 +110,8 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
           }
 
         :error ->
-          %{state | analysis_pid: Manifest.build_new_manifest()}
+          {:ok, pid} = Manifest.build_new_manifest()
+          %{state | analysis_pid: pid}
       end
 
     {:ok, state}

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -11,7 +11,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   def build_new_manifest() do
     parent = self()
 
-    spawn_link(fn ->
+    Task.start_link(fn ->
       active_plt = load_elixir_plt()
       transfer_plt(active_plt, parent)
 


### PR DESCRIPTION
The anonymous function spawned in `ElixirLS.LanguageServer.Dialyzer.Manifest`
was not guaranteed to stop before it's parent (`ElixirLS.LanguageServer.Server`).
In the tests this would manifest itself as an occasion error when the Manifest
spawned process would try to read from an ETS table owned by the server after
the server was already dead which resulted in an `ArgumentError`. An example of
this error occurring can be found at:
https://travis-ci.org/elixir-lsp/elixir-ls/jobs/612862401

By changing the `spawn_link` to a `Task.start_link` we ensure that the spawned
process (now a task) is properly supervised and is brought down before its
parent is, thus eliminating the race condition with the ETS table ownership.