### PR TITLE
fixed crash when using git time-machine in emacs

### DIFF
--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -124,9 +124,12 @@ defmodule ElixirLS.LanguageServer.SourceFile do
         end
       end)
 
-    # Remove extraneous newline from last line
-    [[last_line, ?\n] | rest] = acc
-    acc = [last_line | rest]
+    acc = case acc do
+      # Remove extraneous newline from last line
+      [[last_line, ?\n] | rest] ->
+        [last_line | rest]
+      _ -> []
+    end
 
     IO.iodata_to_binary(Enum.reverse(acc))
   end


### PR DESCRIPTION
When using git time machine in Spacemacs (https://github.com/emacsmirror/git-timemachine), the elixir ls crashes on changing to a previous version of a file.
```
15:50:18.705 [error] GenServer ElixirLS.LanguageServer.Server terminating
** (MatchError) no match of right hand side value: ["", ""]
    (language_server 0.4.0) lib/language_server/source_file.ex:128: ElixirLS.LanguageServer.SourceFile.apply_edit/3
    (elixir 1.10.2) lib/map.ex:798: Map.update!/3
    (language_server 0.4.0) lib/language_server/source_file.ex:22: ElixirLS.LanguageServer.SourceFile.apply_content_changes/2
    (language_server 0.4.0) lib/language_server/server.ex:284: anonymous fn/4 in ElixirLS.LanguageServer.Server.handle_notification/2
    (elixir 1.10.2) lib/map.ex:837: Map.get_and_update/3
    (elixir 1.10.2) lib/map.ex:878: Map.get_and_update!/3
    (language_server 0.4.0) lib/language_server/server.ex:284: ElixirLS.LanguageServer.Server.handle_notification/2
    (language_server 0.4.0) lib/language_server/server.ex:134: ElixirLS.LanguageServer.Server.handle_cast/2
Last message: {:"$gen_cast", {:receive_packet, %{"jsonrpc" => "2.0", "method" => "textDocument/didChange", "params" => %{"contentChanges" => [%{"range" => %{"end" => %{"character" => 0, "line" => 3}, "start" => %{"character" => 0, "line" => 0}}, "rangeLength" => 50, "text" => ""}], "textDocument" => %{"uri" => "file:///Users/gseddon/git/elixir-ls/apps/language_server/lib/test_module.ex", "version" => 1}}}}}
```
This PR handles this edge case better. Honestly I haven't dug through the code enough to find out what assumption is being invalidated by this time-machine behaviour, so am open to feedback on how better to implement this fix.