### PR TITLE
Add neovim coc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You may want to install Elixir and Erlang from source, using the [kiex](https://
 | Atom IDE | [JakeBecker/ide-elixir](https://github.com/JakeBecker/ide-elixir)             | Does not support debugger or @spec suggestions |
 | Vim      | [ALE](https://github.com/w0rp/ale)                                            | Does not support debugger or @spec suggestions |
 | Neovim   | [ALE](https://github.com/w0rp/ale)                                            | Does not support debugger                      |
+| Neovim   | [coc.nvim](https://github.com/neoclide/coc.nvim)                              | Does not support debugger                      |
 | Emacs    | [lsp-mode](https://github.com/emacs-lsp/lsp-mode) |      Supports debugger via [dap-mode](https://github.com/yyoncho/dap-mode) |
 | Emacs    | [eglot](https://github.com/joaotavora/eglot)                                  |                                                |
 


### PR DESCRIPTION
Using coc.nvim support all the ElixirLS features except the debugger

https://github.com/neoclide/coc.nvim/wiki/Language-servers#elixir

#### note:
coc.nvim is compatible with vim8 but the functionality of `@spec`
suggestions only works on neovim.

![image](https://user-images.githubusercontent.com/1911813/78954400-b1d3ea00-7aa1-11ea-9a8a-cec5e5ab8167.png)
