### PR TITLE
Remove keywords from completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Improvements:
 - Vendor Jason library to prevent conflicts with user's code (thanks [Jason Axelson](https://github.com/axelson)) [#253](https://github.com/elixir-lsp/elixir-ls/pull/253)
 
+Changes:
+- No longer always return a static list of keywords for completion (thanks [Jason Axelson](https://github.com/axelson)) [#259](https://github.com/elixir-lsp/elixir-ls/pull/259)
+
 Bug Fixes:
 - Formatting was returning invalid floating point number (thanks [Thanabodee Charoenpiriyakij](https://github.com/wingyplus)) [#250](https://github.com/elixir-lsp/elixir-ls/pull/250)
 

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -65,19 +65,6 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
                    "ExUnit.Assertions"
                  ])
 
-  @keywords %{
-    "end" => "end",
-    "do" => "do\n\t$0\nend",
-    "true" => "true",
-    "false" => "false",
-    "nil" => "nil",
-    "when" => "when",
-    "else" => "else\n\t$0",
-    "rescue" => "rescue\n\t$0",
-    "catch" => "catch\n\t$0",
-    "after" => "after\n\t$0"
-  }
-
   def trigger_characters do
     # VS Code's 24x7 autocompletion triggers automatically on alphanumeric characters. We add these
     # for "SomeModule." calls and @module_attrs
@@ -137,7 +124,6 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       ElixirSense.suggestions(text, line + 1, character + 1)
       |> Enum.map(&from_completion_item(&1, context, options))
       |> Enum.concat(module_attr_snippets(context))
-      |> Enum.concat(keyword_completions(context))
 
     items_json =
       items
@@ -547,23 +533,6 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
   end
 
   defp module_attr_snippets(_), do: []
-
-  # These aren't really useful, to be honest, and it interferes with the auto-indentation
-  # for "else", but better to show them even if there's no good reason to use them
-  defp keyword_completions(%{prefix: prefix}) do
-    @keywords
-    |> Enum.filter(fn {keyword, _} -> String.starts_with?(keyword, prefix) end)
-    |> Enum.map(fn {keyword, snippet} ->
-      %__MODULE__{
-        label: keyword,
-        kind: :keyword,
-        detail: "keyword",
-        insert_text: snippet,
-        tags: [],
-        priority: 1
-      }
-    end)
-  end
 
   defp function_completion(info, context, options) do
     %{

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -132,10 +132,21 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       |> sort_items()
       |> items_to_json(options)
 
-    {:ok, %{"isIncomplete" => false, "items" => items_json}}
+    {:ok, %{"isIncomplete" => is_incomplete(items_json), "items" => items_json}}
   end
 
   ## Helpers
+
+  defp is_incomplete(items) do
+    if Enum.empty?(items) do
+      false
+    else
+      # By returning isIncomplete = true we tell the client that it should
+      # always fetch more results, this lets us control the ordering of
+      # completions accurately
+      true
+    end
+  end
 
   defp from_completion_item(
          %{type: :attribute, name: name},

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -357,12 +357,33 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
 
       {line, char} = {4, 14}
       TestUtils.assert_has_cursor_char(text, line, char)
-      {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
+      {:ok, result} = Completion.completion(text, line, char, @supports)
+
+      assert result["isIncomplete"] == true
+      items = result["items"]
 
       assert ["__struct__", "other", "some"] ==
                items |> Enum.filter(&(&1["kind"] == 5)) |> Enum.map(& &1["label"]) |> Enum.sort()
 
       assert (items |> hd)["detail"] == "MyModule struct field"
+    end
+
+    test "isIncomplete is false when there are no results" do
+      text = """
+      defmodule MyModule do
+        defstruct [some: nil, other: 1]
+
+        def dummy_function() do
+          #                    ^
+      end
+      """
+
+      {line, char} = {3, 25}
+      TestUtils.assert_has_cursor_char(text, line, char)
+
+      {:ok, result} = Completion.completion(text, line, char, @supports)
+      assert result["isIncomplete"] == false
+      assert result["items"] == []
     end
   end
 end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -98,7 +98,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     resp = assert_receive(%{"id" => 1}, 1000)
 
     assert response(1, %{
-             "isIncomplete" => false,
+             "isIncomplete" => true,
              "items" => [
                %{
                  "detail" => "behaviour",
@@ -403,7 +403,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
         resp = assert_receive(%{"id" => 3}, 5000)
 
         assert response(3, %{
-                 "isIncomplete" => false,
+                 "isIncomplete" => true,
                  "items" => [
                    %{
                      "detail" => "module",


### PR DESCRIPTION
They were being returned regardless of context which made them very noisy. Additionally the most important of these ("do/end") is typically inserted by an editor plugin.

Related:
* https://github.com/elixir-lsp/elixir_sense/pull/99
* https://github.com/elixir-lsp/elixir-ls/issues/251