### PR TITLE
Cleanup test's output

### DIFF
--- a/apps/debugger/mix.exs
+++ b/apps/debugger/mix.exs
@@ -6,7 +6,7 @@ defmodule ElixirLS.Debugger.Mixfile do
       app: :debugger,
       version: "0.4.0",
       build_path: "../../_build",
-      config_path: "config/config.exs",
+      config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: ">= 1.7.0",

--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -5,9 +5,22 @@ defmodule ElixirLS.Utils.WireProtocol do
   alias ElixirLS.Utils.{PacketStream, OutputDevice}
 
   def send(packet) do
-    pid = Process.whereis(:raw_user) || Process.group_leader()
+    pid = io_dest()
     body = JasonVendored.encode!(packet) <> "\r\n\r\n"
     IO.binwrite(pid, "Content-Length: #{byte_size(body)}\r\n\r\n" <> body)
+  end
+
+  case Mix.env() do
+    :test ->
+      defp io_dest do
+        Process.whereis(:raw_user) || Process.whereis(:elixir_ls_test_process) ||
+          Process.group_leader()
+      end
+
+    _ ->
+      defp io_dest do
+        Process.whereis(:raw_user) || Process.group_leader()
+      end
   end
 
   def io_intercepted? do

--- a/apps/language_server/lib/language_server/json_rpc.ex
+++ b/apps/language_server/lib/language_server/json_rpc.ex
@@ -6,8 +6,8 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
   responses and notifications
   """
 
-  import ElixirLS.Utils.WireProtocol, only: [{:send, 1}]
   use GenServer
+  alias ElixirLS.Utils.WireProtocol
 
   defstruct language_server: ElixirLS.LanguageServer.Server,
             next_id: 1,
@@ -67,16 +67,16 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
   ## Utils
 
   def notify(method, params) do
-    send(notification(method, params))
+    WireProtocol.send(notification(method, params))
   end
 
   def respond(id, result) do
-    send(response(id, result))
+    WireProtocol.send(response(id, result))
   end
 
   def respond_with_error(id, type, message) do
     {code, default_message} = error_code_and_message(type)
-    send(error_response(id, code, message || default_message))
+    WireProtocol.send(error_response(id, code, message || default_message))
   end
 
   def show_message(type, message) do
@@ -175,7 +175,7 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
 
   @impl GenServer
   def handle_call({:request, method, params}, from, state) do
-    send(request(state.next_id, method, params))
+    WireProtocol.send(request(state.next_id, method, params))
     state = update_in(state.outgoing_requests, &Map.put(&1, state.next_id, from))
     state = %__MODULE__{state | next_id: state.next_id + 1}
     {:noreply, state}

--- a/apps/language_server/lib/language_server/providers/definition.ex
+++ b/apps/language_server/lib/language_server/providers/definition.ex
@@ -21,8 +21,6 @@ defmodule ElixirLS.LanguageServer.Providers.Definition do
             _ -> SourceFile.path_to_uri(file)
           end
 
-        ElixirLS.LanguageServer.JsonRpc.log_message(:info, "Returning location struct")
-
         {:ok,
          %Protocol.Location{
            uri: uri,

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -282,7 +282,8 @@ defmodule ElixirLS.LanguageServer.Server do
         # The source file was not marked as open either due to a bug in the
         # client or a restart of the server. So just ignore the message and do
         # not update the state
-        IO.warn(
+        JsonRpc.log_message(
+          :warning,
           "Received textDocument/didChange for file that is not open. Received uri: #{
             inspect(uri)
           }"

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -7,7 +7,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       version: "0.4.0",
       elixir: ">= 1.7.0",
       build_path: "../../_build",
-      config_path: "config/config.exs",
+      config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -15,9 +15,7 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
   end
 
   setup do
-    {:ok, server} = Server.start_link()
-    {:ok, packet_capture} = PacketCapture.start_link(self())
-    Process.group_leader(server, packet_capture)
+    server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
 
     {:ok, %{server: server}}
   end

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -2,7 +2,6 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
   # TODO: Test loading and saving manifest
 
   alias ElixirLS.LanguageServer.{Dialyzer, Server, Protocol, SourceFile}
-  alias ElixirLS.Utils.PacketCapture
   import ExUnit.CaptureLog
   use ElixirLS.Utils.MixTest.Case, async: false
   use Protocol

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -1,8 +1,12 @@
 defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
 
-  setup_all do
+  setup do
+    alias ElixirLS.Utils.PacketCapture
+    packet_capture = start_supervised!({PacketCapture, self()})
+    Process.register(packet_capture, :elixir_ls_test_process)
+
     pid =
       case WorkspaceSymbols.start_link([]) do
         {:ok, pid} -> pid
@@ -40,6 +44,11 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
 
   test "empty query" do
     assert {:ok, []} == WorkspaceSymbols.symbols("")
+
+    assert_receive %{
+      "method" => "window/logMessage",
+      "params" => %{"message" => "[ElixirLS WorkspaceSymbols] Updating index..."}
+    }
   end
 
   test "returns modules" do

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -22,9 +22,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
 
   setup context do
     unless context[:skip_server] do
-      server = start_supervised!({Server, nil})
-      packet_capture = start_supervised!({PacketCapture, self()})
-      Process.group_leader(server, packet_capture)
+      server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
+
       {:ok, %{server: server}}
     else
       :ok
@@ -47,7 +46,17 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     ]
 
     version = 2
+
     Server.receive_packet(server, did_change(uri, version, content_changes))
+
+    assert_receive %{
+      "method" => "window/logMessage",
+      "params" => %{
+        "message" =>
+          "Received textDocument/didChange for file that is not open. Received uri: \"file:///file.ex\"",
+        "type" => 2
+      }
+    }
 
     # Wait for the server to process the message and ensure that there is no exception
     _ = :sys.get_state(server)

--- a/apps/language_server/test/support/server_test_helpers.ex
+++ b/apps/language_server/test/support/server_test_helpers.ex
@@ -1,0 +1,16 @@
+defmodule ElixirLS.LanguageServer.Test.ServerTestHelpers do
+  import ExUnit.Callbacks, only: [start_supervised!: 1]
+  alias ElixirLS.LanguageServer.Server
+  alias ElixirLS.Utils.PacketCapture
+
+  def start_server do
+    server = start_supervised!({Server, nil})
+    packet_capture = start_supervised!({PacketCapture, self()})
+    Process.group_leader(server, packet_capture)
+
+    Process.whereis(ElixirLS.LanguageServer.Providers.WorkspaceSymbols)
+    |> Process.group_leader(packet_capture)
+
+    server
+  end
+end


### PR DESCRIPTION
If a process is registered as :elixir_ls_test_process, JsonRPC will send output to that process instead of cluttering  up the test output.

Don't import WireProtocol.send/1 because it is easily confused with Kernel.send

Switch an IO.warn to a JsonRpc warning

Send WorkspaceSymbols messages through PacketCapture for the dialyzer test

Fix config_path for debugger and language_server (note: this is not otherwise used, but is better for consistency)