### PR TITLE
Further improve the tests

### DIFF
--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -10,17 +10,8 @@ defmodule ElixirLS.Utils.WireProtocol do
     IO.binwrite(pid, "Content-Length: #{byte_size(body)}\r\n\r\n" <> body)
   end
 
-  case Mix.env() do
-    :test ->
-      defp io_dest do
-        Process.whereis(:raw_user) || Process.whereis(:elixir_ls_test_process) ||
-          Process.group_leader()
-      end
-
-    _ ->
-      defp io_dest do
-        Process.whereis(:raw_user) || Process.group_leader()
-      end
+  defp io_dest do
+    Process.whereis(:raw_user) || Process.group_leader()
   end
 
   def io_intercepted? do

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -166,7 +166,7 @@ defmodule ElixirLS.LanguageServer.Build do
     end
   end
 
-  defp load_all_modules do
+  def load_all_modules do
     apps =
       cond do
         Mix.Project.umbrella?() ->

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -10,6 +10,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: false,
       start_permanent: true,
@@ -30,6 +31,12 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:forms, "~> 0.0.1"},
       {:erl2ex, github: "dazuma/erl2ex"},
       {:dialyxir, "~> 1.0.0", runtime: false}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --no-start"
     ]
   end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -19,6 +19,18 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
     "command" => "editor.action.triggerParameterHints"
   }
 
+  setup context do
+    ElixirLS.LanguageServer.Build.load_all_modules()
+
+    unless context[:skip_server] do
+      server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
+
+      {:ok, %{server: server}}
+    else
+      :ok
+    end
+  end
+
   test "returns all Logger completions on normal require" do
     text = """
     defmodule MyModule do

--- a/apps/language_server/test/support/server_test_helpers.ex
+++ b/apps/language_server/test/support/server_test_helpers.ex
@@ -1,15 +1,22 @@
 defmodule ElixirLS.LanguageServer.Test.ServerTestHelpers do
   import ExUnit.Callbacks, only: [start_supervised!: 1]
+
   alias ElixirLS.LanguageServer.Server
+  alias ElixirLS.LanguageServer.JsonRpc
+  alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
   alias ElixirLS.Utils.PacketCapture
 
   def start_server do
-    server = start_supervised!({Server, nil})
     packet_capture = start_supervised!({PacketCapture, self()})
+
+    server = start_supervised!({Server, nil})
     Process.group_leader(server, packet_capture)
 
-    Process.whereis(ElixirLS.LanguageServer.Providers.WorkspaceSymbols)
-    |> Process.group_leader(packet_capture)
+    json_rpc = start_supervised!({JsonRpc, name: JsonRpc})
+    Process.group_leader(json_rpc, packet_capture)
+
+    workspace_symbols = start_supervised!({WorkspaceSymbols, []})
+    Process.group_leader(workspace_symbols, packet_capture)
 
     server
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule ElixirLS.Mixfile do
   def project do
     [
       apps_path: "apps",
+      aliases: aliases(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       build_per_environment: false,
@@ -26,5 +27,11 @@ defmodule ElixirLS.Mixfile do
   # and cannot be accessed from applications inside the apps folder
   defp deps do
     []
+  end
+
+  defp aliases do
+    [
+      test: "cmd mix test"
+    ]
   end
 end


### PR DESCRIPTION
The previous `:elixir_ls_test_process` approach was not reliable and seemed to suffer from a race condition. Instead always manually start the server so we can be in full control of the processes.

Unfortunately aliases are not well supported in umbrella projects so use `cmd mix test` as specified in:

https://elixirforum.com/t/mix-task-aliases-and-umbrellas/12666