### PR TITLE
Honor :inputs option in .formatter.exs

### DIFF
--- a/apps/language_server/test/providers/formatting_test.exs
+++ b/apps/language_server/test/providers/formatting_test.exs
@@ -180,4 +180,19 @@ defmodule ElixirLS.LanguageServer.Providers.FormattingTest do
              }
            ]
   end
+
+  test "honors :inputs when deciding to format" do
+    file = __ENV__.file
+    uri = "file://" <> file
+    project_dir = Path.dirname(file)
+
+    opts = []
+    assert Formatting.should_format?(uri, project_dir, opts[:inputs])
+
+    opts = [inputs: ["*.exs"]]
+    assert Formatting.should_format?(uri, project_dir, opts[:inputs])
+
+    opts = [inputs: ["*.ex"]]
+    refute Formatting.should_format?(uri, project_dir, opts[:inputs])
+  end
 end


### PR DESCRIPTION
`mix format` reads the `:inputs` option in `.formatter.exs` to include files.

This pull request makes ElixirLS check the same `:inputs` option to decide if a file should be formatted.

Fixes https://github.com/elixir-lsp/vscode-elixir-ls/issues/120.