### PR TITLE
Improve autocomplete and signature help

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -289,7 +289,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
           end
         end
 
-      insert_text = def_snippet(def_str, name, args, arity, options)
+      opts = Keyword.put(options, :with_parens?, true)
+      insert_text = def_snippet(def_str, name, args, arity, opts)
       label = "#{def_str}#{function_label(name, args, arity)}"
 
       filter_text =

--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -47,7 +47,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
     formatted =
       try do
         target_line_length =
-          Mix.Tasks.Format.formatter_opts_for_file(SourceFile.path_from_uri(uri))
+          uri
+          |> SourceFile.formatter_opts()
           |> Keyword.get(:line_length, 98)
 
         target_line_length = target_line_length - String.length(indentation)

--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -8,8 +8,7 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
 
   def format(source_file, uri, project_dir) do
     if can_format?(uri, project_dir) do
-      file = SourceFile.path_from_uri(uri) |> Path.relative_to(project_dir)
-      opts = formatter_opts(file)
+      opts = SourceFile.formatter_opts(uri)
       formatted = IO.iodata_to_binary([Code.format_string!(source_file.text, opts), ?\n])
 
       response =
@@ -39,10 +38,6 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
 
     not String.starts_with?(file_path, project_dir) or
       String.starts_with?(Path.absname(file_path), cwd)
-  end
-
-  defp formatter_opts(for_file) do
-    Mix.Tasks.Format.formatter_opts_for_file(for_file)
   end
 
   defp myers_diff_to_text_edits(myers_diff, starting_pos \\ {0, 0}) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -471,11 +471,23 @@ defmodule ElixirLS.LanguageServer.Server do
         %{"valueSet" => value_set} -> value_set
       end
 
+    signature_help_supported =
+      !!get_in(state.client_capabilities, ["textDocument", "signatureHelp"])
+
+    locals_without_parens =
+      uri
+      |> SourceFile.path_from_uri()
+      |> Mix.Tasks.Format.formatter_opts_for_file()
+      |> Keyword.get(:locals_without_parens, [])
+      |> MapSet.new()
+
     fun = fn ->
       Completion.completion(state.source_files[uri].text, line, character,
         snippets_supported: snippets_supported,
         deprecated_supported: deprecated_supported,
-        tags_supported: tags_supported
+        tags_supported: tags_supported,
+        signature_help_supported: signature_help_supported,
+        locals_without_parens: locals_without_parens
       )
     end
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -476,8 +476,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
     locals_without_parens =
       uri
-      |> SourceFile.path_from_uri()
-      |> Mix.Tasks.Format.formatter_opts_for_file()
+      |> SourceFile.formatter_opts()
       |> Keyword.get(:locals_without_parens, [])
       |> MapSet.new()
 

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -239,13 +239,33 @@ defmodule ElixirLS.LanguageServer.ServerTest do
              "activeSignature" => 0,
              "signatures" => [
                %{
-                 "documentation" => "@spec inspect(item, keyword) :: item when item: var\n" <> _,
+                 "documentation" => %{
+                   "kind" => "markdown",
+                   "value" => """
+                   Inspects and writes the given `item` to the device.
+
+                   ```
+                   @spec inspect(item, keyword) :: item
+                   when item: var
+                   ```
+                   """
+                 },
                  "label" => "inspect(item, opts \\\\ [])",
                  "parameters" => [%{"label" => "item"}, %{"label" => "opts \\\\ []"}]
                },
                %{
-                 "documentation" =>
-                   "@spec inspect(device, item, keyword) :: item when item: var\n" <> _,
+                 "documentation" => %{
+                   "kind" => "markdown",
+                   "value" => """
+                   Inspects `item` according to the given options using the IO `device`.
+
+                   ```
+                   @spec inspect(device, item, keyword) ::
+                     item
+                   when item: var
+                   ```
+                   """
+                 },
                  "label" => "inspect(device, item, opts)",
                  "parameters" => [
                    %{"label" => "device"},
@@ -254,7 +274,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                  ]
                }
              ]
-           }) = resp
+           }) == resp
   end
 
   test "reports build diagnostics", %{server: server} do

--- a/apps/language_server/test/source_file_test.exs
+++ b/apps/language_server/test/source_file_test.exs
@@ -1,0 +1,38 @@
+defmodule ElixirLS.LanguageServer.SourceFileTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirLS.LanguageServer.SourceFile
+
+  test "format_spec/2 with nil" do
+    assert SourceFile.format_spec(nil, []) == ""
+  end
+
+  test "format_spec/2 with empty string" do
+    assert SourceFile.format_spec("", []) == ""
+  end
+
+  test "format_spec/2 with a plain string" do
+    spec = "@spec format_spec(String.t(), keyword()) :: String.t()"
+
+    assert SourceFile.format_spec(spec, line_length: 80) == """
+
+           ```
+           @spec format_spec(String.t(), keyword()) :: String.t()
+           ```
+           """
+  end
+
+  test "format_spec/2 with a spec that needs to be broken over lines" do
+    spec = "@spec format_spec(String.t(), keyword()) :: String.t()"
+
+    assert SourceFile.format_spec(spec, line_length: 30) == """
+
+           ```
+           @spec format_spec(
+             String.t(),
+             keyword()
+           ) :: String.t()
+           ```
+           """
+  end
+end

--- a/apps/language_server/test/support/fixtures/example_docs.ex
+++ b/apps/language_server/test/support/fixtures/example_docs.ex
@@ -1,0 +1,11 @@
+defmodule ElixirLS.LanguageServer.Fixtures.ExampleDocs do
+  @doc """
+  The summary
+
+  Ths rest
+  """
+  @spec add(a_big_name :: integer, b_big_name :: integer) :: integer
+  def add(a, b) do
+    a + b
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "648a501c42c16a610cb67c29f0beb0c087171849", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "dbe8299e224945d23749123b9997792ea543f0bb", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},


### PR DESCRIPTION
This PR addresses the improvements suggested in https://github.com/elixir-lsp/elixir-ls/issues/251.

## Changes

### Signature help

  * Property format markdown documentation and specs

### Autocomplete/suggestions

  * Show function/arity in the list instead of the signature (the signature will be in the detail panel)
  * Show local function's visibility (private/public) + type (function/macro) on top of the detail panel so it can appear on the right side of the list when the panel is hidden.
  * Show remote function's origin (module) + type (function/macro) on top of the detail panel so it can appear on the right side of the list when the panel is hidden.
  * Show function signature on top of the detail panel instead of the spec (much more readable)
  * Show formatted doc summary + spec in the detail panel
  * Autocomplete triggers the signature help instead of injecting the arguments (only if signature help is supported) - This is the most important change in my opinion.
  * Don't add the closing parenthesis to the snippet if the cursor is immediately before a valid argument (this usually happens when we want to wrap an existing variable or literal, e.g. using `IO.inspect`)
  * Read formatter's `:locals_without_parens ` configuration so we know when to add parenthesis or not when autocompleting functions/macros (fix the annoying issue of having to delete the parens when using popular lib DSLs like `Ecto`)
  * Do not inject optional arguments when autocompleting.

### Screenshots

List without noise and formatted markdown documentation and spec:

![image](https://user-images.githubusercontent.com/457237/83332934-67d2dd80-a274-11ea-86bc-b9b94e7edca9.png)

Local functions:

![image](https://user-images.githubusercontent.com/457237/83332969-9a7cd600-a274-11ea-8226-ae2376197d46.png)

Remote functions:

![image](https://user-images.githubusercontent.com/457237/83332972-a49ed480-a274-11ea-9568-f6f2145805e6.png)

Trigger signature help on autocomplete (no more manually deleting arguments)

![image](https://user-images.githubusercontent.com/457237/83333048-052e1180-a275-11ea-9373-57d191de655e.png)





