### PR TITLE
Vendor Jason library

### DIFF
--- a/apps/elixir_ls_utils/lib/packet_stream.ex
+++ b/apps/elixir_ls_utils/lib/packet_stream.ex
@@ -52,7 +52,7 @@ defmodule ElixirLS.Utils.PacketStream do
     if body == :eof do
       :eof
     else
-      Jason.decode!(body)
+      JasonVendored.decode!(body)
     end
   end
 end

--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -6,7 +6,7 @@ defmodule ElixirLS.Utils.WireProtocol do
 
   def send(packet) do
     pid = Process.whereis(:raw_user) || Process.group_leader()
-    body = Jason.encode!(packet) <> "\r\n\r\n"
+    body = JasonVendored.encode!(packet) <> "\r\n\r\n"
     IO.binwrite(pid, "Content-Length: #{byte_size(body)}\r\n\r\n" <> body)
   end
 

--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -26,7 +26,7 @@ defmodule ElixirLS.Utils.Mixfile do
 
   defp deps do
     [
-      {:jason, "~> 1.2"},
+      {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
       {:mix_task_archive_deps, github: "JakeBecker/mix_task_archive_deps"}
     ]
   end

--- a/apps/elixir_ls_utils/test/support/packet_capture.ex
+++ b/apps/elixir_ls_utils/test/support/packet_capture.ex
@@ -49,7 +49,7 @@ defmodule ElixirLS.Utils.PacketCapture do
 
   defp extract_packet(str) do
     with [_header, body] <- String.split(str, "\r\n\r\n", parts: 2),
-         {:ok, packet} <- Jason.decode(body) do
+         {:ok, packet} <- JasonVendored.decode(body) do
       packet
     else
       _ -> nil

--- a/apps/language_server/lib/language_server/protocol/document_symbol.ex
+++ b/apps/language_server/lib/language_server/protocol/document_symbol.ex
@@ -4,6 +4,6 @@ defmodule ElixirLS.LanguageServer.Protocol.DocumentSymbol do
 
   For details see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
   """
-  @derive Jason.Encoder
+  @derive JasonVendored.Encoder
   defstruct [:name, :kind, :range, :selectionRange, :children]
 end

--- a/apps/language_server/lib/language_server/protocol/location.ex
+++ b/apps/language_server/lib/language_server/protocol/location.ex
@@ -4,6 +4,6 @@ defmodule ElixirLS.LanguageServer.Protocol.Location do
 
   For details see https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#location
   """
-  @derive Jason.Encoder
+  @derive JasonVendored.Encoder
   defstruct [:uri, :range]
 end

--- a/apps/language_server/lib/language_server/protocol/symbol_information.ex
+++ b/apps/language_server/lib/language_server/protocol/symbol_information.ex
@@ -4,6 +4,6 @@ defmodule ElixirLS.LanguageServer.Protocol.SymbolInformation do
 
   For details see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
   """
-  @derive Jason.Encoder
+  @derive JasonVendored.Encoder
   defstruct [:name, :kind, :location, :containerName]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -7,6 +7,7 @@
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},
   "getopt": {:hex, :getopt, "1.0.1", "c73a9fa687b217f2ff79f68a3b637711bb1936e712b521d8ce466b29cbf7808a", [:rebar3], [], "hexpm", "53e1ab83b9ceb65c9672d3e7a35b8092e9bdc9b3ee80721471a161c10c59959c"},
   "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "ee95ca80cd67b3a499a14f469536140935eb4483", [branch: "vendored"]},
   "mix_task_archive_deps": {:git, "https://github.com/JakeBecker/mix_task_archive_deps.git", "50301a4314e3cc1104f77a8208d5b66ee382970b", []},
   "providers": {:hex, :providers, "1.8.1", "70b4197869514344a8a60e2b2a4ef41ca03def43cfb1712ecf076a0f3c62f083", [:rebar3], [{:getopt, "1.0.1", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm", "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0"},
 }


### PR DESCRIPTION
Vendor the Jason library so that the version of Jason used by ElixirLS does not conflict with the version used by the end-users code. Right now one will win out over the other which can lead to issues. Luckily since Jason has been pretty stable there haven't been too many issues up to this point.

Pulls the vendored version of Jason from https://github.com/elixir-lsp/jason

Fixes #253