### PR TITLE
Handle formatting errors when file has syntax errors

### DIFF
--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -25,6 +25,9 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
 
       {:error, :internal_error, msg}
     end
+  rescue
+    _e in [TokenMissingError, SyntaxError] ->
+      {:error, :internal_error, "Unable to format due to syntax error"}
   end
 
   # If in an umbrella project, the cwd might be set to a sub-app if it's being compiled. This is

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -475,8 +475,14 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   defp handle_request(formatting_req(_id, uri, _options), state) do
-    fun = fn -> Formatting.format(state.source_files[uri], uri, state.project_dir) end
-    {:async, fun, state}
+    case state.source_files[uri] do
+      nil ->
+        {:error, :server_error, "Missing source file", state}
+
+      source_file ->
+        fun = fn -> Formatting.format(source_file, uri, state.project_dir) end
+        {:async, fun, state}
+    end
   end
 
   defp handle_request(signature_help_req(_id, uri, line, character), state) do

--- a/apps/language_server/test/providers/formatting_test.exs
+++ b/apps/language_server/test/providers/formatting_test.exs
@@ -1,0 +1,70 @@
+defmodule ElixirLS.LanguageServer.Providers.FormattingTest do
+  use ExUnit.Case
+  alias ElixirLS.LanguageServer.Providers.Formatting
+
+  test "Formats a file" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      require Logger
+
+      def dummy_function() do
+        Logger.info "dummy"
+      end
+    end
+    """
+
+    source_file = %ElixirLS.LanguageServer.SourceFile{
+      text: text,
+      version: 1,
+      dirty?: true
+    }
+
+    project_dir = "/project"
+
+    assert {:ok, changes} = Formatting.format(source_file, uri, project_dir)
+
+    assert changes == [
+             %{
+               "newText" => ")",
+               "range" => %{
+                 "end" => %{"character" => 23, "line" => 4},
+                 "start" => %{"character" => 23, "line" => 4}
+               }
+             },
+             %{
+               "newText" => "(",
+               "range" => %{
+                 "end" => %{"character" => 16, "line" => 4},
+                 "start" => %{"character" => 15, "line" => 4}
+               }
+             }
+           ]
+  end
+
+  test "returns an error when formatting a file with a syntax error" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      require Logger
+
+      def dummy_function() do
+        Logger.info("dummy
+      end
+    end
+    """
+
+    source_file = %ElixirLS.LanguageServer.SourceFile{
+      text: text,
+      version: 1,
+      dirty?: true
+    }
+
+    project_dir = "/project"
+
+    assert {:error, :internal_error, msg} = Formatting.format(source_file, uri, project_dir)
+    assert String.contains?(msg, "Unable to format")
+  end
+end

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -1,6 +1,6 @@
 defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
-  alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
   use ExUnit.Case
+  alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
 
   setup_all do
     pid =


### PR DESCRIPTION
Otherwise we're logging an exception which makes the logs unnecessarily noisy and this should be an expected case.

Also handle the case where the source_file is not currently in state