### PR TITLE
Fix exception when processing a textDocument/didChange notification

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -279,6 +279,12 @@ defmodule ElixirLS.LanguageServer.Server do
         # The source file was not marked as open either due to a bug in the
         # client or a restart of the server. So just ignore the message and do
         # not update the state
+        IO.warn(
+          "Received textDocument/didChange for file that is not open. Received uri: #{
+            inspect(uri)
+          }"
+        )
+
         nil
 
       source_file ->

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -274,9 +274,16 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   defp handle_notification(did_change(uri, version, content_changes), state) do
-    update_in(state.source_files[uri], fn source_file ->
-      source_file = %{source_file | version: version, dirty?: true}
-      SourceFile.apply_content_changes(source_file, content_changes)
+    update_in(state.source_files[uri], fn
+      nil ->
+        # The source file was not marked as open either due to a bug in the
+        # client or a restart of the server. So just ignore the message and do
+        # not update the state
+        nil
+
+      source_file ->
+        source_file = %{source_file | version: version, dirty?: true}
+        SourceFile.apply_content_changes(source_file, content_changes)
     end)
   end
 

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -28,6 +28,28 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     {:ok, %{server: server}}
   end
 
+  test "textDocument/didChange when the client hasn't claimed ownership with textDocument/didOpen",
+       %{server: server} do
+    uri = "file:///file.ex"
+
+    content_changes = [
+      %{
+        "range" => %{
+          "end" => %{"character" => 2, "line" => 1},
+          "start" => %{"character" => 0, "line" => 2}
+        },
+        "rangeLength" => 1,
+        "text" => ""
+      }
+    ]
+
+    version = 2
+    Server.receive_packet(server, did_change(uri, version, content_changes))
+
+    # Wait for the server to process the message and ensure that there is no exception
+    _ = :sys.get_state(server)
+  end
+
   test "hover", %{server: server} do
     uri = "file:///file.ex"
     code = ~S(


### PR DESCRIPTION
If there is a client bug (the client did not notify the server that it was opening a file) or the server doesn't know about the file because it recently restarted then do not try to update a non-existant source file in memory.