### PR TITLE
Fix the debugger

### DIFF
--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -443,7 +443,7 @@ defmodule ElixirLS.Debugger.Server do
 
     # FIXME: Private API
     unless match?(%{file: ^mixfile}, Mix.ProjectStack.peek()) do
-      Code.require_file(System.get_env("MIX_EXS") || "mix.exs")
+      Code.compile_file(System.get_env("MIX_EXS") || "mix.exs")
     end
 
     task = task || Mix.Project.config()[:default_task]
@@ -555,7 +555,7 @@ defmodule ElixirLS.Debugger.Server do
       %{name: name, file: file} = project
       :code.purge(name)
       :code.delete(name)
-      Code.require_file(file)
+      Code.compile_file(file)
     end
   end
 

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -555,6 +555,9 @@ defmodule ElixirLS.Debugger.Server do
       %{name: name, file: file} = project
       :code.purge(name)
       :code.delete(name)
+      # It's important to use `compile_file` here instead of `require_file`
+      # because we are recompiling this file to reload the mix project back onto
+      # the project stack.
       Code.compile_file(file)
     end
   end

--- a/apps/elixir_ls_utils/test/support/mix_test.case.ex
+++ b/apps/elixir_ls_utils/test/support/mix_test.case.ex
@@ -129,6 +129,9 @@ defmodule ElixirLS.Utils.MixTest.Case do
     for %{name: module, file: file} <- stack do
       :code.purge(module)
       :code.delete(module)
+      # It's important to use `compile_file` here instead of `require_file`
+      # because we are recompiling this file to reload the mix project back onto
+      # the project stack.
       Code.compile_file(file)
     end
   end

--- a/apps/elixir_ls_utils/test/support/mix_test.case.ex
+++ b/apps/elixir_ls_utils/test/support/mix_test.case.ex
@@ -129,7 +129,7 @@ defmodule ElixirLS.Utils.MixTest.Case do
     for %{name: module, file: file} <- stack do
       :code.purge(module)
       :code.delete(module)
-      Code.require_file(file)
+      Code.compile_file(file)
     end
   end
 


### PR DESCRIPTION
The debugger was inadvertently broken in #93 which the change from the deprecated ([2]) `Code.load_file/1` to `Code.require_file/1`. The compatibility docs for 1.10 [1] list both `Code.require_file/1` and `Code.compile_file/1` as possible replacements for `Code.load_file/1`. In our case we need `Code.compile_file/1` instead of `Code.require_file/1` since `Code.require_file/1` tracks which files have been required and compiled and does not compile them more than once. Specifically the docs state:

> If require_file/2 is called more than once with a given file, that file will be compiled only once

So since `Code.load_file/1` would always compile the file we need to use `Code.compile_file/1` rather than `Code.require_file/1`. When `Code.require_file/1` was used, the call in
`ElixirLS.Debugger.Server.change_env/1` would have no effect because the file was previously required. By changing to `Code.compile_file/1` the project will always be reloaded by compiling it's `mix.exs` file.

[1] https://hexdocs.pm/elixir/1.10.2/compatibility-and-deprecations.html#table-of-deprecations
[2] https://github.com/elixir-lang/elixir/pull/7201

Fixes #131