### PR TITLE
Do not crash debugger on on supported command

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/output.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/output.ex
@@ -21,6 +21,10 @@ defmodule ElixirLS.Debugger.Output do
     GenServer.call(server, {:send_response, request_packet, response_body})
   end
 
+  def send_error_response(server \\ __MODULE__, request_packet, message, format, variables) do
+    GenServer.call(server, {:send_error_response, request_packet, message, format, variables})
+  end
+
   def send_event(server \\ __MODULE__, event, body) do
     GenServer.call(server, {:send_event, event, body})
   end
@@ -46,7 +50,21 @@ defmodule ElixirLS.Debugger.Output do
     {:reply, :ok, seq + 1}
   end
 
-  @impl GenServer
+  def handle_call({:send_error_response, request_packet, message, format, variables}, _from, seq) do
+    send(
+      error_response(
+        seq,
+        request_packet["seq"],
+        request_packet["command"],
+        message,
+        format,
+        variables
+      )
+    )
+
+    {:reply, :ok, seq + 1}
+  end
+
   def handle_call({:send_event, event, body}, _from, seq) do
     send(event(seq, event, body))
     {:reply, :ok, seq + 1}

--- a/apps/elixir_ls_debugger/lib/debugger/output.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/output.ex
@@ -13,7 +13,7 @@ defmodule ElixirLS.Debugger.Output do
 
   ## Client API
 
-  def start(name \\ nil) do
+  def start(name \\ __MODULE__) do
     GenServer.start(__MODULE__, :ok, name: name)
   end
 

--- a/apps/elixir_ls_debugger/lib/debugger/protocol.basic.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/protocol.basic.ex
@@ -36,6 +36,26 @@ defmodule ElixirLS.Debugger.Protocol.Basic do
     end
   end
 
+  defmacro error_response(seq, request_seq, command, message, format, variables) do
+    quote do
+      %{
+        "type" => "response",
+        "command" => unquote(command),
+        "seq" => unquote(seq),
+        "request_seq" => unquote(request_seq),
+        "success" => false,
+        "message" => unquote(message),
+        "body" => %{
+          "error" => %{
+            "id" => unquote(seq),
+            "format" => unquote(format),
+            "variables" => unquote(variables)
+          }
+        }
+      }
+    end
+  end
+
   defmacro event(seq, event, body) do
     quote do
       %{

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -88,6 +88,7 @@ defmodule ElixirLS.Debugger.Server do
     {:noreply, state}
   end
 
+  # the `:DOWN` message is not delivered under normal conditions as the process calls `Process.sleep(:infinity)`
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{task_ref: ref} = state) do
     exit_code =

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -298,7 +298,7 @@ defmodule ElixirLS.Debugger.Server do
     pid = state.threads[thread_id]
     state = remove_paused_process(state, pid)
 
-    :int.continue(pid)
+    :ok = :int.continue(pid)
     {%{"allThreadsContinued" => false}, state}
   end
 
@@ -544,7 +544,7 @@ defmodule ElixirLS.Debugger.Server do
     |> Enum.filter(&interpretable?(&1, exclude_modules))
     |> Enum.map(fn mod ->
       try do
-        :int.ni(mod)
+        {:module, _} = :int.ni(mod)
       catch
         _, _ ->
           IO.warn(
@@ -623,8 +623,8 @@ defmodule ElixirLS.Debugger.Server do
 
   defp save_and_reload(module, beam_bin) do
     :ok = File.write(Path.join(@temp_beam_dir, to_string(module) <> ".beam"), beam_bin)
-    :code.delete(module)
-    :int.ni(module)
+    true = :code.delete(module)
+    {:module, _} = :int.ni(module)
   end
 
   defp set_breakpoints(path, lines) do
@@ -654,7 +654,7 @@ defmodule ElixirLS.Debugger.Server do
   defp set_breakpoint(module, line) do
     case :int.ni(module) do
       {:module, _} ->
-        :int.break(module, line)
+        :ok = :int.break(module, line)
         {:ok, module, line}
 
       _ ->

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -111,11 +111,6 @@ defmodule ElixirLS.Debugger.Server do
     {:noreply, %{state | task_ref: nil}}
   end
 
-  @impl GenServer
-  def handle_info({:EXIT, _, :normal}, state) do
-    {:noreply, state}
-  end
-
   # If we get the disconnect request from the client, we send :disconnect to the server so it will
   # die right after responding to the request
   @impl GenServer

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -58,7 +58,6 @@ defmodule ElixirLS.Debugger.Server do
 
   @impl GenServer
   def init(opts) do
-    {:ok, _pid} = :int.start()
     state = if opts[:output], do: %__MODULE__{output: opts[:output]}, else: %__MODULE__{}
     {:ok, state}
   end

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -125,6 +125,17 @@ defmodule ElixirLS.Debugger.ServerTest do
 
       Server.receive_packet(server, continue_req(10, thread_id))
       assert_receive response(_, 10, "continue", %{"allThreadsContinued" => false})
+
+      Server.receive_packet(server, request(11, "someRequest", %{"threadId" => 123}))
+
+      assert_receive error_response(
+                       _,
+                       11,
+                       "someRequest",
+                       "notSupported",
+                       "Debugger request {command} is currently not supported",
+                       %{"command" => "someRequest"}
+                     )
     end)
   end
 

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -26,8 +26,6 @@ defmodule ElixirLS.Debugger.ServerTest do
     {:ok, %{server: server}}
   end
 
-  # Causes test suite not to finish
-  @tag :pending
   test "basic debugging", %{server: server} do
     in_fixture(__DIR__, "mix_project", fn ->
       Server.receive_packet(server, initialize_req(1, %{}))
@@ -130,8 +128,6 @@ defmodule ElixirLS.Debugger.ServerTest do
     end)
   end
 
-  # Causes test suite not to finish
-  @tag :pending
   test "sets breakpoints in erlang modules", %{server: server} do
     in_fixture(__DIR__, "mix_project", fn ->
       Server.receive_packet(server, initialize_req(1, %{}))

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -127,9 +127,6 @@ defmodule ElixirLS.Debugger.ServerTest do
 
       Server.receive_packet(server, continue_req(10, thread_id))
       assert_receive response(_, 10, "continue", %{"allThreadsContinued" => false})
-
-      assert_receive(event(_, "exited", %{"exitCode" => 0}))
-      assert_receive(event(_, "terminated", %{"restart" => false}))
     end)
   end
 


### PR DESCRIPTION
Without this PR the debugger crashes e.g. on `pause` command
```
(Debugger) Terminating because an exception was raised:
    ** (FunctionClauseError) no function clause matching in ElixirLS.Debugger.Server.handle_request/2
        (elixir_ls_debugger 0.4.0) lib/debugger/server.ex:126: ElixirLS.Debugger.Server.handle_request(%{"arguments" => %{"threadId" => 42}, "command" => "pause", "seq" => 5, "type" => "request"}, %ElixirLS.Debugger.Server{breakpoints: %{}, client_info: %{"adapterID" => "mix_task", "clientID" => "vscode", "clientName" => "Visual Studio Code", "columnsStartAt1" => true, "linesStartAt1" => true, "locale" => "en-gb", "pathFormat" => "path", "supportsProgressReporting" => true, "supportsRunInTerminalRequest" => true, "supportsVariablePaging" => true, "supportsVariableType" => true}, config: %{"__sessionId" => "8cfb813f-e401-41c8-9598-1d45ad7dc211", "name" => "mix (Default task)", "projectDir" => "/Users/lukaszsamson/telemetry_metrics_zabbix", "request" => "launch", "type" => "mix_task"}, next_id: 123, output: ElixirLS.Debugger.Output, paused_processes: %{}, task_ref: #Reference<0.1836231909.743964673.91684>, threads: %{105 => #PID<0.470.0>, 48 => #PID<0.102.0>, 62 => #PID<0.134.0>, 11 => #PID<0.42.0>, 39 => #PID<0.82.0>, 83 => #PID<0.157.0>, 63 => #PID<0.135.0>, 34 => #PID<0.69.0>, 68 => #PID<0.140.0>, 26 => #PID<0.61.0>, 78 => #PID<0.151.0>, 52 => #PID<0.113.0>, 15 => #PID<0.49.0>, 64 => #PID<0.136.0>, 75 => #PID<0.148.0>, 81 => #PID<0.154.0>, 71 => #PID<0.143.0>, 20 => #PID<0.55.0>, 109 => #PID<0.489.0>, 50 => #PID<0.111.0>, 17 => #PID<0.52.0>, 111 => #PID<0.491.0>, 25 => #PID<0.60.0>, 122 => #PID<0.504.0>, 65 => #PID<0.137.0>, 98 => #PID<0.458.0>, 79 => #PID<0.152.0>, 13 => #PID<0.46.0>, 44 => #PID<0.98.0>, 8 => #PID<0.7.0>, 99 => #PID<0.459.0>, 36 => #PID<0.79.0>, 67 => #PID<0.139.0>, 7 => #PID<0.6.0>, 66 => #PID<0.138.0>, 85 => #PID<0.159.0>, 76 => #PID<0.149.0>, 1 => #PID<0.0.0>, 32 => #PID<0.67.0>, 69 => #PID<0.141.0>, 37 => #PID<0.80.0>, 35 => #PID<0.70.0>, ...}, threads_inverse: %{#PID<0.157.0> => 83, #PID<0.133.0> => 61, #PID<0.52.0> => 17, #PID<0.55.0> => 20, #PID<0.66.0> => 31, #PID<0.142.0> => 70, #PID<0.446.0> => 92, #PID<0.137.0> => 65, #PID<0.161.0> => 86, #PID<0.130.0> => 58, #PID<0.53.0> => 18, #PID<0.154.0> => 81, #PID<0.6.0> => 7, #PID<0.95.0> => 42, #PID<0.447.0> => 93, #PID<0.128.0> => 57, #PID<0.68.0> => 33, #PID<0.490.0> => 110, #PID<0.134.0> => 62, #PID<0.54.0> => 19, #PID<0.148.0> => 75, #PID<0.145.0> => 73, #PID<0.501.0> => 119, #PID<0.491.0> => 111, #PID<0.163.0> => 88, #PID<0.488.0> => 108, #PID<0.460.0> => 100, #PID<0.69.0> => 34, #PID<0.138.0> => 66, #PID<0.141.0> => 69, #PID<0.494.0> => 113, #PID<0.131.0> => 59, #PID<0.5.0> => 6, #PID<0.493.0> => 112, #PID<0.150.0> => 77, #PID<0.165.0> => 90, #PID<0.495.0> => 114, #PID<0.96.0> => 43, #PID<0.114.0> => 53, #PID<0.2.0> => 3, #PID<0.3.0> => 4, ...}})
        (elixir_ls_debugger 0.4.0) lib/debugger/server.ex:64: ElixirLS.Debugger.Server.handle_cast/2
        (stdlib 3.13) gen_server.erl:680: :gen_server.try_dispatch/4
        (stdlib 3.13) gen_server.erl:756: :gen_server.handle_msg/6
        (stdlib 3.13) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```
Unfortunately it looks like there is no way to implement `pause`. At least the `:int` module does not provide such function (There is `:sys.suspend/1,2` but I'm not sure if it is compatible with `:int`). There is also no no capability that can inform debugger client that `pause` is not supported.

This PR also:
- Adds debugger protocol error response
- Remove some dead code
- Adds some asserts
- Reenable debugger tests