### PR TITLE
Fix dialyzer test when running locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,3 +11,9 @@ Push the tag
 - `cd release`
 - `zip elixir-ls.zip *`
 - Attach elixir-ls.zip to the release on github https://github.com/elixir-lsp/elixir-ls/releases
+
+# Debugging
+
+If you're debugging a running server than `IO.inspect` is a good approach, any messages you create with it will be sent to your LSP client as a log message
+
+To debug in tests you can use `IO.inspect(Process.whereis(:user), message, label: "message")` to send your output directly to the group leader of the test process.

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -71,6 +71,7 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
         end
         """
 
+        :lib.flush_receive()
         b_uri = SourceFile.path_to_uri("lib/b.ex")
         Server.receive_packet(server, did_open(b_uri, "elixir", 1, b_text))
         File.write!("lib/b.ex", b_text)

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -71,7 +71,6 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
         end
         """
 
-        :lib.flush_receive()
         b_uri = SourceFile.path_to_uri("lib/b.ex")
         Server.receive_packet(server, did_open(b_uri, "elixir", 1, b_text))
         File.write!("lib/b.ex", b_text)

--- a/apps/language_server/test/fixtures/dialyzer/lib/c.ex
+++ b/apps/language_server/test/fixtures/dialyzer/lib/c.ex
@@ -1,2 +1,5 @@
 defmodule C do
+  def myfun do
+    1
+  end
 end


### PR DESCRIPTION
I'm testing running locally on arch linux. It appear that for me locally for the "reports diagnostics then clears them once problems are fixed" test I get the output I get the message:

    [ElixirLS Dialyzer] Analyzing 3 modules: [A, B, :erlang]

Instead of:

    [ElixirLS Dialyzer] Analyzing 2 modules: [A, B]

Adding a function definition in module C causes :erlang to not be detected as needing to be analyzed.