### PR TITLE
Fix module completion after pipe and capture

### DIFF
--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -122,6 +122,6 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       |> Enum.filter(&(&1["detail"] =~ "struct"))
       |> Enum.map(& &1["label"])
 
-      assert "NaiveDateTime" in completions
+    assert "NaiveDateTime" in completions
   end
 end

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -77,4 +77,51 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
              "def my_fun(example,arg)"
            ]
   end
+
+  test "returns module completions after pipe" do
+    text = """
+    defmodule MyModule do
+      NaiveDateTime.utc_now() |> Naiv
+    #                                ^
+    1..100
+    |> Enum.map(&Inte)
+    #                ^
+    def my(%Naiv)
+    #           ^
+    end
+    """
+
+    {line, char} = {1, 33}
+    TestUtils.assert_has_cursor_char(text, line, char)
+    {:ok, %{"items" => items}} = Completion.completion(text, line, char, true)
+
+    completions =
+      items
+      |> Enum.filter(&(&1["detail"] =~ "struct"))
+      |> Enum.map(& &1["label"])
+
+    assert "NaiveDateTime" in completions
+
+    {line, char} = {4, 17}
+    TestUtils.assert_has_cursor_char(text, line, char)
+    {:ok, %{"items" => items}} = Completion.completion(text, line, char, true)
+
+    completions =
+      items
+      |> Enum.filter(&(&1["detail"] =~ "module"))
+      |> Enum.map(& &1["label"])
+
+    assert "Integer" in completions
+
+    {line, char} = {6, 12}
+    TestUtils.assert_has_cursor_char(text, line, char)
+    {:ok, %{"items" => items}} = Completion.completion(text, line, char, true)
+
+    completions =
+      items
+      |> Enum.filter(&(&1["detail"] =~ "struct"))
+      |> Enum.map(& &1["label"])
+
+      assert "NaiveDateTime" in completions
+  end
 end


### PR DESCRIPTION
Those completions do work fine in elixir-sense but elixir-lsp made some changes which resulted in
<img width="660" alt="Screenshot 2020-01-25 at 12 46 37" src="https://user-images.githubusercontent.com/1078186/73121065-3cfb1480-3f76-11ea-8ab5-c79aaa3fb1b1.png">

I also made small improvements:
- improve def detection regexes
- make sure to return string in detail

