### PR TITLE
Switch to new supervisor format introduced in Elixir 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Improvements:
 - Vendor Jason library to prevent conflicts with user's code (thanks [Jason Axelson](https://github.com/axelson)) [#253](https://github.com/elixir-lsp/elixir-ls/pull/253)
+- Switch to new supervisor format (thanks [Jason Axelson](https://github.com/axelson)) [#260](https://github.com/elixir-lsp/elixir-ls/pull/260)
 
 Bug Fixes:
 - Formatting was returning invalid floating point number (thanks [Thanabodee Charoenpiriyakij](https://github.com/wingyplus)) [#250](https://github.com/elixir-lsp/elixir-ls/pull/250)

--- a/apps/debugger/lib/debugger.ex
+++ b/apps/debugger/lib/debugger.ex
@@ -7,14 +7,12 @@ defmodule ElixirLS.Debugger do
 
   @impl Application
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     # We don't start this as a worker because if the debugger crashes, we want
     # this process to remain alive to print errors
     ElixirLS.Debugger.Output.start(ElixirLS.Debugger.Output)
 
     children = [
-      worker(ElixirLS.Debugger.Server, [[name: ElixirLS.Debugger.Server]])
+      {ElixirLS.Debugger.Server, name: ElixirLS.Debugger.Server}
     ]
 
     opts = [strategy: :one_for_one, name: ElixirLS.Debugger.Supervisor, max_restarts: 0]

--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -6,12 +6,10 @@ defmodule ElixirLS.LanguageServer do
 
   @impl Application
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
-      worker(ElixirLS.LanguageServer.Server, [ElixirLS.LanguageServer.Server]),
-      worker(ElixirLS.LanguageServer.JsonRpc, [[name: ElixirLS.LanguageServer.JsonRpc]]),
-      worker(ElixirLS.LanguageServer.Providers.WorkspaceSymbols, [[]])
+      {ElixirLS.LanguageServer.Server, ElixirLS.LanguageServer.Server},
+      {ElixirLS.LanguageServer.JsonRpc, name: ElixirLS.LanguageServer.JsonRpc},
+      {ElixirLS.LanguageServer.Providers.WorkspaceSymbols, []}
     ]
 
     opts = [strategy: :one_for_one, name: ElixirLS.LanguageServer.Supervisor, max_restarts: 0]


### PR DESCRIPTION
These will be hard-deprecated in 1.11