### PR TITLE
Replace Logger.warn with JsonRpc warning

### DIFF
--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -2,7 +2,6 @@ defmodule ElixirLS.LanguageServer do
   @moduledoc """
   Implementation of Language Server Protocol for Elixir
   """
-  require Logger
   use Application
 
   @impl Application

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -1,6 +1,5 @@
 defmodule ElixirLS.LanguageServer.Build do
   alias ElixirLS.LanguageServer.{Server, JsonRpc, SourceFile}
-  require Logger
 
   def build(parent, root_path, fetch_deps?) do
     if Path.absname(File.cwd!()) != Path.absname(root_path) do

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -2,7 +2,6 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   alias ElixirLS.LanguageServer.{JsonRpc, Server}
   alias ElixirLS.LanguageServer.Dialyzer.{Manifest, Analyzer, Utils, SuccessTypings}
   import Utils
-  require Logger
   use GenServer
 
   defstruct [

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -2,7 +2,6 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   alias ElixirLS.LanguageServer.{Dialyzer, JsonRpc}
   import Record
   import Dialyzer.Utils
-  require Logger
 
   @manifest_vsn :v2
 

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -9,7 +9,6 @@ defmodule ElixirLS.LanguageServer.Providers.References do
 
   https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#textDocument_references
   """
-  require Logger
 
   alias ElixirLS.LanguageServer.{SourceFile, Build}
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -32,7 +32,6 @@ defmodule ElixirLS.LanguageServer.Server do
   }
 
   use Protocol
-  require Logger
 
   defstruct [
     :build_ref,
@@ -166,7 +165,8 @@ defmodule ElixirLS.LanguageServer.Server do
     state =
       case state do
         %{settings: nil} ->
-          Logger.warn(
+          JsonRpc.show_message(
+            :warning,
             "Did not receive workspace/didChangeConfiguration notification after 5 seconds. " <>
               "Using default settings."
           )


### PR DESCRIPTION
On Elixir 1.10 `Logger.__should_log__/1` has been removed which causes an exception. This shows that we should look at alternative mechanisms to run elixir-ls that will always run it under the elixir version that it was initially compiled with.

Fixes #107