### PR TITLE
Fix Formatting.format returns character float number

### DIFF
--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -81,7 +81,7 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
       else
         # LSP contentChanges positions are based on UTF-16 string representation
         # https://microsoft.github.io/language-server-protocol/specification#textDocuments
-        {line, col + byte_size(:unicode.characters_to_binary(char, :utf8, :utf16)) / 2}
+        {line, col + div(byte_size(:unicode.characters_to_binary(char, :utf8, :utf16)), 2)}
       end
     end)
   end

--- a/apps/language_server/test/providers/formatting_test.exs
+++ b/apps/language_server/test/providers/formatting_test.exs
@@ -41,7 +41,15 @@ defmodule ElixirLS.LanguageServer.Providers.FormattingTest do
                }
              }
            ]
+
+    assert Enum.all?(changes, fn change ->
+             assert_position_type(change["range"]["end"]) and
+               assert_position_type(change["range"]["start"])
+           end)
   end
+
+  defp assert_position_type(%{"character" => ch, "line" => line}),
+    do: is_integer(ch) and is_integer(line)
 
   test "returns an error when formatting a file with a syntax error" do
     uri = "file://project/file.ex"


### PR DESCRIPTION
This bug happens because of use `/ 2` in advance_pos which is convert
into floating number. Fixes by using `trunc/1`. And add test to ensure
line and character always integer.

Fixes #249