### PR TITLE
Add `@moduledoc false` and `@doc false` as snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 - Display the version of Elixir used to compile ELixirLS (thanks [Jason Axelson](https://github.com/axelson)) [#264](https://github.com/elixir-lsp/elixir-ls/pull/264)
 - Support completion of callback function definitions (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#265](https://github.com/elixir-lsp/elixir-ls/pull/265)
 - Give more direct warnings when mix.exs cannot be found (thanks [Jason Axelson](https://github.com/axelson)) [#297](https://github.com/elixir-lsp/elixir-ls/pull/297)
+- Add completions for `@moduledoc false` and `@doc false` (thanks [Jason Axelson](https://github.com/axelson)) [#288](https://github.com/elixir-lsp/elixir-ls/pull/288)
 
 Changes:
 - Major improvement/change: Improve autocomplete and signature help (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#273](https://github.com/elixir-lsp/elixir-ls/pull/273)

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -749,5 +749,48 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                """
              }
     end
+
+    test "moduledoc completion" do
+      text = """
+      defmodule MyModule do
+        @mod
+        #   ^
+      end
+      """
+
+      {line, char} = {1, 6}
+
+      TestUtils.assert_has_cursor_char(text, line, char)
+
+      assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
+      labels = Enum.map(items, & &1["label"])
+
+      assert labels == [
+               ~s(@moduledoc """"""),
+               "@moduledoc",
+               "@moduledoc false"
+             ]
+    end
+
+    test "doc completion" do
+      text = """
+      defmodule MyModule do
+        @do
+        #  ^
+        end
+      """
+
+      {line, char} = {1, 5}
+
+      TestUtils.assert_has_cursor_char(text, line, char)
+
+      assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
+      labels = Enum.map(items, & &1["label"])
+
+      assert labels == [
+               ~s(@doc """"""),
+               "@doc false"
+             ]
+    end
   end
 end


### PR DESCRIPTION
I fairly often use `@moduledoc false` and `@doc false` but previously there was no autocompletion for them.

Add `@moduledoc false` with a "lower" priority
Add `""""""` to the snippet name to indicate that the snippet will insert a heredoc

Before:

![screenshot-elixir-ls-moduledoc-before](https://user-images.githubusercontent.com/9973/83951850-5176d580-a7d0-11ea-89be-80daeef1c2e0.png)

After:

![screenshot-elixir-ls-moduledoc-after](https://user-images.githubusercontent.com/9973/83951830-1b395600-a7d0-11ea-8065-aff36caafa6a.png)
