### PR TITLE
Added proper support for hierarchicalDocumentSymbolSupport

### DIFF
--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -15,6 +15,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     :typedoc
   ]
 
+  defmodule DocumentSymbol do
+    @moduledoc """
+    Corresponds to the LSP interface of the same name.
+
+    For details see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
+    """
+    @derive Jason.Encoder
+    defstruct [:name, :kind, :range, :selectionRange, :children]
+  end
+
   def symbols(uri, text) do
     symbols = list_symbols(text) |> Enum.map(&build_symbol_information(uri, &1))
     {:ok, symbols}
@@ -232,7 +242,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     do: Enum.map(info, &build_symbol_information(uri, &1))
 
   defp build_symbol_information(uri, info) do
-    %{
+    %DocumentSymbol{
       name: info.name,
       kind: SymbolUtils.symbol_kind_to_code(info.type),
       range: location_to_range(info.location),

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -25,8 +25,28 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     defstruct [:name, :kind, :range, :selectionRange, :children]
   end
 
-  def symbols(uri, text) do
-    symbols = list_symbols(text) |> Enum.map(&build_symbol_information(uri, &1))
+  defmodule SymbolInformation do
+    @moduledoc """
+    Corresponds to the LSP interface of the same name.
+
+    For details see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
+    """
+    @derive Jason.Encoder
+    defstruct [:name, :kind, :location, :containerName]
+  end
+
+  def symbols(uri, text, hierarchical) do
+    symbols = list_symbols(text)
+
+    symbols =
+      if hierarchical do
+        Enum.map(symbols, &build_symbol_information_hierarchical(uri, &1))
+      else
+        symbols
+        |> Enum.map(&build_symbol_information_flat(uri, &1))
+        |> List.flatten()
+      end
+
     {:ok, symbols}
   end
 
@@ -238,17 +258,51 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
 
   defp extract_symbol(_, _), do: nil
 
-  defp build_symbol_information(uri, info) when is_list(info),
-    do: Enum.map(info, &build_symbol_information(uri, &1))
+  defp build_symbol_information_hierarchical(uri, info) when is_list(info),
+    do: Enum.map(info, &build_symbol_information_hierarchical(uri, &1))
 
-  defp build_symbol_information(uri, info) do
+  defp build_symbol_information_hierarchical(uri, info) do
     %DocumentSymbol{
       name: info.name,
       kind: SymbolUtils.symbol_kind_to_code(info.type),
       range: location_to_range(info.location),
       selectionRange: location_to_range(info.location),
-      children: build_symbol_information(uri, info.children)
+      children: build_symbol_information_hierarchical(uri, info.children)
     }
+  end
+
+  defp build_symbol_information_flat(uri, info, parent_name \\ nil)
+
+  defp build_symbol_information_flat(uri, info, parent_name) when is_list(info),
+    do: Enum.map(info, &build_symbol_information_flat(uri, &1, parent_name))
+
+  defp build_symbol_information_flat(uri, info, parent_name) do
+    case info.children do
+      [_ | _] ->
+        [
+          %SymbolInformation{
+            name: info.name,
+            kind: SymbolUtils.symbol_kind_to_code(info.type),
+            location: %{
+              uri: uri,
+              range: location_to_range(info.location)
+            },
+            containerName: parent_name
+          }
+          | Enum.map(info.children, &build_symbol_information_flat(uri, &1, info.name))
+        ]
+
+      _ ->
+        %SymbolInformation{
+          name: info.name,
+          kind: SymbolUtils.symbol_kind_to_code(info.type),
+          location: %{
+            uri: uri,
+            range: location_to_range(info.location)
+          },
+          containerName: parent_name
+        }
+    end
   end
 
   defp location_to_range(location) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -388,7 +388,13 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp handle_request(document_symbol_req(_id, uri), state) do
     fun = fn ->
-      DocumentSymbols.symbols(uri, state.source_files[uri].text)
+      hierarchical? =
+        state.client_capabilities
+        |> Map.get("textDocument", %{})
+        |> Map.get("documentSymbol", %{})
+        |> Map.get("hierarchicalDocumentSymbolSupport", false)
+
+      DocumentSymbols.symbols(uri, state.source_files[uri].text, hierarchical?)
     end
 
     {:async, fun, state}

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1,5 +1,6 @@
 defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
   alias ElixirLS.LanguageServer.Providers.DocumentSymbols
+  alias ElixirLS.LanguageServer.Providers.DocumentSymbols.DocumentSymbol
   use ExUnit.Case
 
   test "returns symbol information" do
@@ -33,9 +34,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@my_mod_var",
@@ -45,7 +46,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 9, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn(arg)",
@@ -55,7 +56,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 12, line: 3}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_private_fn(arg)",
@@ -65,7 +66,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 13, line: 4}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_macro()",
@@ -75,7 +76,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 17, line: 5}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_private_macro()",
@@ -85,7 +86,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 18, line: 6}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_guard(a) when is_integer(a)",
@@ -95,7 +96,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 29, line: 7}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_private_guard(a) when is_integer(a)",
@@ -105,7 +106,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 38, line: 8}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_delegate(list)",
@@ -115,7 +116,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 20, line: 9}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_guard when 1 == 1",
@@ -125,7 +126,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 26, line: 10}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn_no_arg",
@@ -135,7 +136,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 12, line: 11}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn_with_guard(arg) when is_integer(arg)",
@@ -145,7 +146,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 34, line: 12}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn_with_more_blocks(arg)",
@@ -176,11 +177,11 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 12,
                         name: "my_fn()",
@@ -233,9 +234,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "some_function()",
@@ -260,9 +261,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                   start: %{character: 6, line: 1}
                 }
               },
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "some_other_function()",
@@ -300,9 +301,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn()",
@@ -331,9 +332,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn()",
@@ -362,9 +363,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn()",
@@ -395,11 +396,11 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 12,
                         name: "my_fn()",
@@ -447,9 +448,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "size(data)",
@@ -465,9 +466,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 range: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}},
                 selectionRange: %{end: %{character: 0, line: 0}, start: %{character: 0, line: 0}}
               },
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "size(binary)",
@@ -483,9 +484,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                 range: %{end: %{character: 0, line: 5}, start: %{character: 0, line: 5}},
                 selectionRange: %{end: %{character: 0, line: 5}, start: %{character: 0, line: 5}}
               },
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "size(param)",
@@ -515,11 +516,11 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 7,
                         name: "prop",
@@ -529,7 +530,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                           start: %{character: 2, line: 1}
                         }
                       },
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 7,
                         name: "prop_with_def",
@@ -568,11 +569,11 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 7,
                         name: "message",
@@ -616,7 +617,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
                   %{
                     children: [],
@@ -628,7 +629,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 1}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 5,
                     name: "my_union",
@@ -638,7 +639,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 5,
                     name: "my_simple_private",
@@ -648,7 +649,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 3}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 5,
                     name: "my_simple_opaque",
@@ -658,7 +659,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 4}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 5,
                     name: "my_with_args(key, value)",
@@ -668,7 +669,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 5}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 5,
                     name: "my_with_args_when(key, value)",
@@ -705,9 +706,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_callback(type1, type2)",
@@ -717,7 +718,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 1}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_macrocallback(type1, type2)",
@@ -727,7 +728,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_callback_when(type1, type2)",
@@ -737,7 +738,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 4}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_macrocallback_when(type1, type2)",
@@ -747,7 +748,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 5}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_callback_no_arg()",
@@ -757,7 +758,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 7}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_macrocallback_no_arg()",
@@ -787,9 +788,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 24,
                     name: "my_fn(integer)",
@@ -799,7 +800,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 9, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "my_fn(a)",
@@ -831,7 +832,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [],
                 kind: 2,
                 name: "MyModule",
@@ -868,9 +869,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@optional_callbacks",
@@ -880,7 +881,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 1}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@behaviour MyBehaviour",
@@ -890,7 +891,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@impl true",
@@ -900,7 +901,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 3}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@derive",
@@ -910,7 +911,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 4}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@enforce_keys",
@@ -920,7 +921,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 5}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@compile",
@@ -930,7 +931,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 6}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@deprecated",
@@ -940,7 +941,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 7}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@dialyzer",
@@ -950,7 +951,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 8}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@file",
@@ -960,7 +961,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 9}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@external_resource",
@@ -970,7 +971,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 10}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@on_load",
@@ -980,7 +981,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 11}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@on_definition",
@@ -990,7 +991,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 12}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@vsn",
@@ -1000,7 +1001,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 13}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@after_compile",
@@ -1010,7 +1011,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 14}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@before_compile",
@@ -1020,7 +1021,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 15}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@fallback_to_any",
@@ -1030,7 +1031,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 3, line: 16}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 14,
                     name: "@impl MyBehaviour",
@@ -1060,9 +1061,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "test \"does something\"",
@@ -1103,11 +1104,11 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [
-                      %{
+                      %DocumentSymbol{
                         children: [],
                         kind: 12,
                         name: "test \"does something\"",
@@ -1165,9 +1166,9 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "setup",
@@ -1177,7 +1178,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 2, line: 2}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "setup",
@@ -1187,7 +1188,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       start: %{character: 2, line: 5}
                     }
                   },
-                  %{
+                  %DocumentSymbol{
                     children: [],
                     kind: 12,
                     name: "setup_all",
@@ -1225,28 +1226,28 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok,
             [
-              %{
+              %DocumentSymbol{
                 children: [],
                 kind: 20,
                 name: "config :logger :console",
                 range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 1}},
                 selectionRange: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 1}}
               },
-              %{
+              %DocumentSymbol{
                 children: [],
                 kind: 20,
                 name: "config :app :key",
                 range: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}},
                 selectionRange: %{end: %{character: 0, line: 6}, start: %{character: 0, line: 6}}
               },
-              %{
+              %DocumentSymbol{
                 children: [],
                 kind: 20,
                 name: "config :my_app :ecto_repos",
                 range: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}},
                 selectionRange: %{end: %{character: 0, line: 7}, start: %{character: 0, line: 7}}
               },
-              %{
+              %DocumentSymbol{
                 children: [],
                 kind: 20,
                 name: "config :my_app MyApp.Repo",


### PR DESCRIPTION
LSP client advertises whether it supports hierarchical document symbols (DocumentSymbol type), or if
it wants them flat (SymbolInformation type). This is set in the client capabilities in `textDocument
-> documentSymbol -> hierarchicalDocumentSymbolSupport`, where false is the default.

Previously this server always returned DocumentSymbol, which didn't work with clients implementing
the LSP spec properly, like eglot (https://github.com/joaotavora/eglot). This commit adds support
for flat document symbols and thus fixes eglot imenu issues.

This is another issue of inconsistency between LSP specification and LSP clients. LSP specs includes `hierarchicalDocumentSymbolSupport?` which LSP clients can use to say they support hierarhical document symbols, instead of flat ones. This would make me assume the default is the old non-hierarhical format (this is not clearly marked in the spec though). However, some clients (like coc.nvim) don't send this flag and do support the new hierarhical format.

Tested with eglot and coc.nvim, both work fine. However, since coc.nvim doesn't send the above flag, this change makes it use the non-hierarhical format and that looks a tad uglier (see [screenshots](https://imgur.com/a/IqU3tXV)). I would argue this is a problem of the client, but some people might not like a commit that suddenly breaks things, so I am putting this here up for a discussion.

If you decide it's OK, I will complete the tests. So far I only fixed the existing tests, but it would be best to add test cases to test the flat format too.