### PR TITLE
Add generic completion item

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -489,13 +489,16 @@ defmodule ElixirLS.LanguageServer.Server do
       end
       |> MapSet.new()
 
+    signature_after_complete = Map.get(state.settings || %{}, "signatureAfterComplete", true)
+
     fun = fn ->
       Completion.completion(state.source_files[uri].text, line, character,
         snippets_supported: snippets_supported,
         deprecated_supported: deprecated_supported,
         tags_supported: tags_supported,
         signature_help_supported: signature_help_supported,
-        locals_without_parens: locals_without_parens
+        locals_without_parens: locals_without_parens,
+        signature_after_complete: signature_after_complete
       )
     end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -749,7 +749,9 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                """
              }
     end
+  end
 
+  describe "generic suggestions" do
     test "moduledoc completion" do
       text = """
       defmodule MyModule do
@@ -762,7 +764,9 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
 
       TestUtils.assert_has_cursor_char(text, line, char)
 
-      assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
+      assert {:ok, %{"items" => [first | _] = items}} =
+               Completion.completion(text, line, char, @supports)
+
       labels = Enum.map(items, & &1["label"])
 
       assert labels == [
@@ -770,27 +774,17 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                "@moduledoc",
                "@moduledoc false"
              ]
-    end
 
-    test "doc completion" do
-      text = """
-      defmodule MyModule do
-        @do
-        #  ^
-        end
-      """
-
-      {line, char} = {1, 5}
-
-      TestUtils.assert_has_cursor_char(text, line, char)
-
-      assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
-      labels = Enum.map(items, & &1["label"])
-
-      assert labels == [
-               ~s(@doc """"""),
-               "@doc false"
-             ]
+      assert first == %{
+               "detail" => "module attribute snippet",
+               "documentation" => %{:kind => "markdown", "value" => "Documents a module"},
+               "filterText" => "moduledoc",
+               "insertText" => ~s(moduledoc """\n$0\n"""),
+               "insertTextFormat" => 2,
+               "kind" => 15,
+               "label" => ~s(@moduledoc """"""),
+               "sortText" => "00000000"
+             }
     end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "44f7b309268c491d5316aa5797f02c30b7e308ef", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "36484b2b5fd25278086fd3e88f84565011a616fc", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},


### PR DESCRIPTION
Related to https://github.com/elixir-lsp/elixir_sense/issues/104 and https://github.com/elixir-lsp/elixir_sense/pull/105

  * Handle new `:generic` completion type from `ElixirSense`. Required by the `Ecto` and `doc snippets` plugins.
  * Add missing icons/kinds
  * Increase all `:priority` values of all non-generic types (allows ElixirSense to define suggestions with higher priorities, if needed)
  * Remove `doc snippets` (they are now provided by ElixirSense)
  * Use `signatureAfterComplete` setting