### PR TITLE
Directly warn user when mixfile is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 - Support WorkspaceSymbols (go to symbol in workspace) without dialyzer being enabled (thanks [Jason Axelson](https://github.com/axelson)) [#263](https://github.com/elixir-lsp/elixir-ls/pull/263)
 - Display the version of Elixir used to compile ELixirLS (thanks [Jason Axelson](https://github.com/axelson)) [#264](https://github.com/elixir-lsp/elixir-ls/pull/264)
 - Support completion of callback function definitions (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#265](https://github.com/elixir-lsp/elixir-ls/pull/265)
+- Give more direct warnings when mix.exs cannot be found (thanks [Jason Axelson](https://github.com/axelson)) [#297](https://github.com/elixir-lsp/elixir-ls/pull/297)
 
 Changes:
 - Major improvement/change: Improve autocomplete and signature help (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#273](https://github.com/elixir-lsp/elixir-ls/pull/273)

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -162,6 +162,9 @@ defmodule ElixirLS.LanguageServer.Build do
         "No mixfile found in project. " <>
           "To use a subdirectory, set `elixirLS.projectDir` in your settings"
 
+      JsonRpc.log_message(:error, msg <> ". Looked for mixfile at #{inspect(mixfile)}")
+      JsonRpc.show_message(:error, msg)
+
       {:error, [mixfile_diagnostic({Path.absname(mixfile), nil, msg}, :error)]}
     end
   end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -317,7 +317,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     end)
   end
 
-  test "reports error if no mixfile", %{server: server} do
+  test "reports errors if no mixfile", %{server: server} do
     in_fixture(__DIR__, "no_mixfile", fn ->
       mixfile_uri = SourceFile.path_to_uri("mix.exs")
 
@@ -333,6 +333,14 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                        ]
                      }),
                      5000
+
+      assert_receive notification("window/logMessage", %{
+                       "message" => "No mixfile found in project." <> _
+                     })
+
+      assert_receive notification("window/showMessage", %{
+                       "message" => "No mixfile found in project." <> _
+                     })
     end)
   end
 


### PR DESCRIPTION
Without all three types of warnings it can be easy to miss this error, especially if the file that you have open is not mix.exs