### PR TITLE
WorkspaceSymbols index after successful build

### DIFF
--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -53,36 +53,36 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
   ## Client API
 
   @spec symbols(String.t()) :: {:ok, [symbol_information_t]}
-  def symbols(query) do
+  def symbols(query, server \\ __MODULE__) do
     results =
       case query do
         "f " <> fun_query ->
-          query(:functions, fun_query)
+          query(:functions, fun_query, server)
 
         "t " <> type_query ->
-          query(:types, type_query)
+          query(:types, type_query, server)
 
         "c " <> callback_query ->
-          query(:callbacks, callback_query)
+          query(:callbacks, callback_query, server)
 
         module_query ->
-          query(:modules, module_query)
+          query(:modules, module_query, server)
       end
 
     {:ok, results}
   end
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, :ok, opts |> Keyword.put(:name, __MODULE__))
+    GenServer.start_link(__MODULE__, :ok, opts |> Keyword.put_new(:name, __MODULE__))
   end
 
-  def notify_build_complete do
-    GenServer.cast(__MODULE__, :build_complete)
+  def notify_build_complete(server \\ __MODULE__) do
+    GenServer.cast(server, :build_complete)
   end
 
   @spec notify_uris_modified([String.t()]) :: :ok
-  def notify_uris_modified(uris) do
-    GenServer.cast(__MODULE__, {:uris_modified, uris})
+  def notify_uris_modified(uris, server \\ __MODULE__) do
+    GenServer.cast(server, {:uris_modified, uris})
   end
 
   ## Server Callbacks
@@ -351,13 +351,13 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
     |> elem(0)
   end
 
-  defp query(kind, query) do
+  defp query(kind, query, server) do
     case String.trim(query) do
       "" ->
         []
 
       trimmed ->
-        GenServer.call(__MODULE__, {:query, kind, trimmed})
+        GenServer.call(server, {:query, kind, trimmed})
     end
   end
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -183,6 +183,10 @@ defmodule ElixirLS.LanguageServer.Server do
         _ -> handle_build_result(:error, [Build.exception_to_diagnostic(reason)], state)
       end
 
+    if reason == :normal do
+      WorkspaceSymbols.notify_build_complete()
+    end
+
     state = if state.needs_build?, do: trigger_build(state), else: state
     {:noreply, state}
   end
@@ -668,8 +672,6 @@ defmodule ElixirLS.LanguageServer.Server do
 
         GenServer.reply(from, contracts)
       end
-
-      WorkspaceSymbols.notify_build_complete()
 
       %{state | analysis_ready?: true, awaiting_contracts: dirty}
     else

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -1,13 +1,11 @@
 defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
 
+  @server_name WorkspaceSymbolsTestServer
+
   setup_all do
-    pid =
-      case WorkspaceSymbols.start_link([]) do
-        {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> pid
-      end
+    {:ok, pid} = WorkspaceSymbols.start_link(name: @server_name)
 
     state = :sys.get_state(pid)
 
@@ -27,19 +25,15 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
       }
     end)
 
-    WorkspaceSymbols.notify_build_complete()
+    WorkspaceSymbols.notify_build_complete(@server_name)
 
     wait_until_indexed(pid)
-
-    on_exit(fn ->
-      :sys.replace_state(pid, fn _ -> state end)
-    end)
 
     {:ok, %{}}
   end
 
   test "empty query" do
-    assert {:ok, []} == WorkspaceSymbols.symbols("")
+    assert {:ok, []} == WorkspaceSymbols.symbols("", @server_name)
   end
 
   test "returns modules" do
@@ -53,7 +47,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
               }
-            ]} = WorkspaceSymbols.symbols("ElixirLS.LanguageServer.Fixtures.")
+            ]} = WorkspaceSymbols.symbols("ElixirLS.LanguageServer.Fixtures.", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -67,7 +61,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols"
               }
-            ]} = WorkspaceSymbols.symbols("work")
+            ]} = WorkspaceSymbols.symbols("work", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end
@@ -120,7 +114,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.__info__/1"
                }
              ]
-           } = WorkspaceSymbols.symbols("f ElixirLS.LanguageServer.Fixtures.")
+           } = WorkspaceSymbols.symbols("f ElixirLS.LanguageServer.Fixtures.", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -134,7 +128,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "f ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_function/1"
               }
-            ]} = WorkspaceSymbols.symbols("f fun")
+            ]} = WorkspaceSymbols.symbols("f fun", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end
@@ -159,7 +153,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "t ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_opaque_type/0"
                }
              ]
-           } = WorkspaceSymbols.symbols("t ElixirLS.LanguageServer.Fixtures.")
+           } = WorkspaceSymbols.symbols("t ElixirLS.LanguageServer.Fixtures.", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -175,7 +169,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "t ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_opaque_type/0"
                }
              ]
-           } = WorkspaceSymbols.symbols("t opa")
+           } = WorkspaceSymbols.symbols("t opa", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end
@@ -200,7 +194,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                  name: "c ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macrocallback/1"
                }
              ]
-           } = WorkspaceSymbols.symbols("c ElixirLS.LanguageServer.Fixtures.")
+           } = WorkspaceSymbols.symbols("c ElixirLS.LanguageServer.Fixtures.", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
 
@@ -214,7 +208,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
                 },
                 name: "c ElixirLS.LanguageServer.Fixtures.WorkspaceSymbols.some_macrocallback/1"
               }
-            ]} = WorkspaceSymbols.symbols("c macr")
+            ]} = WorkspaceSymbols.symbols("c macr", @server_name)
 
     assert uri |> String.ends_with?("test/support/fixtures/workspace_symbols.ex")
   end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -267,14 +267,13 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                        "uri" => ^error_file,
                        "diagnostics" => [
                          %{
-                           "message" =>
-                             "(CompileError) undefined function does_not_exist" <>
-                               _,
+                           "message" => "(CompileError) undefined function does_not_exist" <> _,
                            "range" => %{"end" => %{"line" => 3}, "start" => %{"line" => 3}},
                            "severity" => 1
                          }
                        ]
-                     })
+                     }),
+                     300
     end)
   end
 
@@ -288,14 +287,13 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                        "uri" => ^error_file,
                        "diagnostics" => [
                          %{
-                           "message" =>
-                             "(SyntaxError) syntax error before: ','" <>
-                               _,
+                           "message" => "(SyntaxError) syntax error before: ','" <> _,
                            "range" => %{"end" => %{"line" => 1}, "start" => %{"line" => 1}},
                            "severity" => 1
                          }
                        ]
-                     })
+                     }),
+                     300
     end)
   end
 

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -273,7 +273,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                          }
                        ]
                      }),
-                     300
+                     1000
     end)
   end
 
@@ -293,7 +293,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                          }
                        ]
                      }),
-                     300
+                     1000
     end)
   end
 


### PR DESCRIPTION
Previously WorkspaceSymbols depended on a side-effect of running Dialyzer:
https://github.com/elixir-lsp/elixir-ls/pull/110#discussion_r376827177

Now that the Build step loads all modules (added in #227) we need to change the WorkspaceSymbols index to be rebuilt after a successful compile.