### PR TITLE
Add nix derivation for ElixirLS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+let
+  packages = nixpkgs.beam.packages.erlang;
+in rec {
+  elixirLS = packages.callPackage nix/package.nix {};
+}

--- a/nix/fetch-mix-deps.nix
+++ b/nix/fetch-mix-deps.nix
@@ -1,0 +1,38 @@
+{ stdenvNoCC, elixir, rebar, rebar3, git, cacert }:
+
+{ name ? null, src, sha256 ? null, env ? "prod" }:
+
+stdenvNoCC.mkDerivation {
+  name = "mix-deps" + (if name != null then "-${name}" else "");
+
+  nativeBuildInputs = [ elixir git cacert ];
+
+  inherit src;
+
+  configurePhase = ''
+    export MIX_ENV="${env}"
+
+    export HEX_HOME="$PWD/hex"
+    export MIX_HOME="$PWD/mix"
+    export MIX_DEPS_PATH="$out"
+    export MIX_REBAR="${rebar}/bin/rebar"
+    export MIX_REBAR3="${rebar3}/bin/rebar3"
+    export REBAR_GLOBAL_CONFIG_DIR="$PWD/rebar3"
+    export REBAR_CACHE_DIR="$PWD/rebar3.cache"
+
+    mix local.hex --force
+    '';
+
+  buildPhase = ''
+    mix deps.get
+    find "$out" -path '*/.git/*' -a ! -name HEAD -exec rm -rf {} +
+    '';
+
+  dontInstall = true;
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,54 @@
+{ stdenv, elixir, rebar3, hex, callPackage, git, cacert }:
+
+let
+  fetchMixDeps = callPackage ./fetch-mix-deps.nix {};
+in stdenv.mkDerivation rec {
+  name = "elixir-ls";
+  version = "dev";
+
+  nativeBuildInputs = [ elixir hex git deps cacert ];
+
+  deps = fetchMixDeps {
+    name = "${name}-${version}";
+    inherit src;
+  };
+
+  src = ../.;
+
+  dontStrip = true;
+
+  configurePhase = ''
+    export MIX_ENV=prod
+
+    export HEX_OFFLINE=1
+    export HEX_HOME="$PWD/hex"
+    export MIX_HOME="$PWD"
+    export MIX_REBAR3="${rebar3}/bin/rebar3"
+    export REBAR_GLOBAL_CONFIG_DIR="$PWD/rebar3"
+    export REBAR_CACHE_DIR="$PWD/rebar3.cache"
+
+    cp --no-preserve=all -R ${deps} deps
+
+    mix deps.compile --no-deps-check
+  '';
+
+  buildPhase = ''
+    mix do compile --no-deps-check, elixir_ls.release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -Rv release $out/lib
+
+    # Prepare the wrapper script
+    substitute release/language_server.sh $out/bin/elixir-ls \
+      --replace 'exec "''${dir}/launch.sh"' "exec $out/lib/launch.sh"
+    chmod +x $out/bin/elixir-ls
+
+    # prepare the launcher
+    substituteInPlace $out/lib/launch.sh \
+      --replace "ERL_LIBS=\"\$SCRIPTPATH:\$ERL_LIBS\"" \
+                "ERL_LIBS=$out/lib:\$ERL_LIBS" \
+      --replace "elixir -e" "${elixir}/bin/elixir -e"
+  '';
+}


### PR DESCRIPTION
To test out one can run `nix-build` in the root of the project. After
build finish there will be `result/` directory containing built project
which can be ran with `result/bin/elixir-ls`.