### PR TITLE
Bump elixir_sense and use ElixirSense.references/3

### DIFF
--- a/apps/elixir_ls_utils/test/support/test_utils.ex
+++ b/apps/elixir_ls_utils/test/support/test_utils.ex
@@ -10,4 +10,8 @@ defmodule ElixirLS.Utils.TestUtils do
 
     assert char == "^"
   end
+
+  def assert_match_list(list1, list2) do
+    assert Enum.sort(list1) == Enum.sort(list2)
+  end
 end

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -529,6 +529,9 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       origin: origin
     } = info
 
+    # ElixirSense now returns types as an atom
+    type = to_string(type)
+
     %{
       pipe_before?: pipe_before?,
       capture_before?: capture_before?,

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -1,8 +1,8 @@
 defmodule ElixirLS.LanguageServer.Providers.References do
   @moduledoc """
-  This module provides References support by using
-  the `Mix.Tasks.Xref.call/0` task to find all references to
-  any function or module identified at the provided location.
+  This module provides References support by using `ElixirSense.references/3` to
+  find all references to any function or module identified at the provided
+  location.
   """
   require Logger
 
@@ -10,9 +10,9 @@ defmodule ElixirLS.LanguageServer.Providers.References do
 
   def references(text, line, character, _include_declaration) do
     Build.with_build_lock(fn ->
-      xref_at_cursor(text, line, character)
-      |> Enum.filter(fn %{line: line} -> is_integer(line) end)
-      |> Enum.map(&build_location/1)
+      ElixirSense.references(text, line + 1, character + 1)
+      |> Enum.map(&build_reference/1)
+      |> Enum.map(&build_loc/1)
     end)
   end
 
@@ -20,77 +20,28 @@ defmodule ElixirLS.LanguageServer.Providers.References do
     Mix.Tasks.Xref.__info__(:functions) |> Enum.member?({:calls, 0})
   end
 
-  defp xref_at_cursor(text, line, character) do
-    env_at_cursor = line_environment(text, line)
-    %{aliases: aliases} = env_at_cursor
-
-    subject_at_cursor(text, line, character)
-    # TODO: Don't call into here directly
-    |> ElixirSense.Core.Source.split_module_and_func(aliases)
-    |> expand_mod_fun(env_at_cursor)
-    |> add_arity(env_at_cursor)
-    |> callers()
-  end
-
-  defp line_environment(text, line) do
-    # TODO: Don't call into here directly
-    ElixirSense.Core.Parser.parse_string(text, true, true, line + 1)
-    |> ElixirSense.Core.Metadata.get_env(line + 1)
-  end
-
-  defp subject_at_cursor(text, line, character) do
-    # TODO: Don't call into here directly
-    ElixirSense.Core.Source.subject(text, line + 1, character + 1)
-  end
-
-  defp expand_mod_fun({nil, nil}, _environment), do: nil
-
-  defp expand_mod_fun(mod_fun, %{imports: imports, aliases: aliases, module: module}) do
-    # TODO: Don't call into here directly
-    mod_fun = ElixirSense.Core.Introspection.actual_mod_fun(mod_fun, imports, aliases, module)
-
-    case mod_fun do
-      {mod, nil} -> {mod, nil}
-      {mod, fun} -> {mod, fun}
-    end
-  end
-
-  defp add_arity({mod, fun}, %{scope: {fun, arity}, module: mod}), do: {mod, fun, arity}
-  defp add_arity({mod, fun}, _env), do: {mod, fun, nil}
-
-  defp callers(mfa) do
-    if Mix.Project.umbrella?() do
-      umbrella_calls()
-    else
-      Mix.Tasks.Xref.calls()
-    end
-    |> Enum.filter(caller_filter(mfa))
-  end
-
-  def umbrella_calls() do
-    build_dir = Path.expand(Mix.Project.config()[:build_path])
-
-    Mix.Project.apps_paths()
-    |> Enum.flat_map(fn {app, path} ->
-      Mix.Project.in_project(app, path, [build_path: build_dir], fn _ ->
-        Mix.Tasks.Xref.calls()
-        |> Enum.map(fn %{file: file} = call ->
-          Map.put(call, :file, Path.expand(file))
-        end)
-      end)
-    end)
-  end
-
-  defp caller_filter({module, nil, nil}), do: &match?(%{callee: {^module, _, _}}, &1)
-  defp caller_filter({module, func, nil}), do: &match?(%{callee: {^module, ^func, _}}, &1)
-  defp caller_filter({module, func, arity}), do: &match?(%{callee: {^module, ^func, ^arity}}, &1)
-
-  defp build_location(%{file: file, line: line}) do
+  defp build_reference(ref) do
     %{
-      "uri" => SourceFile.path_to_uri(file),
+      range: %{
+        start: %{line: ref.range.start.line, column: ref.range.start.column},
+        end: %{line: ref.range.end.line, column: ref.range.end.column}
+      },
+      uri: ref.uri
+    }
+  end
+
+  defp build_loc(reference) do
+    # Adjust for ElixirSense 1-based indexing
+    line_start = reference.range.start.line - 1
+    line_end = reference.range.end.line - 1
+    column_start = reference.range.start.column - 1
+    column_end = reference.range.end.column - 1
+
+    %{
+      "uri" => SourceFile.path_to_uri(reference.uri),
       "range" => %{
-        "start" => %{"line" => line - 1, "character" => 0},
-        "end" => %{"line" => line - 1, "character" => 0}
+        "start" => %{"line" => line_start, "character" => column_start},
+        "end" => %{"line" => line_end, "character" => column_end}
       }
     }
   end

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -3,16 +3,25 @@ defmodule ElixirLS.LanguageServer.Providers.References do
   This module provides References support by using `ElixirSense.references/3` to
   find all references to any function or module identified at the provided
   location.
+
+  Does not support configuring "includeDeclaration" and assumes it is always
+  `true`
+
+  https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#textDocument_references
   """
   require Logger
 
   alias ElixirLS.LanguageServer.{SourceFile, Build}
 
-  def references(text, line, character, _include_declaration) do
+  def references(text, uri, line, character, _include_declaration) do
     Build.with_build_lock(fn ->
       ElixirSense.references(text, line + 1, character + 1)
-      |> Enum.map(&build_reference/1)
-      |> Enum.map(&build_loc/1)
+      |> Enum.map(fn elixir_sense_reference ->
+        elixir_sense_reference
+        |> build_reference(uri)
+        |> build_loc()
+      end)
+      |> Enum.filter(&has_uri?/1)
     end)
   end
 
@@ -20,15 +29,29 @@ defmodule ElixirLS.LanguageServer.Providers.References do
     Mix.Tasks.Xref.__info__(:functions) |> Enum.member?({:calls, 0})
   end
 
-  defp build_reference(ref) do
+  defp build_reference(ref, current_file_uri) do
     %{
       range: %{
         start: %{line: ref.range.start.line, column: ref.range.start.column},
         end: %{line: ref.range.end.line, column: ref.range.end.column}
       },
-      uri: ref.uri
+      uri: build_uri(ref, current_file_uri)
     }
   end
+
+  def build_uri(elixir_sense_ref, current_file_uri) do
+    case elixir_sense_ref.uri do
+      # A `nil` uri indicates that the reference was in the passed in text
+      # https://github.com/elixir-lsp/elixir-ls/pull/82#discussion_r351922803
+      nil -> current_file_uri
+      # ElixirSense returns a plain path (e.g. "/home/bob/my_app/lib/a.ex") as
+      # the "uri" so we convert it to an actual uri
+      path when is_binary(path) -> SourceFile.path_to_uri(path)
+      _ -> nil
+    end
+  end
+
+  defp has_uri?(reference), do: !is_nil(reference["uri"])
 
   defp build_loc(reference) do
     # Adjust for ElixirSense 1-based indexing
@@ -38,7 +61,7 @@ defmodule ElixirLS.LanguageServer.Providers.References do
     column_end = reference.range.end.column - 1
 
     %{
-      "uri" => SourceFile.path_to_uri(reference.uri),
+      "uri" => reference.uri,
       "range" => %{
         "start" => %{"line" => line_start, "character" => column_start},
         "end" => %{"line" => line_end, "character" => column_end}

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -354,6 +354,7 @@ defmodule ElixirLS.LanguageServer.Server do
       {:ok,
        References.references(
          state.source_files[uri].text,
+         uri,
          line,
          character,
          include_declaration

--- a/apps/language_server/test/language_server/providers/references_test.exs
+++ b/apps/language_server/test/language_server/providers/references_test.exs
@@ -1,0 +1,104 @@
+defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirLS.LanguageServer.Providers.References
+  require ElixirLS.Test.TextLoc
+
+  test "finds references to a function" do
+    file_path = Path.join(__DIR__, "../../support/references_b.ex") |> Path.expand()
+    text = File.read!(file_path)
+    uri = "file://#{file_path}"
+
+    {line, char} = {2, 8}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+        some_var = 42
+            ^
+    """)
+
+    ElixirLS.Utils.TestUtils.assert_match_list(
+      References.references(text, uri, line, char, true),
+      [
+        %{
+          "range" => %{
+            "start" => %{"line" => 3, "character" => 4},
+            "end" => %{"line" => 3, "character" => 12}
+          },
+          "uri" => uri
+        },
+        %{
+          "range" => %{
+            "start" => %{"line" => 5, "character" => 12},
+            "end" => %{"line" => 5, "character" => 20}
+          },
+          "uri" => uri
+        }
+      ]
+    )
+  end
+
+  test "cannot find a references to a macro generated function call" do
+    file_path = Path.join(__DIR__, "../../support/uses_macro_a.ex") |> Path.expand()
+    text = File.read!(file_path)
+    uri = "file://#{file_path}"
+    {line, char} = {6, 13}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+        macro_a_func()
+                 ^
+    """)
+
+    assert References.references(text, uri, line, char, true) == []
+  end
+
+  test "finds a references to a macro imported function call" do
+    file_path = Path.join(__DIR__, "../../support/uses_macro_a.ex") |> Path.expand()
+    text = File.read!(file_path)
+    uri = "file://#{file_path}"
+    {line, char} = {10, 4}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+        macro_imported_fun()
+        ^
+    """)
+
+    assert References.references(text, uri, line, char, true) == [
+             %{
+               "range" => %{
+                 "start" => %{"line" => 10, "character" => 4},
+                 "end" => %{"line" => 10, "character" => 22}
+               },
+               "uri" => uri
+             }
+           ]
+  end
+
+  test "finds references to a variable" do
+    file_path = Path.join(__DIR__, "../../support/references_b.ex") |> Path.expand()
+    text = File.read!(file_path)
+    uri = "file://#{file_path}"
+    {line, char} = {4, 14}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+        IO.puts(some_var + 1)
+                  ^
+    """)
+
+    assert References.references(text, uri, line, char, true) == [
+             %{
+               "range" => %{
+                 "end" => %{"character" => 12, "line" => 2},
+                 "start" => %{"character" => 4, "line" => 2}
+               },
+               "uri" => uri
+             },
+             %{
+               "range" => %{
+                 "end" => %{"character" => 20, "line" => 4},
+                 "start" => %{"character" => 12, "line" => 4}
+               },
+               "uri" => uri
+             }
+           ]
+  end
+end

--- a/apps/language_server/test/support/macro_a.ex
+++ b/apps/language_server/test/support/macro_a.ex
@@ -1,0 +1,15 @@
+defmodule ElixirLS.Test.MacroA do
+  defmacro __using__(_) do
+    quote do
+      import ElixirLS.Test.MacroA
+
+      def macro_a_func do
+        :ok
+      end
+    end
+  end
+
+  def macro_imported_fun do
+    :ok
+  end
+end

--- a/apps/language_server/test/support/references_a.ex
+++ b/apps/language_server/test/support/references_a.ex
@@ -1,0 +1,5 @@
+defmodule ElixirLS.Test.ReferencesA do
+  def a_fun do
+    ElixirLS.Test.ReferencesB.b_fun()
+  end
+end

--- a/apps/language_server/test/support/references_b.ex
+++ b/apps/language_server/test/support/references_b.ex
@@ -1,0 +1,8 @@
+defmodule ElixirLS.Test.ReferencesB do
+  def b_fun do
+    some_var = 42
+
+    IO.puts(some_var + 1)
+    :ok
+  end
+end

--- a/apps/language_server/test/support/text_loc.ex
+++ b/apps/language_server/test/support/text_loc.ex
@@ -1,0 +1,36 @@
+defmodule ElixirLS.Test.TextLoc do
+  def annotate(path, line, character) do
+    with {:ok, text} <- read_file_line(path, line) do
+      pointer_line = String.duplicate(" ", character) <> "^\n"
+      {:ok, text <> pointer_line}
+    end
+  end
+
+  defmacro annotate_assert(path, line, character, expected) do
+    quote do
+      assert {:ok, actual} =
+               ElixirLS.Test.TextLoc.annotate(unquote(path), unquote(line), unquote(character))
+
+      if actual == unquote(expected) do
+        assert actual == unquote(expected)
+      else
+        IO.puts("Acutal is:")
+        IO.puts(["\"\"\"", "\n", actual, "\"\"\""])
+        assert actual == unquote(expected)
+      end
+    end
+  end
+
+  def read_file_line(path, line) do
+    File.stream!(path, [:read, :utf8], :line)
+    |> Stream.drop(line)
+    |> Enum.take(1)
+    |> hd()
+    |> wrap_in_ok()
+  rescue
+    e in File.Error ->
+      {:error, e}
+  end
+
+  defp wrap_in_ok(input), do: {:ok, input}
+end

--- a/apps/language_server/test/support/uses_macro_a.ex
+++ b/apps/language_server/test/support/uses_macro_a.ex
@@ -1,0 +1,19 @@
+defmodule ElixirLS.Test.UsesMacroA do
+  use ElixirLS.Test.MacroA
+
+  @inputs [1, 2, 3]
+
+  def my_fun do
+    macro_a_func()
+  end
+
+  def my_other_fun do
+    macro_imported_fun()
+  end
+
+  for input <- @inputs do
+    def gen_fun(unquote(input)) do
+      unquote(input) + 1
+    end
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "899db30568fa8decfe20b42a64fcb7f87798c3ef", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "4b27cc0457f4dfae037a63e8d8080f9abe7a2b09", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "4b27cc0457f4dfae037a63e8d8080f9abe7a2b09", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "877fa6f392546bcc037536eb316a13b0388ecb7b", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Now that https://github.com/elixir-lsp/elixir_sense/issues/42 is fixed (via https://github.com/elixir-lsp/elixir_sense/pull/61) and umbrella support is added via https://github.com/elixir-lsp/elixir_sense/pull/46 we no longer need to maintain a separate implementation of `ElixirSense.references/3` and can instead use the implementation provided by ElixirSense. This is good because now we're using less of the private internals of ElixirSense.

Fixes #68 
Fixes #39 