### PR TITLE
Extract impl name for textDocument/documentSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - Update dialyxir to 1.0.0-rc.7
+- Improvements to `textDocument/documentSymbol`, now `DocumentSymbol` is returned instead of the more simplistic `SymbolInformation` (thanks to [Łukasz Samson](https://github.com/lukaszsamson) and [kent-medin](https://github.com/kent-medin)) [#76](https://github.com/elixir-lsp/elixir-ls/pull/76)
 
 ### v0.2.28: 16 Nov 2019
 

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -151,6 +151,13 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
+  # @behaviour BehaviourModule
+  defp extract_symbol(_current_module, {:@, _, [{:behaviour, location, [behaviour_expression]}]}) do
+    module_name = extract_module_name(behaviour_expression)
+
+    %{type: :constant, name: "@behaviour #{module_name}", location: location, children: []}
+  end
+
   # @impl true
   defp extract_symbol(_current_module, {:@, _, [{:impl, location, [true]}]}) do
     %{type: :constant, name: "@impl true", location: location, children: []}

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -148,6 +148,18 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     }
   end
 
+  # @impl true
+  defp extract_symbol(_current_module, {:@, _, [{:impl, location, [true]}]}) do
+    %{type: :constant, name: "@impl true", location: location, children: []}
+  end
+
+  # @impl BehaviourModule
+  defp extract_symbol(_current_module, {:@, _, [{:impl, location, [impl_expression]}]}) do
+    module_name = extract_module_name(impl_expression)
+
+    %{type: :constant, name: "@impl #{module_name}", location: location, children: []}
+  end
+
   # Other attributes
   defp extract_symbol(_current_module, {:@, _, [{name, location, _}]}) do
     %{type: :constant, name: "@#{name}", location: location, children: []}

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -1,7 +1,10 @@
 defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   @moduledoc """
-  Document Symbols provider
+  Document Symbols provider. Generates and returns the nested `DocumentSymbol` format.
+
+  https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#textDocument_documentSymbol
   """
+
   @symbol_enum %{
     file: 1,
     module: 2,

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -883,7 +883,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                   %{
                     children: [],
                     kind: 14,
-                    name: "@behaviour",
+                    name: "@behaviour MyBehaviour",
                     range: %{end: %{character: 3, line: 2}, start: %{character: 3, line: 2}},
                     selectionRange: %{
                       end: %{character: 3, line: 2},

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -862,6 +862,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
       @after_compile __MODULE__
       @before_compile __MODULE__
       @fallback_to_any true
+      @impl MyBehaviour
     end
     """
 
@@ -892,7 +893,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                   %{
                     children: [],
                     kind: 14,
-                    name: "@impl",
+                    name: "@impl true",
                     range: %{end: %{character: 3, line: 3}, start: %{character: 3, line: 3}},
                     selectionRange: %{
                       end: %{character: 3, line: 3},
@@ -1027,6 +1028,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     selectionRange: %{
                       end: %{character: 3, line: 16},
                       start: %{character: 3, line: 16}
+                    }
+                  },
+                  %{
+                    children: [],
+                    kind: 14,
+                    name: "@impl MyBehaviour",
+                    range: %{end: %{character: 3, line: 17}, start: %{character: 3, line: 17}},
+                    selectionRange: %{
+                      end: %{character: 3, line: 17},
+                      start: %{character: 3, line: 17}
                     }
                   }
                 ],


### PR DESCRIPTION
Instead of only showing `@impl` for any `@impl` lines, show the name of the impl as well. So either `@impl true` or `@impl MyApp.SomeBehaviour`

Here is what it looks like VSCode's outline view:
![vscode-outline-screenshot](https://user-images.githubusercontent.com/9973/69745907-3b80ad80-10e7-11ea-991f-4e6c8544f719.png)
