### PR TITLE
textDocument/documentSymbol should handle a non-fully initialized server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+Bug Fixes:
+- Fix `textDocument/documentSymbol` on a non-fully initialized server (thanks [Jason Axelson](https://github.com/axelson)) [#173](https://github.com/elixir-lsp/elixir-ls/pull/173)
+
 ### v0.3.2: 28 Mar 2020
 
 Improvements:

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -394,12 +394,19 @@ defmodule ElixirLS.LanguageServer.Server do
   defp handle_request(document_symbol_req(_id, uri), state) do
     fun = fn ->
       hierarchical? =
-        state.client_capabilities
-        |> Map.get("textDocument", %{})
-        |> Map.get("documentSymbol", %{})
-        |> Map.get("hierarchicalDocumentSymbolSupport", false)
+        get_in(state.client_capabilities, [
+          "textDocument",
+          "documentSymbol",
+          "hierarchicalDocumentSymbolSupport"
+        ]) || false
 
-      DocumentSymbols.symbols(uri, state.source_files[uri].text, hierarchical?)
+      source_file = state.source_files[uri]
+
+      if source_file do
+        DocumentSymbols.symbols(uri, source_file.text, hierarchical?)
+      else
+        {:ok, []}
+      end
     end
 
     {:async, fun, state}

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -126,6 +126,18 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     assert %{received_shutdown?: true} = :sys.get_state(server)
   end
 
+  test "document symbols request when there are no client capabilities and the source file is not loaded into the server",
+       %{server: server} do
+    server_state = :sys.get_state(server)
+    assert server_state.client_capabilities == nil
+    assert server_state.source_files == %{}
+
+    Server.receive_packet(server, document_symbol_req(1, "file:///file.ex"))
+
+    resp = assert_receive(%{"id" => 1}, 1000)
+    assert resp["result"] == []
+  end
+
   test "incremental formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->
       uri = Path.join([root_uri(), "file.ex"])


### PR DESCRIPTION
Sometimes requests will be processed when the server has not been initialized with client capabilities yet, this should not result in an error. Was previously:
```
[Error - 6:07:18 AM] Request textDocument/documentSymbol failed.
  Message: an exception was raised:
    ** (BadMapError) expected a map, got: nil
        (elixir 1.10.2) lib/map.ex:450: Map.get(nil, "textDocument", %{})
        (language_server 0.3.0) lib/language_server/server.ex:398: anonymous fn/2 in ElixirLS.LanguageServer.Server.handle_request/2
        (language_server 0.3.0) lib/language_server/server.ex:485: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2
  Code: -32000
```

Fixes #172