### PR TITLE
Warn in debugger if on an unsupported version of elixir

### DIFF
--- a/apps/debugger/lib/debugger/cli.ex
+++ b/apps/debugger/lib/debugger/cli.ex
@@ -8,6 +8,22 @@ defmodule ElixirLS.Debugger.CLI do
     Application.ensure_all_started(:debugger, :permanent)
     IO.puts("Started ElixirLS debugger v#{Launch.debugger_version()}")
     Launch.print_versions()
+    warn_if_unsupported_version()
     WireProtocol.stream_packets(&Server.receive_packet/1)
+  end
+
+  # Debugging does not work on Elixir 1.10.0-1.10.2:
+  # https://github.com/elixir-lsp/elixir-ls/issues/158
+  defp warn_if_unsupported_version do
+    elixir_version = System.version()
+
+    if Version.match?(elixir_version, ">= 1.10.0") && Version.match?(elixir_version, "< 1.10.3") do
+      message =
+        "WARNING: Debugging is not supported on Elixir #{elixir_version}. Please upgrade" <>
+          " to at least 1.10.3\n" <>
+          "more info: https://github.com/elixir-lsp/elixir-ls/issues/158"
+
+      Output.print_err(message)
+    end
   end
 end


### PR DESCRIPTION
Debugging does not work on Elixir 1.10.0-1.10.2 which was resolved in https://github.com/elixir-lang/elixir/pull/9864 (which is included in Elixir 1.10.3). So we warn if running on an unsupported version of elixir.

The generated warning looks like:
![example-debugger-unsupported-warning](https://user-images.githubusercontent.com/9973/80291214-88dd6700-86e7-11ea-998e-ea9f97e94c46.png)

Fixes #158