### PR TITLE
Improvements to document outline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: elixir
 script:
   - MIX_ENV=test mix compile --force --warnings-as-errors
-  - if [ $CHECK_FORMATTED -eq true ]; then
+  - if [ "$CHECK_FORMATTED" -eq 1 ]
+    then
       mix format --check-formatted
     else
       echo "Not checking formatting"
     fi
+
   - mix test
 env:
   global:
@@ -23,4 +25,4 @@ matrix:
       elixir: 1.8.1
     - otp_release: 22.0
       elixir: 1.9.1
-      env: CHECK_FORMATTED=true
+      env: CHECK_FORMATTED=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 script:
   - MIX_ENV=test mix compile --force --warnings-as-errors
-  - if [ "$CHECK_FORMATTED" = "true" ]; then
+  - if [ $CHECK_FORMATTED -eq true ]; then
       mix format --check-formatted
     else
       echo "Not checking formatting"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: elixir
 script:
   - MIX_ENV=test mix compile --force --warnings-as-errors
-  - mix format --check-formatted
+  - if [ "$CHECK_FORMATTED" = "true" ]; then
+      mix format --check-formatted
+    else
+      echo "Not checking formatting"
+    fi
   - mix test
 env:
   global:
@@ -19,3 +23,4 @@ matrix:
       elixir: 1.8.1
     - otp_release: 22.0
       elixir: 1.9.1
+      env: CHECK_FORMATTED=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: elixir
 script:
   - MIX_ENV=test mix compile --force --warnings-as-errors
-  - if [ "$CHECK_FORMATTED" -eq 1 ]
+  - |
+    if [[ "$CHECK_FORMATTED" -eq 1 ]]
     then
       mix format --check-formatted
     else
       echo "Not checking formatting"
     fi
-
   - mix test
 env:
   global:

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -260,8 +260,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   defp extract_module_name(list) when is_list(list) do
     list_stringified =
       list
-      |> Enum.map(&extract_module_name/1)
-      |> Enum.join(", ")
+      |> Enum.map_join(", ", &extract_module_name/1)
 
     "[" <> list_stringified <> "]"
   end

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -258,9 +258,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   end
 
   defp extract_module_name(list) when is_list(list) do
-    list_stringified =
-      list
-      |> Enum.map_join(", ", &extract_module_name/1)
+    list_stringified = list |> Enum.map_join(", ", &extract_module_name/1)
 
     "[" <> list_stringified <> "]"
   end

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -94,6 +94,17 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     )
   end
 
+  defp extract_symbol(_module_name, {defname, location, _properties})
+       when defname in [:defstruct, :defexception] do
+    name =
+      case defname do
+        :defstruct -> "struct"
+        :defexception -> "exception"
+      end
+
+    %{type: :struct, name: name, location: location, children: []}
+  end
+
   # Module Variable
 
   defp extract_symbol(_, {:@, _, [{:moduledoc, _, _}]}), do: nil

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -72,7 +72,13 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
       |> Enum.map(&extract_symbol(module_name, &1))
       |> Enum.reject(&is_nil/1)
 
-    %{type: :module, name: module_name, location: location, children: module_symbols}
+    type =
+      case defname do
+        :defmodule -> :module
+        :defprotocol -> :interface
+      end
+
+    %{type: type, name: module_name, location: location, children: module_symbols}
   end
 
   # Protocol implementations

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -59,6 +59,10 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     [extract_symbol("", ast)]
   end
 
+  defp extract_modules({:config, _, _} = ast) do
+    [extract_symbol("", ast)]
+  end
+
   defp extract_modules(_ast), do: []
 
   # Modules, protocols
@@ -151,7 +155,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
-  # Test
+  # ExUnit test
   defp extract_symbol(_current_module, {:test, location, [name | _]}) do
     %{
       type: :function,
@@ -161,6 +165,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
+  # ExUnit setup and setup_all callbacks
   defp extract_symbol(_current_module, {name, location, [_name | _]})
        when name in [:setup, :setup_all] do
     %{
@@ -171,7 +176,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
-  # Describe
+  # ExUnit describe
   defp extract_symbol(current_module, {:describe, location, [name | ast]}) do
     [[do: module_body]] = ast
 
@@ -191,6 +196,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
       name: ~s(describe "#{name}"),
       location: location,
       children: module_symbols
+    }
+  end
+
+  # Config entry
+  defp extract_symbol(_current_module, {:config, location, [app, name | _]}) do
+    %{
+      type: :key,
+      name: "config :#{app} :#{name}",
+      location: location,
+      children: []
     }
   end
 

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -206,4 +206,6 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
       erlang_module -> erlang_module
     end
   end
+
+  defp extract_module_name(_), do: "# unknown"
 end

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -31,6 +31,8 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     type_parameter: 26
   }
 
+  @defs [:def, :defp, :defmacro, :defmacrop, :defguard, :defguardp, :defdelegate]
+
   def symbols(uri, text) do
     symbols = list_symbols(text) |> Enum.map(&build_symbol_information(uri, &1))
     {:ok, symbols}
@@ -85,28 +87,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     %{type: :constant, name: "@#{name}", location: location, children: []}
   end
 
-  # Function
-  defp extract_symbol(_current_module, {:def, _, [{_, location, _} = fn_head | _]}) do
-    %{
-      type: :function,
-      name: Macro.to_string(fn_head),
-      location: location,
-      children: []
-    }
-  end
-
-  # Private Function
-  defp extract_symbol(_current_module, {:defp, _, [{_, location, _} = fn_head | _]}) do
-    %{
-      type: :function,
-      name: Macro.to_string(fn_head),
-      location: location,
-      children: []
-    }
-  end
-
-  # Macro
-  defp extract_symbol(_current_module, {:defmacro, _, [{_, location, _} = fn_head | _]}) do
+  # Function, macro, guard, delegate
+  defp extract_symbol(_current_module, {defname, _, [{_, location, _} = fn_head | _]})
+       when defname in @defs do
     %{
       type: :function,
       name: Macro.to_string(fn_head),

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -161,6 +161,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
+  defp extract_symbol(_current_module, {name, location, [_name | _]})
+       when name in [:setup, :setup_all] do
+    %{
+      type: :function,
+      name: "#{name}",
+      location: location,
+      children: []
+    }
+  end
+
   # Describe
   defp extract_symbol(current_module, {:describe, location, [name | ast]}) do
     [[do: module_body]] = ast

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -38,38 +38,19 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
 
   defp list_symbols(src) do
     Code.string_to_quoted!(src, columns: true, line: 0)
-    |> extract_moduls()
+    |> extract_modules()
   end
 
   # Identify and extract the module symbol, and the symbols contained within the module
-  defp extract_moduls({:__block__, [], ast}) do
-    ast |> Enum.map(&extract_moduls(&1)) |> List.flatten()
+  defp extract_modules({:__block__, [], ast}) do
+    ast |> Enum.map(&extract_modules(&1)) |> List.flatten()
   end
 
-  defp extract_moduls({:defmodule, _, _child_ast} = ast) do
+  defp extract_modules({:defmodule, _, _child_ast} = ast) do
     [extract_symbol("", ast)]
   end
 
-  defp extract_moduls_aaa({:defmodule, _, _child_ast} = ast) do
-    {_, _, [{:__aliases__, location, module_name}, [do: module_body]]} = ast
-
-    mod_defns =
-      case module_body do
-        {:__block__, [], mod_defns} -> mod_defns
-        stmt -> [stmt]
-      end
-
-    module_name = Enum.join(module_name, ".")
-
-    module_symbols =
-      mod_defns
-      |> Enum.map(&extract_symbol(module_name, &1))
-      |> Enum.reject(&is_nil/1)
-
-    [%{type: :module, name: module_name, location: location, children: module_symbols}]
-  end
-
-  defp extract_moduls(_ast), do: []
+  defp extract_modules(_ast), do: []
 
   # Module Variable
   defp extract_symbol(_module_name, {:defmodule, _, _child_ast} = ast) do

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -215,23 +215,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
       case config_entry do
         list when is_list(list) ->
           list
-          |> Enum.map(fn
-            {key, _} when is_atom(key) -> key
-            _ -> nil
-          end)
-          |> Enum.reject(&is_nil/1)
+          |> Enum.map(fn {key, _} -> Macro.to_string(key) end)
 
-        key when is_atom(key) ->
-          [key]
-
-        _ ->
-          []
+        key ->
+          [Macro.to_string(key)]
       end
 
     for key <- keys do
       %{
         type: :key,
-        name: "config :#{app} :#{key}",
+        name: "config :#{app} #{key}",
         location: location,
         children: []
       }

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -786,6 +786,226 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "skips docs attributes" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      @moduledoc ""
+      @doc ""
+      @typedoc ""
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles various builtin attributes" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      @optional_callbacks non_vital_fun: 0, non_vital_macro: 1
+      @behaviour MyBehaviour
+      @impl true
+      @derive [MyProtocol]
+      @enforce_keys [:name]
+      @compile {:inline, my_fun: 1}
+      @deprecated ""
+      @dialyzer {:nowarn_function, my_fun: 1}
+      @file "hello.ex"
+      @external_resource ""
+      @on_load :load_check
+      @on_definition :load_check
+      @vsn "1.0"
+      @after_compile __MODULE__
+      @before_compile __MODULE__
+      @fallback_to_any true
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@optional_callbacks",
+                    range: %{end: %{character: 3, line: 1}, start: %{character: 3, line: 1}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 1},
+                      start: %{character: 3, line: 1}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@behaviour",
+                    range: %{end: %{character: 3, line: 2}, start: %{character: 3, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 2},
+                      start: %{character: 3, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@impl",
+                    range: %{end: %{character: 3, line: 3}, start: %{character: 3, line: 3}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 3},
+                      start: %{character: 3, line: 3}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@derive",
+                    range: %{end: %{character: 3, line: 4}, start: %{character: 3, line: 4}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 4},
+                      start: %{character: 3, line: 4}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@enforce_keys",
+                    range: %{end: %{character: 3, line: 5}, start: %{character: 3, line: 5}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 5},
+                      start: %{character: 3, line: 5}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@compile",
+                    range: %{end: %{character: 3, line: 6}, start: %{character: 3, line: 6}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 6},
+                      start: %{character: 3, line: 6}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@deprecated",
+                    range: %{end: %{character: 3, line: 7}, start: %{character: 3, line: 7}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 7},
+                      start: %{character: 3, line: 7}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@dialyzer",
+                    range: %{end: %{character: 3, line: 8}, start: %{character: 3, line: 8}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 8},
+                      start: %{character: 3, line: 8}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@file",
+                    range: %{end: %{character: 3, line: 9}, start: %{character: 3, line: 9}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 9},
+                      start: %{character: 3, line: 9}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@external_resource",
+                    range: %{end: %{character: 3, line: 10}, start: %{character: 3, line: 10}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 10},
+                      start: %{character: 3, line: 10}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@on_load",
+                    range: %{end: %{character: 3, line: 11}, start: %{character: 3, line: 11}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 11},
+                      start: %{character: 3, line: 11}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@on_definition",
+                    range: %{end: %{character: 3, line: 12}, start: %{character: 3, line: 12}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 12},
+                      start: %{character: 3, line: 12}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@vsn",
+                    range: %{end: %{character: 3, line: 13}, start: %{character: 3, line: 13}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 13},
+                      start: %{character: 3, line: 13}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@after_compile",
+                    range: %{end: %{character: 3, line: 14}, start: %{character: 3, line: 14}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 14},
+                      start: %{character: 3, line: 14}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@before_compile",
+                    range: %{end: %{character: 3, line: 15}, start: %{character: 3, line: 15}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 15},
+                      start: %{character: 3, line: 15}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@fallback_to_any",
+                    range: %{end: %{character: 3, line: 16}, start: %{character: 3, line: 16}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 16},
+                      start: %{character: 3, line: 16}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles exunit tests" do
     uri = "file://project/test.exs"
     text = ~S[

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1205,6 +1205,8 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
        format: "$date $time [$level] $metadata$message\n",
        metadata: [:user_id]
     config :app, :key, :value
+    config :my_app,
+      ecto_repos: [MyApp.Repo]
     """
 
     assert {:ok,
@@ -1222,6 +1224,13 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 name: "config :app :key",
                 range: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}},
                 selectionRange: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}}
+              },
+              %{
+                children: [],
+                kind: 20,
+                name: "config :my_app :ecto_repos",
+                range: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}},
+                selectionRange: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}}
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -74,12 +74,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 kind: 2,
                 name: "MyModule",
                 range: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 }
               }
             ]} = DocumentSymbols.symbols(uri, text)
@@ -118,24 +118,24 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     kind: 2,
                     name: "SubModule",
                     range: %{
-                      end: %{character: 18, line: 2},
-                      start: %{character: 18, line: 2}
+                      end: %{character: 8, line: 2},
+                      start: %{character: 8, line: 2}
                     },
                     selectionRange: %{
-                      end: %{character: 18, line: 2},
-                      start: %{character: 18, line: 2}
+                      end: %{character: 8, line: 2},
+                      start: %{character: 8, line: 2}
                     }
                   }
                 ],
                 kind: 2,
                 name: "MyModule",
                 range: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 }
               }
             ]} = DocumentSymbols.symbols(uri, text)
@@ -173,12 +173,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 kind: 2,
                 name: "MyModule",
                 range: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 }
               },
               %{
@@ -200,13 +200,75 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 kind: 2,
                 name: "MyOtherModule",
                 range: %{
-                  end: %{character: 16, line: 4},
-                  start: %{character: 16, line: 4}
+                  end: %{character: 6, line: 4},
+                  start: %{character: 6, line: 4}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 4},
-                  start: %{character: 16, line: 4}
+                  end: %{character: 6, line: 4},
+                  start: %{character: 6, line: 4}
                 }
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles elixir atom module definitions" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule :'Elixir.MyModule' do
+        def my_fn(), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn()",
+                    range: %{end: %{character: 12, line: 2}, start: %{character: 12, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 2},
+                      start: %{character: 12, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles erlang atom module definitions" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule :my_module do
+        def my_fn(), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn()",
+                    range: %{end: %{character: 12, line: 2}, start: %{character: 12, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 2},
+                      start: %{character: 12, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "my_module",
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
@@ -241,12 +303,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 kind: 2,
                 name: "MyModuleTest",
                 range: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 }
               }
             ]} = DocumentSymbols.symbols(uri, text)
@@ -298,12 +360,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 kind: 2,
                 name: "MyModuleTest",
                 range: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 },
                 selectionRange: %{
-                  end: %{character: 16, line: 1},
-                  start: %{character: 16, line: 1}
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
                 }
               }
             ]} = DocumentSymbols.symbols(uri, text)

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1207,6 +1207,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
     config :app, :key, :value
     config :my_app,
       ecto_repos: [MyApp.Repo]
+    config :my_app, MyApp.Repo,
+      migration_timestamps: [type: :naive_datetime_usec],
+      username: "postgres"
     """
 
     assert {:ok,
@@ -1231,6 +1234,13 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 name: "config :my_app :ecto_repos",
                 range: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}},
                 selectionRange: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}}
+              },
+              %{
+                children: [],
+                kind: 20,
+                name: "config :my_app MyApp.Repo",
+                range: %{end: %{character: 0, line: 9}, start: %{character: 0, line: 9}},
+                selectionRange: %{end: %{character: 0, line: 9}, start: %{character: 0, line: 9}}
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -504,6 +504,70 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "handles module definitions with struct" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      defstruct [:prop]
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 23,
+                    name: "struct",
+                    range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
+                    selectionRange: %{
+                      end: %{character: 2, line: 1},
+                      start: %{character: 2, line: 1}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles module definitions with exception" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyError do
+      defexception [:message]
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 23,
+                    name: "exception",
+                    range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
+                    selectionRange: %{
+                      end: %{character: 2, line: 1},
+                      start: %{character: 2, line: 1}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyError",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles exunit tests" do
     uri = "file://project/test.exs"
     text = ~S[

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -273,6 +273,50 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "handles nested module definitions with __MODULE__" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule __MODULE__ do
+        defmodule __MODULE__.SubModule do
+          def my_fn(), do: :ok
+        end
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [
+                      %{
+                        children: [],
+                        kind: 12,
+                        name: "my_fn()",
+                        range: %{end: %{character: 14, line: 3}, start: %{character: 14, line: 3}},
+                        selectionRange: %{
+                          end: %{character: 14, line: 3},
+                          start: %{character: 14, line: 3}
+                        }
+                      }
+                    ],
+                    kind: 2,
+                    name: "__MODULE__.SubModule",
+                    range: %{end: %{character: 8, line: 2}, start: %{character: 8, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 8, line: 2},
+                      start: %{character: 8, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "__MODULE__",
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles exunit tests" do
     uri = "file://project/test.exs"
     text = ~S[

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -509,7 +509,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     text = """
     defmodule MyModule do
-      defstruct [:prop]
+      defstruct [:prop, prop_with_def: nil]
     end
     """
 
@@ -518,7 +518,28 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               %{
                 children: [
                   %{
-                    children: [],
+                    children: [
+                      %{
+                        children: [],
+                        kind: 7,
+                        name: "prop",
+                        range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
+                        selectionRange: %{
+                          end: %{character: 2, line: 1},
+                          start: %{character: 2, line: 1}
+                        }
+                      },
+                      %{
+                        children: [],
+                        kind: 7,
+                        name: "prop_with_def",
+                        range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
+                        selectionRange: %{
+                          end: %{character: 2, line: 1},
+                          start: %{character: 2, line: 1}
+                        }
+                      }
+                    ],
                     kind: 23,
                     name: "struct",
                     range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
@@ -550,7 +571,18 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               %{
                 children: [
                   %{
-                    children: [],
+                    children: [
+                      %{
+                        children: [],
+                        kind: 7,
+                        name: "message",
+                        range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},
+                        selectionRange: %{
+                          end: %{character: 2, line: 1},
+                          start: %{character: 2, line: 1}
+                        }
+                      }
+                    ],
                     kind: 23,
                     name: "exception",
                     range: %{end: %{character: 2, line: 1}, start: %{character: 2, line: 1}},

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -14,6 +14,20 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
         defguard my_guard(a) when is_integer(a)
         defguardp my_private_guard(a) when is_integer(a)
         defdelegate my_delegate(list), to: Enum, as: :reverse
+        defguard my_guard when 1 == 1
+        def my_fn_no_arg, do: :ok
+        def my_fn_with_guard(arg) when is_integer(arg), do: :ok
+        def my_fn_with_more_blocks(arg) do
+          :ok
+        rescue
+          e in ArgumentError -> :ok
+        else
+          _ -> :ok
+        catch
+          _ -> :ok
+        after
+          :ok
+        end
       end
     ]
 
@@ -99,6 +113,46 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     selectionRange: %{
                       end: %{character: 20, line: 9},
                       start: %{character: 20, line: 9}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_guard when 1 == 1",
+                    range: %{end: %{character: 26, line: 10}, start: %{character: 26, line: 10}},
+                    selectionRange: %{
+                      end: %{character: 26, line: 10},
+                      start: %{character: 26, line: 10}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn_no_arg",
+                    range: %{end: %{character: 12, line: 11}, start: %{character: 12, line: 11}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 11},
+                      start: %{character: 12, line: 11}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn_with_guard(arg) when is_integer(arg)",
+                    range: %{end: %{character: 34, line: 12}, start: %{character: 34, line: 12}},
+                    selectionRange: %{
+                      end: %{character: 34, line: 12},
+                      start: %{character: 34, line: 12}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn_with_more_blocks(arg)",
+                    range: %{end: %{character: 12, line: 13}, start: %{character: 12, line: 13}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 13},
+                      start: %{character: 12, line: 13}
                     }
                   }
                 ],

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -342,6 +342,83 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "handles protocols and implementations" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defprotocol MyProtocol do
+      @doc "Calculates the size"
+      def size(data)
+    end
+
+    defimpl MyProtocol, for: BitString do
+      def size(binary), do: byte_size(binary)
+    end
+
+    defimpl MyProtocol, for: [List, MyList] do
+      def size(param), do: length(param)
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "size(data)",
+                    range: %{end: %{character: 6, line: 2}, start: %{character: 6, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 6, line: 2},
+                      start: %{character: 6, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyProtocol",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              },
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "size(binary)",
+                    range: %{end: %{character: 6, line: 6}, start: %{character: 6, line: 6}},
+                    selectionRange: %{
+                      end: %{character: 6, line: 6},
+                      start: %{character: 6, line: 6}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyProtocol, for: BitString",
+                range: %{end: %{character: 0, line: 5}, start: %{character: 0, line: 5}},
+                selectionRange: %{end: %{character: 0, line: 5}, start: %{character: 0, line: 5}}
+              },
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "size(param)",
+                    range: %{end: %{character: 6, line: 10}, start: %{character: 6, line: 10}},
+                    selectionRange: %{
+                      end: %{character: 6, line: 10},
+                      start: %{character: 6, line: 10}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyProtocol, for: [List, MyList]",
+                range: %{end: %{character: 0, line: 9}, start: %{character: 0, line: 9}},
+                selectionRange: %{end: %{character: 0, line: 9}, start: %{character: 0, line: 9}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles exunit tests" do
     uri = "file://project/test.exs"
     text = ~S[

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -321,6 +321,37 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "handles unquoted module definitions" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule unquote(var) do
+        def my_fn(), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn()",
+                    range: %{end: %{character: 12, line: 2}, start: %{character: 12, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 2},
+                      start: %{character: 12, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "# unknown",
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles erlang atom module definitions" do
     uri = "file://project/file.ex"
     text = ~S[

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -375,7 +375,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     }
                   }
                 ],
-                kind: 2,
+                kind: 11,
                 name: "MyProtocol",
                 range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
                 selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1162,4 +1162,35 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
+
+  test "handles config" do
+    uri = "file://project/test.exs"
+
+    text = """
+    use Mix.Config
+    config :logger, :console,
+       level: :info,
+       format: "$date $time [$level] $metadata$message\n",
+       metadata: [:user_id]
+    config :app, :key, :value
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [],
+                kind: 20,
+                name: "config :logger :console",
+                range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 1}},
+                selectionRange: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 1}}
+              },
+              %{
+                children: [],
+                kind: 20,
+                name: "config :app :key",
+                range: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}},
+                selectionRange: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
 end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -11,6 +11,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
         defp my_private_fn(arg), do: :ok
         defmacro my_macro(), do: :ok
         defmacrop my_private_macro(), do: :ok
+        defguard my_guard(a) when is_integer(a)
+        defguardp my_private_guard(a) when is_integer(a)
+        defdelegate my_delegate(list), to: Enum, as: :reverse
       end
     ]
 
@@ -22,10 +25,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     children: [],
                     kind: 14,
                     name: "@my_mod_var",
-                    range: %{
-                      end: %{character: 9, line: 2},
-                      start: %{character: 9, line: 2}
-                    },
+                    range: %{end: %{character: 9, line: 2}, start: %{character: 9, line: 2}},
                     selectionRange: %{
                       end: %{character: 9, line: 2},
                       start: %{character: 9, line: 2}
@@ -35,10 +35,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     children: [],
                     kind: 12,
                     name: "my_fn(arg)",
-                    range: %{
-                      end: %{character: 12, line: 3},
-                      start: %{character: 12, line: 3}
-                    },
+                    range: %{end: %{character: 12, line: 3}, start: %{character: 12, line: 3}},
                     selectionRange: %{
                       end: %{character: 12, line: 3},
                       start: %{character: 12, line: 3}
@@ -48,10 +45,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     children: [],
                     kind: 12,
                     name: "my_private_fn(arg)",
-                    range: %{
-                      end: %{character: 13, line: 4},
-                      start: %{character: 13, line: 4}
-                    },
+                    range: %{end: %{character: 13, line: 4}, start: %{character: 13, line: 4}},
                     selectionRange: %{
                       end: %{character: 13, line: 4},
                       start: %{character: 13, line: 4}
@@ -61,26 +55,57 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     children: [],
                     kind: 12,
                     name: "my_macro()",
-                    range: %{
-                      end: %{character: 17, line: 5},
-                      start: %{character: 17, line: 5}
-                    },
+                    range: %{end: %{character: 17, line: 5}, start: %{character: 17, line: 5}},
                     selectionRange: %{
                       end: %{character: 17, line: 5},
                       start: %{character: 17, line: 5}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_private_macro()",
+                    range: %{end: %{character: 18, line: 6}, start: %{character: 18, line: 6}},
+                    selectionRange: %{
+                      end: %{character: 18, line: 6},
+                      start: %{character: 18, line: 6}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_guard(a) when is_integer(a)",
+                    range: %{end: %{character: 29, line: 7}, start: %{character: 29, line: 7}},
+                    selectionRange: %{
+                      end: %{character: 29, line: 7},
+                      start: %{character: 29, line: 7}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_private_guard(a) when is_integer(a)",
+                    range: %{end: %{character: 38, line: 8}, start: %{character: 38, line: 8}},
+                    selectionRange: %{
+                      end: %{character: 38, line: 8},
+                      start: %{character: 38, line: 8}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_delegate(list)",
+                    range: %{end: %{character: 20, line: 9}, start: %{character: 20, line: 9}},
+                    selectionRange: %{
+                      end: %{character: 20, line: 9},
+                      start: %{character: 20, line: 9}
                     }
                   }
                 ],
                 kind: 2,
                 name: "MyModule",
-                range: %{
-                  end: %{character: 6, line: 1},
-                  start: %{character: 6, line: 1}
-                },
-                selectionRange: %{
-                  end: %{character: 6, line: 1},
-                  start: %{character: 6, line: 1}
-                }
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -17,64 +17,70 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
     assert {:ok,
             [
               %{
-                containerName: nil,
+                children: [
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@my_mod_var",
+                    range: %{
+                      end: %{character: 9, line: 2},
+                      start: %{character: 9, line: 2}
+                    },
+                    selectionRange: %{
+                      end: %{character: 9, line: 2},
+                      start: %{character: 9, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn(arg)",
+                    range: %{
+                      end: %{character: 12, line: 3},
+                      start: %{character: 12, line: 3}
+                    },
+                    selectionRange: %{
+                      end: %{character: 12, line: 3},
+                      start: %{character: 12, line: 3}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_private_fn(arg)",
+                    range: %{
+                      end: %{character: 13, line: 4},
+                      start: %{character: 13, line: 4}
+                    },
+                    selectionRange: %{
+                      end: %{character: 13, line: 4},
+                      start: %{character: 13, line: 4}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_macro()",
+                    range: %{
+                      end: %{character: 17, line: 5},
+                      start: %{character: 17, line: 5}
+                    },
+                    selectionRange: %{
+                      end: %{character: 17, line: 5},
+                      start: %{character: 17, line: 5}
+                    }
+                  }
+                ],
                 kind: 2,
-                location: %{
-                  range: %{
-                    end: %{character: 16, line: 1},
-                    start: %{character: 16, line: 1}
-                  },
-                  uri: ^uri
+                name: "MyModule",
+                range: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
                 },
-                name: "MyModule"
-              },
-              %{
-                containerName: "MyModule",
-                kind: 14,
-                location: %{
-                  range: %{
-                    end: %{character: 9, line: 2},
-                    start: %{character: 9, line: 2}
-                  },
-                  uri: ^uri
-                },
-                name: "@my_mod_var"
-              },
-              %{
-                containerName: "MyModule",
-                kind: 12,
-                location: %{
-                  range: %{
-                    end: %{character: 12, line: 3},
-                    start: %{character: 12, line: 3}
-                  },
-                  uri: ^uri
-                },
-                name: "my_fn(arg)"
-              },
-              %{
-                containerName: "MyModule",
-                kind: 12,
-                location: %{
-                  range: %{
-                    end: %{character: 13, line: 4},
-                    start: %{character: 13, line: 4}
-                  },
-                  uri: ^uri
-                },
-                name: "my_private_fn(arg)"
-              },
-              %{
-                containerName: "MyModule",
-                kind: 12,
-                location: %{
-                  range: %{
-                    end: %{character: 17, line: 5},
-                    start: %{character: 17, line: 5}
-                  },
-                  uri: ^uri
-                },
-                name: "my_macro()"
+                selectionRange: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                }
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
@@ -92,40 +98,115 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
     assert {:ok,
             [
               %{
-                containerName: nil,
+                children: [
+                  %{
+                    children: [
+                      %{
+                        children: [],
+                        kind: 12,
+                        name: "my_fn()",
+                        range: %{
+                          end: %{character: 14, line: 3},
+                          start: %{character: 14, line: 3}
+                        },
+                        selectionRange: %{
+                          end: %{character: 14, line: 3},
+                          start: %{character: 14, line: 3}
+                        }
+                      }
+                    ],
+                    kind: 2,
+                    name: "SubModule",
+                    range: %{
+                      end: %{character: 18, line: 2},
+                      start: %{character: 18, line: 2}
+                    },
+                    selectionRange: %{
+                      end: %{character: 18, line: 2},
+                      start: %{character: 18, line: 2}
+                    }
+                  }
+                ],
                 kind: 2,
-                location: %{
-                  range: %{
-                    end: %{character: 18, line: 2},
-                    start: %{character: 18, line: 2}
-                  },
-                  uri: "file://project/file.ex"
+                name: "MyModule",
+                range: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
                 },
-                name: "SubModule"
+                selectionRange: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                }
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handels multiple module definitions" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule MyModule do
+        def some_function(), do: :ok
+      end
+      defmodule MyOtherModule do
+        def some_other_function(), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "some_function()",
+                    range: %{
+                      end: %{character: 12, line: 2},
+                      start: %{character: 12, line: 2}
+                    },
+                    selectionRange: %{
+                      end: %{character: 12, line: 2},
+                      start: %{character: 12, line: 2}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                },
+                selectionRange: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                }
               },
               %{
-                containerName: "SubModule",
-                kind: 12,
-                location: %{
-                  range: %{
-                    end: %{character: 14, line: 3},
-                    start: %{character: 14, line: 3}
-                  },
-                  uri: ^uri
-                },
-                name: "my_fn()"
-              },
-              %{
-                containerName: nil,
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "some_other_function()",
+                    range: %{
+                      end: %{character: 12, line: 5},
+                      start: %{character: 12, line: 5}
+                    },
+                    selectionRange: %{
+                      end: %{character: 12, line: 5},
+                      start: %{character: 12, line: 5}
+                    }
+                  }
+                ],
                 kind: 2,
-                location: %{
-                  range: %{
-                    end: %{character: 16, line: 1},
-                    start: %{character: 16, line: 1}
-                  },
-                  uri: ^uri
+                name: "MyOtherModule",
+                range: %{
+                  end: %{character: 16, line: 4},
+                  start: %{character: 16, line: 4}
                 },
-                name: "MyModule"
+                selectionRange: %{
+                  end: %{character: 16, line: 4},
+                  start: %{character: 16, line: 4}
+                }
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
@@ -142,28 +223,88 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
     assert {:ok,
             [
               %{
-                containerName: nil,
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "test \"does something\"",
+                    range: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    },
+                    selectionRange: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    }
+                  }
+                ],
                 kind: 2,
-                location: %{
-                  range: %{
-                    end: %{character: 16, line: 1},
-                    start: %{character: 16, line: 1}
-                  },
-                  uri: ^uri
+                name: "MyModuleTest",
+                range: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
                 },
-                name: "MyModuleTest"
-              },
+                selectionRange: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                }
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles exunit descibe tests" do
+    uri = "file://project/test.exs"
+    text = ~S[
+      defmodule MyModuleTest do
+        use ExUnit.Case
+        describe "some descripton" do
+          test "does something", do: :ok
+        end
+      end
+    ]
+
+    assert {:ok,
+            [
               %{
-                containerName: "MyModuleTest",
-                kind: 12,
-                location: %{
-                  range: %{
-                    end: %{character: 8, line: 3},
-                    start: %{character: 8, line: 3}
-                  },
-                  uri: ^uri
+                children: [
+                  %{
+                    children: [
+                      %{
+                        children: [],
+                        kind: 12,
+                        name: "test \"does something\"",
+                        range: %{
+                          end: %{character: 10, line: 4},
+                          start: %{character: 10, line: 4}
+                        },
+                        selectionRange: %{
+                          end: %{character: 10, line: 4},
+                          start: %{character: 10, line: 4}
+                        }
+                      }
+                    ],
+                    kind: 12,
+                    name: "describe \"some descripton\"",
+                    range: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    },
+                    selectionRange: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModuleTest",
+                range: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
                 },
-                name: "test \"does something\""
+                selectionRange: %{
+                  end: %{character: 16, line: 1},
+                  start: %{character: 16, line: 1}
+                }
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1103,4 +1103,63 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
+
+  test "handles exunit callbacks" do
+    uri = "file://project/test.exs"
+
+    text = """
+    defmodule MyModuleTest do
+      use ExUnit.Case
+      setup do
+        [conn: Plug.Conn.build_conn()]
+      end
+      setup :clean_up_tmp_directory
+      setup_all do
+        :ok
+      end
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "setup",
+                    range: %{end: %{character: 2, line: 2}, start: %{character: 2, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 2, line: 2},
+                      start: %{character: 2, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "setup",
+                    range: %{end: %{character: 2, line: 5}, start: %{character: 2, line: 5}},
+                    selectionRange: %{
+                      end: %{character: 2, line: 5},
+                      start: %{character: 2, line: 5}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "setup_all",
+                    range: %{end: %{character: 2, line: 6}, start: %{character: 2, line: 6}},
+                    selectionRange: %{
+                      end: %{character: 2, line: 6},
+                      start: %{character: 2, line: 6}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModuleTest",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
 end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -568,6 +568,224 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text)
   end
 
+  test "handles module definitions with typespecs" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      @type my_simple :: integer
+      @type my_union :: integer | binary
+      @typep my_simple_private :: integer
+      @opaque my_simple_opaque :: integer
+      @type my_with_args(key, value) :: [{key, value}]
+      @type my_with_args_when(key, value) :: [{key, value}] when value: integer
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_simple",
+                    range: %{end: %{character: 3, line: 1}, start: %{character: 3, line: 1}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 1},
+                      start: %{character: 3, line: 1}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_union",
+                    range: %{end: %{character: 3, line: 2}, start: %{character: 3, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 2},
+                      start: %{character: 3, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_simple_private",
+                    range: %{end: %{character: 3, line: 3}, start: %{character: 3, line: 3}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 3},
+                      start: %{character: 3, line: 3}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_simple_opaque",
+                    range: %{end: %{character: 3, line: 4}, start: %{character: 3, line: 4}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 4},
+                      start: %{character: 3, line: 4}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_with_args(key, value)",
+                    range: %{end: %{character: 3, line: 5}, start: %{character: 3, line: 5}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 5},
+                      start: %{character: 3, line: 5}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 5,
+                    name: "my_with_args_when(key, value)",
+                    range: %{end: %{character: 3, line: 6}, start: %{character: 3, line: 6}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 6},
+                      start: %{character: 3, line: 6}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles module definitions with callbacks" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      @callback my_callback(type1, type2) :: return_type
+      @macrocallback my_macrocallback(type1, type2) :: Macro.t
+
+      @callback my_callback_when(type1, type2) :: return_type when type1: integer
+      @macrocallback my_macrocallback_when(type1, type2) :: Macro.t when type1: integer, type2: binary
+
+      @callback my_callback_no_arg() :: return_type
+      @macrocallback my_macrocallback_no_arg() :: Macro.t
+    end
+    """
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_callback(type1, type2)",
+                    range: %{end: %{character: 3, line: 1}, start: %{character: 3, line: 1}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 1},
+                      start: %{character: 3, line: 1}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_macrocallback(type1, type2)",
+                    range: %{end: %{character: 3, line: 2}, start: %{character: 3, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 2},
+                      start: %{character: 3, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_callback_when(type1, type2)",
+                    range: %{end: %{character: 3, line: 4}, start: %{character: 3, line: 4}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 4},
+                      start: %{character: 3, line: 4}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_macrocallback_when(type1, type2)",
+                    range: %{end: %{character: 3, line: 5}, start: %{character: 3, line: 5}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 5},
+                      start: %{character: 3, line: 5}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_callback_no_arg()",
+                    range: %{end: %{character: 3, line: 7}, start: %{character: 3, line: 7}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 7},
+                      start: %{character: 3, line: 7}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_macrocallback_no_arg()",
+                    range: %{end: %{character: 3, line: 8}, start: %{character: 3, line: 8}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 8},
+                      start: %{character: 3, line: 8}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
+                selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles funs with specs" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule MyModule do
+        @spec my_fn(integer) :: atom
+        def my_fn(a), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                children: [
+                  %{
+                    children: [],
+                    kind: 24,
+                    name: "my_fn(integer)",
+                    range: %{end: %{character: 9, line: 2}, start: %{character: 9, line: 2}},
+                    selectionRange: %{
+                      end: %{character: 9, line: 2},
+                      start: %{character: 9, line: 2}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 12,
+                    name: "my_fn(a)",
+                    range: %{end: %{character: 12, line: 3}, start: %{character: 12, line: 3}},
+                    selectionRange: %{
+                      end: %{character: 12, line: 3},
+                      start: %{character: 12, line: 3}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModule",
+                range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}},
+                selectionRange: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
   test "handles exunit tests" do
     uri = "file://project/test.exs"
     text = ~S[


### PR DESCRIPTION
This PR introduces many improvements and fixes to document outline provider.

- Includes support for nested modules and ExUnit `describe` blocks (basing on https://github.com/kent-medin/elixir-ls/commit/14c892b4e96015345a537f68312abe1b92e1981e) which fixes https://github.com/elixir-lsp/elixir-ls/issues/67 (and originally https://github.com/JakeBecker/elixir-ls/issues/188 and https://github.com/JakeBecker/elixir-ls/issues/178)
- Adds support for ExUnit `setup` and `setup_al`l blocks
- Adds support for atoms in module names (fixes https://github.com/JakeBecker/elixir-ls/issues/187)
- Adds support for protocols and implementations
- Adds support for types and callbacks
- Adds support for structs and exceptions
- Adds support for guards, delegates and private macros
- Adds support for elixir config files