### PR TITLE
Support asdf-vm setup in wrapper scripts

### DIFF
--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 # Launches the debugger. This script must be in the same directory as the compiled .ez archives.
 
+[ -f "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"
+
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null
   filename="$(basename "$1")"

--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 # Launches the language server. This script must be in the same directory as the compiled .ez archives.
 
+[ -f "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"
+
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null
   filename="$(basename "$1")"


### PR DESCRIPTION
IDEs often don't have the same environment as the command line and this can, in certain circumstances, break Elixir. I've had multiple projects that could not start elixir-ls from Emacs, for example, due to subtle PATH differences. 

asdf-vm is probably the most widely used version manager for Elixir projects; this PR invokes its configuration script if it exists, ensuring that Elixir gets invoked in the same way as on the command line. 

I'm not super happy with explicitly supporting a single version manager, but it smells like "the standard" in Elixir land and if the config script is not available, this PR is a no-op anyway. 