### PR TITLE
Do not advertise workspaceFolder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes:
 - Formatting was returning invalid floating point number (thanks [Thanabodee Charoenpiriyakij](https://github.com/wingyplus)) [#250](https://github.com/elixir-lsp/elixir-ls/pull/250)
 - Fix detection of empty hover hints (thanks [Dmitry Gutov](https://github.com/dgutov)) [#279](https://github.com/elixir-lsp/elixir-ls/pull/279)
 - Debugger doesn't fail when modules cannot be interpretted (thanks [Łukasz Samson](https://github.com/lukaszsamson)) (such as nifs) [#283](https://github.com/elixir-lsp/elixir-ls/pull/283)
+- Do not advertise `workspaceFolders` support (thanks [Jason Axelson](https://github.com/axelson)) [#298](https://github.com/elixir-lsp/elixir-ls/pull/298)
 
 House keeping:
 - Server runs with a unique id (and uses it to disambiguate commands) (thanks [Alessandro Tagliapietra](https://github.com/alex88)) [#278](https://github.com/elixir-lsp/elixir-ls/pull/278)

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -586,7 +586,7 @@ defmodule ElixirLS.LanguageServer.Server do
       "codeLensProvider" => %{"resolveProvider" => false},
       "executeCommandProvider" => %{"commands" => ["spec:#{server_instance_id}"]},
       "workspace" => %{
-        "workspaceFolders" => %{"supported" => true, "changeNotifications" => true}
+        "workspaceFolders" => %{"supported" => false, "changeNotifications" => false}
       }
     }
   end


### PR DESCRIPTION
In https://github.com/elixir-lsp/elixir-ls/issues/295 the user received a warning:

> Received unmatched notification: %{"jsonrpc" => "2.0", "method" =>
  "workspace/didChangeWorkspaceFolders"

This occurs because the server advertises that it supports workspace folders:
https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders

This was introduced in https://github.com/elixir-lsp/elixir-ls/pull/35 which was actually about didChangeWatchedFiles and not workspace folders.

Fixes #296