### PR TITLE
Only call DocumentSymbols.symbols/3 for .ex and .exs files

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -418,7 +418,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
       source_file = state.source_files[uri]
 
-      if source_file do
+      if source_file && String.ends_with?(uri, [".ex", ".exs"]) do
         DocumentSymbols.symbols(uri, source_file.text, hierarchical?)
       else
         {:ok, []}


### PR DESCRIPTION
This PR fixes the following problem:

If the user has the outline panel enabled and opens a `.eex` or `.leex` file, the call to `DocumentSymbols.symbols/3` fails since those files are not valid Elixir syntax.

Message:

```
[Error - 9:14:39 PM] Request textDocument/documentSymbol failed.
  Message: [DocumentSymbols] Compilation error while parsing source file
  Code: -32000 
```

