### PR TITLE
DocumentSymbols provider handles compilation errors gracefully

### DIFF
--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2395,4 +2395,19 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
              }
            ]
   end
+
+  test "handles a file with compilation errors by returning an empty list" do
+    uri = "file://project/test.exs"
+
+    text = """
+    defmodule A do
+      def hello do
+        Hello.hi(
+      end
+    end
+    """
+
+    assert {:error, :server_error, message} = DocumentSymbols.symbols(uri, text, true)
+    assert String.contains?(message, "Compilation error")
+  end
 end


### PR DESCRIPTION
Rather than throwing an exception (which causes the spawned process to crash) the DocumentSymbols provider will now simply return an error.

This is beneficial because this is very much an expected error and thus it is confusing to show the exception in the logs. Possibly there are also performance benefits to this as well.

Ideally the DocumentSymbols provider could still return valid symbols in this case, but that is currently infeasible.