### PR TITLE
Re-organize installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,54 +26,6 @@ The original repository has now been deprecated in favor of this one. Any IDE ex
 
 Note: On first run Dialyzer will build a PLT cache which will take a considerable amount of CPU time (usually 10+ minutes). After that is complete the CPU usage will go back to normal. Alternatively instead of waiting you can disable Dialyzer in the settings.
 
-## Installation
-
-How you install ElixirLS depends on your editor.
-
-For VSCode install the extension: https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls
-
-### Emacs
-
-Download the latest release:
-https://github.com/elixir-lsp/elixir-ls/releases/latest and unzip it into a
-directory (this is the directory referred to as the
-`"path-to-elixir-ls/release"` below)
-
-If using `lsp-mode` add this configuration:
-```elisp
-  (use-package lsp-mode
-    :commands lsp
-    :ensure t
-    :diminish lsp-mode
-    :hook
-    (elixir-mode . lsp)
-    :init
-    (add-to-list 'exec-path "path-to-elixir-ls/release"))
-```
-
-For eglot use:
-```elisp
-(require 'eglot)
-
-;; This is optional. It automatically runs `M-x eglot` for you whenever you are in `elixir-mode`
-(add-hook 'elixir-mode-hook 'eglot-ensure)
-
-;; Make sure to edit the path appropriately, use the .bat script instead for Windows
-(add-to-list 'eglot-server-programs '(elixir-mode "path-to-elixir-ls/release/language_server.sh"))
-```
-
-## Supported versions
-
-Elixir:
-
-- 1.7.0 minimum
-
-Erlang:
-
-- OTP 20 minimum
-
-You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.
-
 ## IDE plugins
 
 | IDE          | Plugin                                                                        | Support                                        |
@@ -88,6 +40,56 @@ You may want to install Elixir and Erlang from source, using the [kiex](https://
 | Sublime Text | [LSP-elixir](https://github.com/sublimelsp/LSP-elixir)                        | Does not support debugger                      |
 
 Feel free to create and publish your own client packages and add them to this list!
+
+## Detailed Installation Instructions
+
+How you install ElixirLS depends on your editor.
+
+For VSCode install the extension: https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls
+
+<details>
+  <summary>Emacs Installation Instructions</summary>
+
+  Download the latest release:
+  https://github.com/elixir-lsp/elixir-ls/releases/latest and unzip it into a
+  directory (this is the directory referred to as the
+  `"path-to-elixir-ls/release"` below)
+
+  If using `lsp-mode` add this configuration:
+  ```elisp
+    (use-package lsp-mode
+      :commands lsp
+      :ensure t
+      :diminish lsp-mode
+      :hook
+      (elixir-mode . lsp)
+      :init
+      (add-to-list 'exec-path "path-to-elixir-ls/release"))
+  ```
+
+  For eglot use:
+  ```elisp
+  (require 'eglot)
+
+  ;; This is optional. It automatically runs `M-x eglot` for you whenever you are in `elixir-mode`
+  (add-hook 'elixir-mode-hook 'eglot-ensure)
+
+  ;; Make sure to edit the path appropriately, use the .bat script instead for Windows
+  (add-to-list 'eglot-server-programs '(elixir-mode "path-to-elixir-ls/release/language_server.sh"))
+  ```
+</details>
+
+## Supported versions
+
+Elixir:
+
+- 1.7.0 minimum
+
+Erlang:
+
+- OTP 20 minimum
+
+You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.
 
 ## Debugger support
 


### PR DESCRIPTION
Move the list of plugins higher and use GFM spoiler tags for the detailed emacs
installation instructions.