### PR TITLE
Stop tracking removed files and modules

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -374,13 +374,15 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
 
         {active_plt, new_mod_deps, raw_warnings} = Analyzer.analyze(active_plt, files_to_analyze)
 
-        mod_deps = Map.merge(mod_deps, new_mod_deps)
+        mod_deps = update_mod_deps(mod_deps, new_mod_deps, removed_modules)
         warnings = add_warnings(warnings, raw_warnings)
 
         md5 =
           for {file, {_, hash}} <- file_changes, into: md5 do
             {file, hash}
           end
+
+        md5 = remove_files(md5, removed_files)
 
         {active_plt, mod_deps, md5, warnings}
       end)
@@ -391,6 +393,18 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     )
 
     analysis_finished(parent, :ok, active_plt, mod_deps, md5, warnings, timestamp, build_ref)
+  end
+
+  defp update_mod_deps(mod_deps, new_mod_deps, removed_modules) do
+    mod_deps
+    |> Map.merge(new_mod_deps)
+    |> Map.drop(removed_modules)
+    |> Enum.map(fn {mod, deps} -> {mod, deps -- removed_modules} end)
+    |> Enum.into(%{})
+  end
+
+  defp remove_files(md5, removed_files) do
+    Map.drop(md5, removed_files)
   end
 
   defp add_warnings(warnings, raw_warnings) do

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -399,8 +399,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     mod_deps
     |> Map.merge(new_mod_deps)
     |> Map.drop(removed_modules)
-    |> Enum.map(fn {mod, deps} -> {mod, deps -- removed_modules} end)
-    |> Enum.into(%{})
+    |> Map.new(fn {mod, deps} -> {mod, deps -- removed_modules} end)
   end
 
   defp remove_files(md5, removed_files) do


### PR DESCRIPTION
After a file is removed
* its md5 should not be tracked anymore and 
* its module should not be tracked in `mod_deps`