### PR TITLE
Fix requestMessage doesnt seem to match spec

### DIFF
--- a/apps/language_server/lib/language_server/json_rpc.ex
+++ b/apps/language_server/lib/language_server/json_rpc.ex
@@ -27,6 +27,16 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
     end
   end
 
+  defmacro request(id, method) do
+    quote do
+      %{
+        "id" => unquote(id),
+        "method" => unquote(method),
+        "jsonrpc" => "2.0"
+      }
+    end
+  end
+
   defmacro request(id, method, params) do
     quote do
       %{

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -465,6 +465,19 @@ defmodule ElixirLS.LanguageServer.Server do
     {:ok, x, state}
   end
 
+  defp handle_request(request(_, _) = req, state) do
+    handle_invalid_request(req, state)
+  end
+
+  defp handle_request(request(_, _, _) = req, state) do
+    handle_invalid_request(req, state)
+  end
+
+  defp handle_invalid_request(req, state) do
+    IO.inspect(req, label: "Unmatched request")
+    {:error, :invalid_request, nil, state}
+  end
+
   defp handle_request_async(id, func) do
     parent = self()
 

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -116,6 +116,11 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
+  test "requests shutdown", %{server: server} do
+    Server.receive_packet(server, request(1, "shutdown"))
+    assert %{received_shutdown?: true} = :sys.get_state(server)
+  end
+
   # TODO: Fix this test for the incremental formatter
   @tag :pending
   test "formatter", %{server: server} do

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -125,6 +125,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     Server.receive_packet(server, request(1, "shutdown", nil))
     assert %{received_shutdown?: true} = :sys.get_state(server)
   end
+
   # TODO: Fix this test for the incremental formatter
   @tag :pending
   test "formatter", %{server: server} do

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -116,11 +116,15 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
-  test "requests shutdown", %{server: server} do
+  test "requests shutdown without params", %{server: server} do
     Server.receive_packet(server, request(1, "shutdown"))
     assert %{received_shutdown?: true} = :sys.get_state(server)
   end
 
+  test "requests shutdown with params", %{server: server} do
+    Server.receive_packet(server, request(1, "shutdown", nil))
+    assert %{received_shutdown?: true} = :sys.get_state(server)
+  end
   # TODO: Fix this test for the incremental formatter
   @tag :pending
   test "formatter", %{server: server} do


### PR DESCRIPTION
In the LSP spec for requestMessage, the params key is optional. However, the code seems to only expect the 3 arity variant. This patch allows both the 2 arity and 3 arity variants, so that the shutdown requests will work (which doesn't include a params key).

Fixes #138

See also:
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage