### PR TITLE
Change did not receive workspace/didChangeConfiguration log level

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -156,7 +156,7 @@ defmodule ElixirLS.LanguageServer.Server do
       case state do
         %{settings: nil} ->
           JsonRpc.show_message(
-            :warning,
+            :info,
             "Did not receive workspace/didChangeConfiguration notification after 5 seconds. " <>
               "Using default settings."
           )


### PR DESCRIPTION
Change from warning to info since it is very much expected on most clients, and in coc.vim warnings require the user to clear them.

Fixes #217