### PR TITLE
Add Kate editor to the list of IDE plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You may want to install Elixir and Erlang from source, using the [kiex](https://
 | Neovim   | [coc.nvim](https://github.com/neoclide/coc.nvim)                              | Does not support debugger                      |
 | Emacs    | [lsp-mode](https://github.com/emacs-lsp/lsp-mode) |      Supports debugger via [dap-mode](https://github.com/yyoncho/dap-mode) |
 | Emacs    | [eglot](https://github.com/joaotavora/eglot)                                  |                                                |
+| Kate     | [built-in LSP Client plugin](https://kate-editor.org/post/2020/2020-01-01-kate-lsp-client-status/) | Does not support debugger |
 
 Feel free to create and publish your own client packages and add them to this list!
 


### PR DESCRIPTION
This adds KDE's Kate to the list of IDE plugins.

The way Kate works though is a bit different than the rest. It has a built-in plugin for LSP (which must be enabled first) and the configuration is a JSON through the settings interface. Since there is no place in Kate's site that says anythings about the LSP, I've just linked to the latest post about LSP Client status from the Kate team.

Anyway, just wanted to share with people that this is a very viable option for editing and, from my short experience, a good one.