### PR TITLE
Change workspace symbols to only look at modules in the current application

### DIFF
--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -461,7 +461,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
     Enum.each(app_names, &Application.load/1)
 
     app_names
-    |> Enum.map(fn app_name ->
+    |> Enum.flat_map(fn app_name ->
       Application.spec(app_name, :modules)
       |> Enum.flat_map(fn app_module ->
         case find_module_path(app_module) do
@@ -476,7 +476,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
     if Mix.Project.umbrella?() do
       Mix.Project.apps_paths() |> Map.keys()
     else
-      Keyword.fetch!(Mix.Project.config(), :app)
+      [Keyword.fetch!(Mix.Project.config(), :app)]
     end
   end
 

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -56,74 +56,91 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
               }
-            ]} = WorkspaceSymbols.symbols("ElixirLS.LanguageServer.Fixtures.", @server_name)
+            ]} =
+             WorkspaceSymbols.symbols(
+               "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols",
+               @server_name
+             )
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
-    assert {:ok,
-            [
-              %{
-                kind: 2,
-                location: %{
-                  range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}},
-                  uri: uri
-                },
-                name: "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
-              }
-            ]} = WorkspaceSymbols.symbols("work", @server_name)
+    assert {:ok, results} = WorkspaceSymbols.symbols("work", @server_name)
+
+    assert %{
+             kind: 2,
+             location: %{
+               range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}},
+               uri: uri
+             },
+             name: "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
+           } = matches(results, "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols")
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end
 
   test "returns functions" do
-    assert {
-             :ok,
-             [
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}},
-                   uri: uri
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/1"
-               },
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/0"
-               },
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.behaviour_info/1"
-               },
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 3}, start: %{character: 0, line: 2}}
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macro/1"
-               },
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 2}, start: %{character: 0, line: 1}}
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_function/1"
-               },
-               %{
-                 kind: 12,
-                 location: %{
-                   range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
-                 },
-                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.__info__/1"
-               }
-             ]
-           } = WorkspaceSymbols.symbols("f ElixirLS.LanguageServer.Fixtures.", @server_name)
+    query = "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
+    assert {:ok, results} = WorkspaceSymbols.symbols(query, @server_name)
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}},
+               uri: uri
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/1"
+           } =
+             matches(results, "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/1")
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/0"
+           } =
+             matches(results, "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.module_info/0")
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.behaviour_info/1"
+           } =
+             matches(
+               results,
+               "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.behaviour_info/1"
+             )
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 3}, start: %{character: 0, line: 2}}
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macro/1"
+           } =
+             matches(results, "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macro/1")
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 2}, start: %{character: 0, line: 1}}
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_function/1"
+           } =
+             matches(
+               results,
+               "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_function/1"
+             )
+
+    assert %{
+             kind: 12,
+             location: %{
+               range: %{end: %{character: 0, line: 1}, start: %{character: 0, line: 0}}
+             },
+             name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.__info__/1"
+           } = matches(results, "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.__info__/1")
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -137,7 +154,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_function/1"
               }
-            ]} = WorkspaceSymbols.symbols("f fun", @server_name)
+            ]} = WorkspaceSymbols.symbols("f some_fun", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end
@@ -162,7 +179,11 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "t ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_opaque_type/0"
                }
              ]
-           } = WorkspaceSymbols.symbols("t ElixirLS.LanguageServer.Fixtures.", @server_name)
+           } =
+             WorkspaceSymbols.symbols(
+               "t ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.",
+               @server_name
+             )
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -203,7 +224,11 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "c ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macrocallback/1"
                }
              ]
-           } = WorkspaceSymbols.symbols("c ElixirLS.LanguageServer.Fixtures.", @server_name)
+           } =
+             WorkspaceSymbols.symbols(
+               "c ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.",
+               @server_name
+             )
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -229,5 +254,15 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
       Process.sleep(500)
       wait_until_indexed(pid)
     end
+  end
+
+  defp matches(results, name) do
+    assert [matching_result] =
+             Enum.filter(
+               results,
+               &(&1.name == name)
+             )
+
+    matching_result
   end
 end


### PR DESCRIPTION
This improves speed considerably since many more modules are not processed. If the old behavior is preferred by some users we could investigate making it configurable.

However, I think that this behavior is in line with LSP expectation:
> The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string.

from:
https://microsoft.github.io/language-server-protocol/specification#workspace_symbol

@lukaszsamson I'm curious if you have any strong feelings on this. Personally I haven't been using the workspace symbols request because I want to look only at symbols in my project and right now it is too noisy.