### PR TITLE
Properly get beam file for preloaded modules in dialyzer

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -359,7 +359,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
 
         files_to_analyze =
           for module <- modules_to_analyze do
-            temp_modules[module] || :code.which(module)
+            temp_modules[module] || Utils.get_beam_file(module)
           end
 
         # Clear warnings for files that changed or need to be re-analyzed

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -1,5 +1,5 @@
 defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
-  alias ElixirLS.LanguageServer.{Dialyzer, JsonRpc}
+  alias ElixirLS.LanguageServer.{Dialyzer, Dialyzer.Utils, JsonRpc}
   import Record
   import Dialyzer.Utils
 
@@ -125,7 +125,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
       |> Path.wildcard()
       |> Enum.map(&pathname_to_module/1)
       |> expand_references()
-      |> Enum.map(&:code.which/1)
+      |> Enum.map(&Utils.get_beam_file/1)
       |> Enum.filter(&is_list/1)
 
     File.mkdir_p!(Path.dirname(elixir_plt_path()))


### PR DESCRIPTION
Fixes dialyzer diagnostics not showing for code using preloaded modules
e.g.
```
:erlang.monitor_node(:asdf, 2)
```