### PR TITLE
Properly handle callback suggestion

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -444,13 +444,13 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
 
   defp def_snippet(def_str, name, args, arity, opts) do
     if Keyword.get(opts, :snippets_supported, false) do
-      "#{def_str}#{function_snippet(name, args, arity)} do\n\t$0\nend"
+      "#{def_str}#{function_snippet(name, args, arity, opts)} do\n\t$0\nend"
     else
       "#{def_str}#{name}"
     end
   end
 
-  defp function_snippet(name, args, arity, opts \\ []) do
+  defp function_snippet(name, args, arity, opts) do
     cond do
       Keyword.get(opts, :capture_before?) && arity <= 1 ->
         Enum.join([name, "/", arity])

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -281,6 +281,13 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       insert_text = def_snippet(def_str, name, args, arity, options)
       label = "#{def_str}#{function_label(name, args, arity)}"
 
+      filter_text =
+        if def_str do
+          "#{def_str}#{name}"
+        else
+          name
+        end
+
       %__MODULE__{
         label: label,
         kind: :interface,
@@ -288,7 +295,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         documentation: summary,
         insert_text: insert_text,
         priority: 2,
-        filter_text: name,
+        filter_text: filter_text,
         tags: metadata_to_tags(metadata)
       }
     end

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -141,7 +141,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
   test "provides completions for callbacks without `def` before" do
     text = """
     defmodule MyModule do
-      use GenServer
+      @behaviour ElixirLS.LanguageServer.Fixtures.ExampleBehaviour
 
     # ^
     end
@@ -156,16 +156,15 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       |> Enum.filter(&(&1["detail"] =~ "callback"))
       |> Enum.at(0)
 
-    assert first_completion["label"] =~ "def code_change"
+    assert first_completion["label"] =~ "def build_greeting"
 
-    assert first_completion["insertText"] ==
-             "def code_change(${1:old_vsn}, ${2:state}, ${3:extra}) do\n\t$0\nend"
+    assert first_completion["insertText"] == "def build_greeting(${1:name}) do\n\t$0\nend"
   end
 
   test "provides completions for callbacks with `def` before" do
     text = """
     defmodule MyModule do
-      use GenServer
+      @behaviour ElixirLS.LanguageServer.Fixtures.ExampleBehaviour
 
       def
        # ^
@@ -181,7 +180,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       |> Enum.filter(&(&1["detail"] =~ "callback"))
       |> Enum.at(0)
 
-    assert first_completion["label"] =~ "def code_change"
+    assert first_completion["label"] =~ "def build_greeting"
   end
 
   test "returns module completions after pipe" do

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -265,7 +265,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                            "severity" => 1
                          }
                        ]
-                     })
+                     }),
+                     300
     end)
   end
 
@@ -286,7 +287,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                            "severity" => 1
                          }
                        ]
-                     })
+                     }),
+                     300
     end)
   end
 

--- a/apps/language_server/test/support/fixtures/example_behaviour.ex
+++ b/apps/language_server/test/support/fixtures/example_behaviour.ex
@@ -1,0 +1,4 @@
+defmodule ElixirLS.LanguageServer.Fixtures.ExampleBehaviour do
+  @callback greet_world() :: nil
+  @callback build_greeting(name :: String.t()) :: String.t()
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "6395dd568e542a8b05a2d3dee61f02142564f30d", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "648a501c42c16a610cb67c29f0beb0c087171849", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},


### PR DESCRIPTION
Properly handle callback suggestions (with or without `def/defmacro` before the cursor). 

Requires https://github.com/elixir-lsp/elixir_sense/pull/99, otherwise, suggestions will not appear after typing `"d"`, `"de"` or `"def"`.