### PR TITLE
Fix crash in document symbols privider

### DIFF
--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -219,9 +219,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   end
 
   # ExUnit describe
-  defp extract_symbol(current_module, {:describe, location, [name | ast]}) do
-    [[do: module_body]] = ast
-
+  defp extract_symbol(current_module, {:describe, location, [name | [[do: module_body]]]}) do
     mod_defns =
       case module_body do
         {:__block__, [], mod_defns} -> mod_defns


### PR DESCRIPTION
When editing a test file I noticed
```
    ** (MatchError) no match of right hand side value: []
        (language_server 0.4.0) lib/language_server/providers/document_symbols.ex:223: ElixirLS.LanguageServer.Providers.DocumentSymbols.extract_symbol/2
        (elixir 1.10.3) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
        (elixir 1.10.3) lib/enum.ex:1396: Enum."-map/2-lists^map/1-0-"/2
        (language_server 0.4.0) lib/language_server/providers/document_symbols.ex:93: ElixirLS.LanguageServer.Providers.DocumentSymbols.extract_symbol/2
        (language_server 0.4.0) lib/language_server/providers/document_symbols.ex:59: ElixirLS.LanguageServer.Providers.DocumentSymbols.extract_modules/1
        (language_server 0.4.0) lib/language_server/providers/document_symbols.ex:47: ElixirLS.LanguageServer.Providers.DocumentSymbols.list_symbols/1
        (language_server 0.4.0) lib/language_server/providers/document_symbols.ex:24: ElixirLS.LanguageServer.Providers.DocumentSymbols.symbols/3
        (language_server 0.4.0) lib/language_server/server.ex:554: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2
```
With this PR the pattern match is on the function level and a fallback branch is matched.