### PR TITLE
Drop OTP 20 and add version support guidance

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,5 +6,5 @@
 #
 # The versions selected here are the versions that are used to build a binary
 # release for distribution
-elixir 1.7.4-otp-20
-erlang 20.3.8.23
+elixir 1.7.4-otp-21
+erlang 21.3.8.17

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 matrix:
   include:
     - otp_release: 21.3
-      elixir: 1.7.4
+      elixir: 1.8.2
     - otp_release: 22.3
       elixir: 1.9.4
     - otp_release: 23.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,8 @@ cache:
   - _build
 matrix:
   include:
-    - otp_release: 20.3
-      elixir: 1.7.4
     - otp_release: 21.3
-      elixir: 1.8.2
+      elixir: 1.7.4
     - otp_release: 22.3
       elixir: 1.9.4
     - otp_release: 23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Potentially breaking changes:
 - Do not format files that are not listed in `inputs` of `.formatter.exs` (thanks [Tan Jay Jun](https://github.com/jayjun)) [#315](https://github.com/elixir-lsp/elixir-ls/pull/315)
-- Drop OTP 20 support and set some version support guidelines (thanks [Jason Axelson](https://github.com/axelson)) [PR #337](https://github.com/elixir-lsp/elixir-ls/pull/337)
+- Drop OTP 20 and Elixir 1.7.x support and set some version support guidelines (thanks [Jason Axelson](https://github.com/axelson)) [PR #337](https://github.com/elixir-lsp/elixir-ls/pull/337)
 
 Improvements:
 - Add Ecto completion plugin from ElixirSense (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#333](https://github.com/elixir-lsp/elixir-ls/pull/333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Potentially breaking changes:
 - Do not format files that are not listed in `inputs` of `.formatter.exs` (thanks [Tan Jay Jun](https://github.com/jayjun)) [#315](https://github.com/elixir-lsp/elixir-ls/pull/315)
-- Drop OTP 20 support and set some version support guidelines (thanks [Jason Axelson](https://github.com/axelson)) (PR #?)
+- Drop OTP 20 support and set some version support guidelines (thanks [Jason Axelson](https://github.com/axelson)) [PR #337](https://github.com/elixir-lsp/elixir-ls/pull/337)
 
 Improvements:
 - Add Ecto completion plugin from ElixirSense (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#333](https://github.com/elixir-lsp/elixir-ls/pull/333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Potentially breaking changes:
 - Do not format files that are not listed in `inputs` of `.formatter.exs` (thanks [Tan Jay Jun](https://github.com/jayjun)) [#315](https://github.com/elixir-lsp/elixir-ls/pull/315)
+- Drop OTP 20 support and set some version support guidelines (thanks [Jason Axelson](https://github.com/axelson)) (PR #?)
 
 Improvements:
 - Add Ecto completion plugin from ElixirSense (thanks [Marlus Saraiva](https://github.com/msaraiva)) [#333](https://github.com/elixir-lsp/elixir-ls/pull/333)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ https://hexdocs.pm/elixir/compatibility-and-deprecations.html#content
 OTP Supports the last 3 versions:
 http://erlang.2086793.n4.nabble.com/OTP-Versions-and-Maint-Branches-td4722416.html
 
-ElixirLS supports the last 4 versions of Elixir and the last 3 versions of OTP. However this is not a hard and fast rule and may change in the future.
+ElixirLS generally aims to support the last 3 versions of Elixir and the last 3 versions of OTP. However this is not a hard and fast rule and may change in the future.
 
 # Packaging
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,13 @@
+# Version Support Guidelines
+
+Elixir itself supports 5 versions with security updates:
+https://hexdocs.pm/elixir/compatibility-and-deprecations.html#content
+
+OTP Supports the last 3 versions:
+http://erlang.2086793.n4.nabble.com/OTP-Versions-and-Maint-Branches-td4722416.html
+
+ElixirLS supports the last 4 versions of Elixir and the last 3 versions of OTP. However this is not a hard and fast rule and may change in the future.
+
 # Packaging
 
 Bump the changelog

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Elixir:
 
 Erlang:
 
-- OTP 20 minimum
+- OTP 21 minimum
 
 You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For VSCode install the extension: https://marketplace.visualstudio.com/items?ite
 
 Elixir:
 
-- 1.7.0 minimum
+- 1.8.0 minimum
 
 Erlang:
 


### PR DESCRIPTION
Drop OTP 20 because it is generally no longer supported by the OTP team.

Fixes #336 