### PR TITLE
DocumentSymbols provider should handle modules without a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Meta:
 Bug Fixes:
 - Fix `textDocument/documentSymbol` on a non-fully initialized server (thanks [Jason Axelson](https://github.com/axelson)) [#173](https://github.com/elixir-lsp/elixir-ls/pull/173)
 - Don't return snippets to clients that don't declare `snippetSupport` for completions (thanks [Jason Axelson](https://github.com/axelson)) [#173](https://github.com/elixir-lsp/elixir-ls/pull/177)
+- Handle an exception that was raised in the DocumentSymbols provider (thanks [Jason Axelson](https://github.com/axelson)) [#173](https://github.com/elixir-lsp/elixir-ls/pull/179)
 
 ### v0.3.2: 28 Mar 2020
 

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2324,4 +2324,75 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               }
             ]} = DocumentSymbols.symbols(uri, text, false)
   end
+
+  test "[nested] handles a file with a top-level module without a name" do
+    uri = "file://project/test.exs"
+
+    text = """
+    defmodule do
+    def foo, do: :bar
+    end
+    """
+
+    assert {:ok, document_symbols} = DocumentSymbols.symbols(uri, text, true)
+
+    assert [
+             %Protocol.DocumentSymbol{
+               children: children,
+               kind: 2,
+               name: "MISSING_MODULE_NAME",
+               range: %{
+                 start: %{line: 0, character: 0},
+                 end: %{line: 0, character: 0}
+               },
+               selectionRange: %{
+                 start: %{line: 0, character: 0},
+                 end: %{line: 0, character: 0}
+               }
+             }
+           ] = document_symbols
+
+    assert children == [
+             %Protocol.DocumentSymbol{
+               children: [],
+               kind: 12,
+               name: "foo",
+               range: %{
+                 start: %{character: 4, line: 1},
+                 end: %{character: 4, line: 1}
+               },
+               selectionRange: %{
+                 start: %{character: 4, line: 1},
+                 end: %{character: 4, line: 1}
+               }
+             }
+           ]
+  end
+
+  test "[nested] handles a file with a top-level protocol module without a name" do
+    uri = "file://project/test.exs"
+
+    text = """
+    defprotocol do
+    end
+    """
+
+    assert {:ok, document_symbols} = DocumentSymbols.symbols(uri, text, true)
+
+    assert [
+             %Protocol.DocumentSymbol{
+               children: [],
+               kind: 11,
+               name: "MISSING_PROTOCOL_NAME",
+               range: %{
+                 start: %{line: 0, character: 0},
+                 end: %{line: 0, character: 0}
+               },
+               selectionRange: %{
+                 start: %{line: 0, character: 0},
+                 end: %{line: 0, character: 0}
+               }
+             }
+           ] = document_symbols
+  end
 end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2379,7 +2379,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
 
     assert {:ok, document_symbols} = DocumentSymbols.symbols(uri, text, true)
 
-    assert [
+    assert document_symbols == [
              %Protocol.DocumentSymbol{
                children: [],
                kind: 11,
@@ -2393,6 +2393,6 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                  end: %{line: 0, character: 0}
                }
              }
-           ] = document_symbols
+           ]
   end
 end


### PR DESCRIPTION
The DocumentSymbols provider should be able to handle a variety of compilation errors so that it can be useful while debugging the compilation errors. The main problem was that the `extract_symbol/2` clause that handled `defmodule` and `defprotocol` was overly restrictive in the pattern match that it did. So I've changed it to match all the possible AST variations (although some may still raise an exception within the clause, but this prevents bad data from propagating).

`MISSING_MODULE_NAME` was returned since a non-empty name is required by the Language Server Protocol.