### PR TITLE
Support setting MIX_TARGET

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -10,7 +10,15 @@ defmodule ElixirLS.LanguageServer.Build do
         with_build_lock(fn ->
           {us, _} =
             :timer.tc(fn ->
-              IO.puts("Compiling with Mix env #{Mix.env()}")
+              IO.puts("MIX_ENV: #{Mix.env()}")
+
+              if function_exported?(Mix, :target, 0) do
+                # Even though we know we have the function here,
+                # Compilation will fail calling Mix.target/0 directly
+                # since Elixir 1.7 is used to compile - So we get around
+                # that with apply/3
+                IO.puts("MIX_TARGET: #{apply(Mix, :target, [])}")
+              end
 
               prev_deps = cached_deps()
               :ok = Mix.Project.clear_deps_cache()


### PR DESCRIPTION
Resolves https://github.com/elixir-lsp/elixir-ls/issues/248

This allows you to set MIX_TARGET in a config and have it used in Elixir versions >= 1.8

This is most often used with Nerves and removes a lot of compilation errors in repos relying on a target to be set

I used this little [target_test](https://github.com/jjcarstens/target_test) to test and everything seemed to work as expected (built for the target and errors/warnings went away 🙌 )

