### PR TITLE
Fix version check and improve message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This fork started when [Jake Becker's repository](https://github.com/JakeBecker/
 ## Features
 
 - Debugger support
-- Automatic, incremental Dialyzer analysis (requires Erlang OTP 20)
+- Automatic, incremental Dialyzer analysis
 - Automatic inline suggestion of @specs based on Dialyzer's inferred success typings
 - Inline reporting of build warnings and errors
 - Documentation lookup on hover
@@ -77,7 +77,7 @@ Starting in Elixir 1.6, Mix compilers adhere to the [Mix.Task.Compiler](https://
 
 ## Dialyzer integration
 
-If you're using Erlang >= OTP 20, ElixirLS will automatically analyze your project with Dialyzer after each successful build. It maintains a "manifest" file in `.elixir_ls/dialyzer_manifest` that stores the results of the analysis. The initial analysis for a project can take a few minutes, but after that's completed, modules are re-analyzed only if necessary, so subsequent analyses are typically very fast -- often less than a second. It also looks at your modules' abstract code to determine whether they reference any modules that haven't been analyzed and includes them automatically.
+ElixirLS will automatically analyze your project with Dialyzer after each successful build. It maintains a "manifest" file in `.elixir_ls/dialyzer_manifest` that stores the results of the analysis. The initial analysis for a project can take a few minutes, but after that's completed, modules are re-analyzed only if necessary, so subsequent analyses are typically very fast -- often less than a second. It also looks at your modules' abstract code to determine whether they reference any modules that haven't been analyzed and includes them automatically.
 
 You can control which warnings are shown using the `elixirLS.dialyzerWarnOpts` setting in your project or IDE's `settings.json`. To disable it completely, set `elixirLS.dialyzerEnabled` to false.
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -605,10 +605,10 @@ defmodule ElixirLS.LanguageServer.Server do
 
     otp_release = String.to_integer(System.otp_release())
 
-    if otp_release < 19 do
+    if otp_release < 20 do
       JsonRpc.show_message(
         :info,
-        "Upgrade Erlang to version OTP 20 for debugging support (Currently OTP #{otp_release})"
+        "Erlang OTP releases below 20 are not supported (Currently OTP #{otp_release})"
       )
     end
 


### PR DESCRIPTION
cleanup readme
OTP < 20 are not supported since 996682e3873e56b8305c2265db165ea819fcfe8f