### PR TITLE
Add +swbt none to remove busy-wait and improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Potentially breaking changes:
 
 Improvements:
 - Use ElixirSense's error tolerant parser for document symbols (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#322](https://github.com/elixir-lsp/elixir-ls/pull/322)
+- Disable busy-wait in BEAM to reduce CPU usage (thanks [Jason Axelson](https://github.com/axelson)) [#331](https://github.com/elixir-lsp/elixir-ls/pull/331)
 
 House keeping:
 - Fix the link in the README to releases (thanks [RJ Dellecese](https://github.com/rjdellecese)) [#312](https://github.com/elixir-lsp/elixir-ls/pull/312)

--- a/apps/elixir_ls_utils/priv/debugger.bat
+++ b/apps/elixir_ls_utils/priv/debugger.bat
@@ -1,4 +1,4 @@
 @echo off & setlocal enabledelayedexpansion
 
 SET ERL_LIBS=%~dp0;%ERL_LIBS%
-elixir -e "ElixirLS.Debugger.CLI.main()"
+elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none" -e "ElixirLS.Debugger.CLI.main()"

--- a/apps/elixir_ls_utils/priv/language_server.bat
+++ b/apps/elixir_ls_utils/priv/language_server.bat
@@ -1,4 +1,4 @@
 @echo off & setlocal enabledelayedexpansion
 
 SET ERL_LIBS=%~dp0;%ERL_LIBS%
-elixir -e "ElixirLS.LanguageServer.CLI.main()"
+elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none" -e "ElixirLS.LanguageServer.CLI.main()"

--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -63,4 +63,4 @@ SCRIPT=$(readlink_f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 export ERL_LIBS="$SCRIPTPATH:$ERL_LIBS"
 
-exec elixir -e "$ELS_SCRIPT"
+exec elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none"  -e "$ELS_SCRIPT"


### PR DESCRIPTION
Utilizing busy-wait to reduce latency primarily makes sense for applications that are running as the only node on the machine. So it doesn't make sense for ElixirLS because there will usually be other processes running on the machine such as the editor and potentially other ElixirLS instances.

A blog post that touches on `+swbt none`:
https://www.ably.io/blog/beam-optimization-mqtt/

Also add sbwtdcpu and sbwtdio

Fixes #328