### PR TITLE
Ajust suggestions/autocomplete for multiple clients/scenarios

### DIFF
--- a/apps/language_server/test/support/fixtures/example_default_args.ex
+++ b/apps/language_server/test/support/fixtures/example_default_args.ex
@@ -1,0 +1,9 @@
+defmodule ElixirLS.LanguageServer.Fixtures.ExampleDefaultArgs do
+  def my_func(text, opts1 \\ [], opts2 \\ []) do
+    IO.inspect({text, opts1, opts2})
+  end
+
+  def func_with_1_arg(text \\ "hi") do
+    IO.inspect(text)
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "dbe8299e224945d23749123b9997792ea543f0bb", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "68dd83576af3ed67c1bc4536ff1673247496f01a", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},


### PR DESCRIPTION
This PR addresses some of the problems related to **suggestions/autocomplete** I could find when working/simulating the UX in different editors.

## Context

This resumes the of the work done in https://github.com/elixir-lsp/elixir-ls/pull/273 and also addresses https://github.com/elixir-lsp/elixir-ls/issues/281.

Making everything work nicely for every situation turned out to be much more complicated than I expected. The reason is that we have many variables to take into account, for instance:  

  * is the function configured to have parenthesis? (according to the .formatter)
  * is signature supported?
  * is snippet supported?
  * is there a capture before?
  * is there a pipe before?
  * is there any text after? what kind of text?
  * does the function has any argument? if so, is there any default argument?
  * are there other functions with the same name but different arity?
  
Any different answer to any of the questions above can lead to a different behaviour in any of the following features:

  * List of suggestions
    - which functions with the same name should be excluded?
  * Signature hint
    - when to show?
    - at what argument?
  * Auto-completion/snippets (different rules may apply to different functions in the same list)
    * Insert just the name
    * Insert name + arity
    * Insert name + arguments (with or without parenthesis)
    * Insert name + arguments (with or without parenthesis), removing unused default arguments

## Examples

Regarding https://github.com/elixir-lsp/elixir-ls/issues/281. The `detail` now looks pretty much like the `TypeScript` (and other languages) version, which was presented by @lukaszsamson in this [comment](https://github.com/elixir-lsp/elixir-ls/pull/273#issuecomment-636628197).

![image](https://user-images.githubusercontent.com/457237/84948904-c3012e80-b0c2-11ea-910b-6aeeddc60a0e.png)

With the `details` box hidden:

![image](https://user-images.githubusercontent.com/457237/84952131-e4184e00-b0c7-11ea-9e82-df2691e0137d.png)

Functions with default arguments, which generates multiple functions, might be listed differently depending on the context. For instance, if signature support is enabled, only the original function is listed since all the other derived function also have the same docs, spec and snippet:

![image](https://user-images.githubusercontent.com/457237/84949416-913c9780-b0c3-11ea-8e0d-a345e554ba09.png)

After confirmation:

![image](https://user-images.githubusercontent.com/457237/84949810-30fa2580-b0c4-11ea-8833-90ad11dc3fd8.png)

However, there are situations where we want the list all functions. Here a couple of examples:

### If you have a `capture` prefix

It will list all derived functions since each of them will have a different snippet:

![image](https://user-images.githubusercontent.com/457237/84949675-f85a4c00-b0c3-11ea-86c4-5832366c305c.png)

After confirmation:

![image](https://user-images.githubusercontent.com/457237/84949907-60a92d80-b0c4-11ea-9a47-71aa68baa0d4.png)

### Functions configured to not include parenthesis or when using editors without signature support

![image](https://user-images.githubusercontent.com/457237/84951018-2b054400-b0c6-11ea-83c4-6ac60955bf8c.png)

In this case, the arguments added will correspond to the arity selected.

Selecting `add/2`:

![image](https://user-images.githubusercontent.com/457237/84951399-c1396a00-b0c6-11ea-9a90-1ae349184619.png)

Selecting `add/3`:

![image](https://user-images.githubusercontent.com/457237/84951277-94855280-b0c6-11ea-89d0-2513afcc5674.png)

---

There are many other rules implemented for many of the other cases I mentioned. Feel free to give it try and please let me know if you find any issue or have any question.

It's going to be really hard to have a solution that can please everyone. The intention is to improve UX for most users without compromising usability for the others.



