### PR TITLE
Fix usage of private API Mix.Dep.clear_cached/0

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -13,8 +13,7 @@ defmodule ElixirLS.LanguageServer.Build do
               IO.puts("Compiling with Mix env #{Mix.env()}")
 
               prev_deps = cached_deps()
-              # FIXME: Private API
-              Mix.Dep.clear_cached()
+              :ok = Mix.Project.clear_deps_cache()
 
               case reload_project() do
                 {:ok, mixfile_diagnostics} ->


### PR DESCRIPTION
Mix.Project.clear_deps_cache() is a supported API (as of 1.7.0) and it just calls `Mix.Dep.clear_cached/0` so the code is effectively identical (but now supported!)

For reference it was added in:
https://github.com/elixir-lang/elixir/pull/7248