### PR TITLE
Bring textDocumentSync save option up to spec

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -493,7 +493,7 @@ defmodule ElixirLS.LanguageServer.Server do
       "textDocumentSync" => %{
         "change" => 2,
         "openClose" => true,
-        "save" => true
+        "save" => %{"includeText" => true}
       },
       "hoverProvider" => true,
       "completionProvider" => %{"triggerCharacters" => Completion.trigger_characters()},


### PR DESCRIPTION
The [current Language Server Protocol specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#textDocument_synchronization) (3.15 at the time of writing) dictates that the `save` value  of `TextDocumentSyncOptions` should, if defined, be of type `SaveOptions`, which it in turn defines as an object with an optional `includeText` property of type `boolean`.

This changes the `textDocumentSync["save"]` value, which was set to a bare boolean, to a map with the expected `includeText` boolean value.

I noticed this issue while using the [vim-lsp](https://github.com/prabirshrestha/vim-lsp) Vim plugin—an error occurred each time it acted on the aforementioned `save` option. I verified that this change corrects the behavior with that particular LSP client.