### PR TITLE
Fix undesirable "No documentation available" hover hints

### DIFF
--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -42,7 +42,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
     end)
   end
 
-  defp contents(%{docs: "No documentation available"}) do
+  defp contents(%{docs: "No documentation available\n"}) do
     []
   end
 


### PR DESCRIPTION
Returning `[]` as originally intended.

Broken since https://github.com/elixir-lsp/elixir_sense/commit/efb42a7e1570b3d73d4fb1de0225171258f8fd36.