### PR TITLE
Change running scripts to run bash instead of sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Bump ElixirSense
   - Main changes: return results by arity, return all type signatures, typespec and dialyzer fixes
 
+Breaking Changes:
+
+- `language_server.sh` and `debugger.sh` run bash instead of `sh` (this is expected to break very few setups, if any) [#118](https://github.com/elixir-lsp/elixir-ls/pull/118)
+
 ### v0.2.28: 16 Nov 2019
 
 - Fix debugger tasks not continuing to run on Elixir 1.9 (thanks to [joshua-andrassy](https://github.com/joshua-andrassy) for doing the legwork)

--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Launches the debugger. This script must be in the same directory as the compiled .ez archives.
 
 [ -f "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"

--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Launches the language server. This script must be in the same directory as the compiled .ez archives.
 
 [ -f "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"


### PR DESCRIPTION
While this lowers compatibility somewhat, any system that a developer is actively using is expected to have bash installed. This change is required because asdf does not currently support sh, only bash and other more advanced shells.

Fixes #114