### PR TITLE
Fix workspace symbols indexing error

### DIFF
--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -378,6 +378,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
       chunked_module_paths
       |> do_process_chunked(fn chunk ->
         for {module, path} <- chunk,
+            Code.ensure_loaded?(module),
             {function, arity} <- module.module_info(:exports) do
           {function, arity} = SourceFile.strip_macro_prefix({function, arity})
           line = find_function_line(module, function, arity, path)


### PR DESCRIPTION
No test because it would be difficult to re-write the test cases to handle/check this case.

Fixes one of the issues mentioned in #185 