### PR TITLE
WIP: Configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Configuration file location and precedence:
 
 ### Configuration File Contents
 
-The configuration file can include comments (e.g. lines starting with `//` are ignored)
+The configuration files are json but can include line-based comments (e.g. lines starting with `//` are ignored, although multi-line comments `/**/` are not supported)
 
 Configuration keys:
 - `dialyzerEnabled`: Run ElixirLS's rapid Dialyzer when code is saved

--- a/README.md
+++ b/README.md
@@ -91,6 +91,73 @@ Erlang:
 
 You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.
 
+## Configuration
+
+ElixirLS can be configured through configuration/settings files
+
+Configuration file location and precedence:
+
+- $XDG_CONFIG_HOME/elixir_ls/config.json (e.g. `~/.config/elixir_ls/config.json`)
+- repo/.elixir_ls_config.json
+  - Or should this be the projectDir/.elixir_ls_config.json (which is a little tricky because the project directory can be set in `workspace/didChangeConfiguration`)
+  - I think this should be added in the future
+- Editor config (e.g. `workspace/didChangeConfiguration`)
+  - Note: Mainly supported via vscode-elixir-ls
+
+### Configuration File Contents
+
+The configuration file can include comments (e.g. lines starting with `//` are ignored)
+
+Configuration keys:
+- `dialyzerEnabled`: Run ElixirLS's rapid Dialyzer when code is saved
+  - Allowed values: `true`, `false`
+  - default: `true`
+- `dialyzerWarnOpts`: Dialyzer options to enable or disable warnings. See
+  Dialyzer's documentation for options. Note that the `race_conditions` option
+  is unsupported
+  - Allowed values: "error_handling", "no_behaviours", "no_contracts",
+    "no_fail_call", "no_fun_app", "no_improper_lists", "no_match",
+    "no_missing_calls", "no_opaque", "no_return", "no_undefined_callbacks",
+    "no_unused", "underspecs", "unknown", "unmatched_returns", "overspecs",
+    "specdiffs"
+  - default: `[]`
+- `dialyzerFormat`: Formatter to use for Dialyzer warnings
+  - Allowed values: ["dialyzer", "dialyxir_short", "dialyxir_long"]
+  - default: `"dialyxir_long"`
+- `mixEnv`: Mix environment to use for compilation
+  - default: `"test"`
+- `projectDir`: Subdirectory containing Mix project if not in the project root
+  - default: `"."`
+- `fetchDeps`: Automatically fetch project dependencies when compiling
+  - Allowed values: `true`, `false`
+  - default: `true`
+- `suggestSpecs`: Suggest @spec annotations inline using Dialyzer's inferred
+  success typings (Requires Dialyzer)
+  - Allowed values: `true`, `false`
+  - default: `true`
+
+Example config:
+```jsonc
+{
+  // You may want to disable dialyzer if you find it unhelpful or your machine is underpowered
+  "dialyzerEnabled": false,
+
+  // You may want to disable fetching dependencies since it sometimes gets stuck/has race conditions
+  "fetchDeps": false
+}
+```
+
+### Local setup
+
+Because ElixirLS may get launched from an IDE that itself got launched from a
+graphical shell, the environment may not be complete enough to run or even find
+the correct Elixir/OTP version. The wrapper scripts try to configure `asdf-vm`
+if available, but that may not be what you want or need. Therefore, prior to
+executing Elixir, the script will source `$XDG_CONFIG_HOME/elixir_ls/setup.sh`
+(e.g. `~/.config/elixir_ls/setup.sh`), if available. The environment variable
+`ELS_MODE` is set to either `debugger` or `language_server` to help you decide
+what to do inside the script, if needed.
+
 ## Debugger support
 
 ElixirLS includes debugger support adhering to the [VS Code debugger protocol](https://code.visualstudio.com/docs/extensionAPI/api-debugging) which is closely related to the Language Server Protocol. At the moment, only line breakpoints are supported.
@@ -191,7 +258,7 @@ If you get an error like the following immediately on startup:
     ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
 ```
 
-and you installed Elixir and Erlang from the Erlang Solutions repository, you may not have a full installation of erlang. This can be solved with `sudo apt-get install esl-erlang`. Originally reported in [#208](https://github.com/elixir-lsp/elixir-ls/issues/208).
+and you installed Elixir and Erlang from the Erlang Solutions repository, you may not have a full installation of erlang. This can be solved with `sudo apt-get install esl-erlang`. Originally reported in [#208](https://github.com/elixir-lsp/elixir-ls/issues/208). If you're running Fedora [you may need to run](https://github.com/JakeBecker/vscode-elixir-ls/issues/104#issuecomment-622414197) `sudo dnf install erlang`
 
 ## Known Issues/Limitations
 
@@ -209,14 +276,6 @@ and you installed Elixir and Erlang from the Erlang Solutions repository, you ma
 Run `mix compile`, then `mix elixir_ls.release -o <release_dir>`. This builds the language server and debugger as a set of `.ez` archives and creates `.sh` and `.bat` scripts to launch them.
 
 If you're packaging these archives in an IDE plugin, make sure to build using the minimum supported OTP version for the best backwards-compatibility. Alternatively, you can use a [precompiled release](https://github.com/elixir-lsp/elixir-ls/releases).
-
-### Local setup
-
-Because ElixirLS may get launched from an IDE that itself got launched from a graphical shell, the environment may not
-be complete enough to run or even find the correct Elixir/OTP version. The wrapper scripts try to configure `asdf-vm`
-if available, but that may not be what you want or need. Therefore, prior to executing Elixir, the script will source
-`$XDG_CONFIG_HOME/elixir_ls/setup.sh` (e.g. `~/.config/elixir_ls/setup.sh`), if available. The environment variable
-`ELS_MODE` is set to either `debugger` or `language_server` to help you decide what to do inside the script, if needed.
 
 ## Acknowledgements and related projects
 

--- a/apps/elixir_ls_utils/lib/config/setting_def.ex
+++ b/apps/elixir_ls_utils/lib/config/setting_def.ex
@@ -1,0 +1,8 @@
+defmodule ElixirLS.Utils.Config.SettingDef do
+  @moduledoc """
+  Defines attributes for an individual setting supported by ElixirLS.
+  """
+
+  @enforce_keys [:key, :json_key, :type, :default, :doc]
+  defstruct [:key, :json_key, :type, :default, :doc]
+end

--- a/apps/elixir_ls_utils/lib/config_parser.ex
+++ b/apps/elixir_ls_utils/lib/config_parser.ex
@@ -1,0 +1,171 @@
+defmodule ElixirLS.Utils.ConfigParser do
+  @moduledoc """
+  Parses and loads an ElixirLS configuration file
+  """
+
+  alias ElixirLS.Utils.Config.SettingDef
+
+  @settings [
+    %SettingDef{
+      key: :dialyzer_enabled,
+      json_key: "dialyzerEnabled",
+      type: :boolean,
+      default: true,
+      doc: "Run ElixirLS's rapid Dialyzer when code is saved"
+    },
+    %SettingDef{
+      key: :dialyzer_format,
+      json_key: "dialyzerFormat",
+      type: {:one_of, ["dialyzer", "dialyxir_short", "dialyxir_long"]},
+      default: "dialyxir_long",
+      doc: "Formatter to use for Dialyzer warnings"
+    },
+    %SettingDef{
+      key: :dialyzer_warn_opts,
+      json_key: "dialyzerWarnOpts",
+      type:
+        {:custom, ElixirLS.Utils.NimbleListChecker, :list,
+         [
+           "error_handling",
+           "no_behaviours",
+           "no_contracts",
+           "no_fail_call",
+           "no_fun_app",
+           "no_improper_lists",
+           "no_match",
+           "no_missing_calls",
+           "no_opaque",
+           "no_return",
+           "no_undefined_callbacks",
+           "no_unused",
+           "underspecs",
+           "unknown",
+           "unmatched_returns",
+           "overspecs",
+           "specdiffs"
+         ]},
+      default: [],
+      doc:
+        "Dialyzer options to enable or disable warnings. See Dialyzer's documentation for options. Note that the `race_conditions` option is unsupported"
+    },
+    %SettingDef{
+      key: :fetch_deps,
+      json_key: "fetchDeps",
+      type: :boolean,
+      default: true,
+      doc: "Automatically fetch project dependencies when compiling"
+    },
+    %SettingDef{
+      key: :mix_env,
+      json_key: "mixEnv",
+      type: :string,
+      default: "test",
+      doc: "Mix environment to use for compilation"
+    },
+    %SettingDef{
+      key: :mix_target,
+      json_key: "mixTarget",
+      type: :string,
+      default: "host",
+      doc: "Mix target (`MIX_TARGET`) to use for compilation (requires Elixir >= 1.8)"
+    },
+    %SettingDef{
+      key: :project_dir,
+      json_key: "projectDir",
+      type: :string,
+      default: "",
+      doc:
+        "Subdirectory containing Mix project if not in the project root. " <>
+          "If value is \"\" then defaults to the workspace rootUri."
+    },
+    %SettingDef{
+      key: :suggest_specs,
+      json_key: "suggestSpecs",
+      type: :boolean,
+      default: true,
+      doc:
+        "Suggest @spec annotations inline using Dialyzer's inferred success typings " <>
+          "(Requires Dialyzer)"
+    },
+    %SettingDef{
+      key: :trace,
+      json_key: "trace",
+      type: :map,
+      default: %{},
+      doc: "Ignored"
+    }
+  ]
+
+  def load_config_file(path) do
+    with {:ok, contents} <- File.read(path) do
+      load_config(contents)
+    end
+  end
+
+  def load_config(contents) do
+    with {:ok, settings_map} <- json_decode(contents),
+         {:ok, validated_options} <- parse_config(settings_map) do
+      {:ok, Map.new(validated_options), []}
+    end
+  end
+
+  def default_config do
+    @settings
+    |> Map.new(fn %SettingDef{} = setting_def ->
+      %SettingDef{key: key, default: default} = setting_def
+      {key, default}
+    end)
+  end
+
+  @doc """
+  Parse the raw decoded JSON to the settings map (including translation from
+  camelCase to snake_case)
+  """
+  def parse_config(settings_map) do
+    # Because we use a configuration layering approach, this configuration
+    # parsing should be based on the settings_map and not the possible settings.
+    # The return value should be *only* the settings that were passed in, don't
+    # return the defaults here.
+    values =
+      settings_map
+      |> Enum.map(fn {json_key, value} ->
+        case translate_key(json_key) do
+          {:ok, key} -> {:ok, {key, value}}
+          {:error, "unknown key"} -> {:error, {:unrecognized_configuration_key, json_key, value}}
+        end
+      end)
+
+    {good, errors} = Enum.split_with(values, &match?({:ok, _}, &1))
+    config = Map.new(good, fn {:ok, {key, val}} -> {key, val} end)
+
+    {:ok, config, errors}
+  end
+
+  for %SettingDef{key: key, json_key: json_key} <- @settings do
+    defp translate_key(unquote(json_key)) do
+      {:ok, unquote(key)}
+    end
+  end
+
+  defp translate_key(_), do: {:error, "unknown key"}
+
+  for setting <- @settings do
+    def valid_key?(unquote(setting.json_key)), do: true
+  end
+
+  def valid_key?(_), do: false
+
+  def json_decode(contents) when is_binary(contents) do
+    contents
+    |> String.split(["\n", "\r", "\r\n"], trim: true)
+    |> Enum.map(&String.trim/1)
+    # Ignore json comments
+    |> Enum.reject(&String.starts_with?(&1, "#"))
+    |> Enum.join()
+    |> JasonVendored.decode()
+    |> case do
+      {:ok, _} = ok -> ok
+      {:error, %JasonVendored.DecodeError{} = err} -> {:error, {:invalid_json, err}}
+    end
+  end
+end

--- a/apps/elixir_ls_utils/lib/config_parser.ex
+++ b/apps/elixir_ls_utils/lib/config_parser.ex
@@ -160,7 +160,7 @@ defmodule ElixirLS.Utils.ConfigParser do
     |> String.split(["\n", "\r", "\r\n"], trim: true)
     |> Enum.map(&String.trim/1)
     # Ignore json comments
-    |> Enum.reject(&String.starts_with?(&1, "#"))
+    |> Enum.reject(&String.starts_with?(&1, "//"))
     |> Enum.join()
     |> JasonVendored.decode()
     |> case do

--- a/apps/elixir_ls_utils/lib/xdg.ex
+++ b/apps/elixir_ls_utils/lib/xdg.ex
@@ -1,0 +1,32 @@
+defmodule ElixirLS.Utils.XDG do
+  @moduledoc """
+  Utilities for reading files within ElixirLS's XDG configuration directory
+  """
+
+  @default_xdg_directory "$HOME/.config"
+
+  def read_elixir_ls_config_file(path) do
+    xdg_directory()
+    |> Path.join("elixir_ls")
+    |> Path.join(path)
+    |> File.read()
+    |> case do
+      {:ok, file_contents} -> {:ok, file_contents}
+      err -> err
+    end
+  end
+
+  defp xdg_directory do
+    case System.get_env("XDG_CONFIG_HOME") do
+      nil ->
+        @default_xdg_directory
+
+      xdg_directory ->
+        if File.dir?(xdg_directory) do
+          xdg_directory
+        else
+          raise "$XDG_CONFIG_HOME environment variable set, but directory does not exist"
+        end
+    end
+  end
+end

--- a/apps/elixir_ls_utils/test/config_parser_test.exs
+++ b/apps/elixir_ls_utils/test/config_parser_test.exs
@@ -1,0 +1,113 @@
+defmodule ElixirLS.Utils.ConfigParserTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirLS.Utils.ConfigParser
+
+  @default_mix_env "test"
+  @default_dialyzer_enabled true
+  @default_project_dir ""
+
+  test "default_config returns the defaults" do
+    config = ConfigParser.default_config()
+
+    assert config.mix_env == @default_mix_env
+    assert config.dialyzer_enabled == @default_dialyzer_enabled
+    assert config.project_dir == @default_project_dir
+  end
+
+  test "load_config new defaults" do
+    config_contents = "{\"dialyzerFormat\": \"dialyxir_short\"}"
+
+    assert {:ok, %{dialyzer_format: "dialyxir_short"}, []} =
+             ConfigParser.load_config(config_contents)
+  end
+
+  test "load_config with an empty configuration file returns an empty config" do
+    config_contents = "{}"
+
+    assert {:ok, config, errors} = ConfigParser.load_config(config_contents)
+
+    assert config == %{}
+    assert errors == []
+  end
+
+  test "load_config with an invalid setting key" do
+    config_contents = JasonVendored.encode!(%{"badKey" => "invalid"})
+
+    assert {:ok, config, errors} = ConfigParser.load_config(config_contents)
+
+    assert [error: {:unrecognized_configuration_key, "badKey", "invalid"}] = errors
+  end
+
+  test "load_config with dialyzer disabled and false" do
+    config_contents = "{\n\t\"dialyzerEnabled\": false,\n\t\"dialyzerFormat\": \"dialyzer\"\n}\n"
+    assert {:ok, config, errors} = ConfigParser.load_config(config_contents)
+
+    assert config == %{
+             dialyzer_enabled: false,
+             dialyzer_format: "dialyzer"
+           }
+  end
+
+  @tag :pending
+  test "load_config with a setting with an invalid value" do
+    config_contents = JasonVendored.encode!(%{"dialyzerFormat" => "other_format"})
+
+    assert {:ok, _config, errors} = ConfigParser.load_config(config_contents)
+
+    assert [
+             error:
+               {:value_not_allowed, "other_format", "dialyzerFormat",
+                ["dialyzer", "dialyxir_short", "dialyxir_long"]}
+           ] = errors
+  end
+
+  test "load_config can set the default mix env" do
+    config_contents = JasonVendored.encode!(%{"mixEnv" => "dev"})
+
+    assert {:ok, config, errors} = ConfigParser.load_config(config_contents)
+
+    assert config.mix_env == "dev"
+    assert errors == []
+  end
+
+  test "load_config with an invalid json file" do
+    config_contents = "this is not json"
+
+    assert {:error, {:invalid_json, decode_error}} = ConfigParser.load_config(config_contents)
+
+    assert decode_error.data == config_contents
+  end
+
+  test "load_config/1 ignores lines with comments" do
+    config_contents = """
+    # This is the configuration file for ElixirLS
+    {
+      # Disable dialyzer
+      "dialyzerEnabled": false
+    }
+    """
+
+    assert {:ok, config, _} = ConfigParser.load_config(config_contents)
+
+    assert config.dialyzer_enabled == false
+  end
+
+  test "load_config_file/1 loads a valid configuration file" do
+    path =
+      Path.join([__DIR__, "support/example_config_file.jsonc"])
+      |> Path.expand()
+
+    assert {:ok, config, errors} = ConfigParser.load_config_file(path)
+    assert config.dialyzer_enabled == false
+    assert config.fetch_deps == false
+    assert config.mix_env == "dev"
+    assert errors == []
+  end
+
+  test "load_config_file/1 with a missing configuration file" do
+    path = "non-existant-file"
+
+    assert {:error, :enoent} = ConfigParser.load_config_file(path)
+  end
+end

--- a/apps/elixir_ls_utils/test/config_parser_test.exs
+++ b/apps/elixir_ls_utils/test/config_parser_test.exs
@@ -81,9 +81,9 @@ defmodule ElixirLS.Utils.ConfigParserTest do
 
   test "load_config/1 ignores lines with comments" do
     config_contents = """
-    # This is the configuration file for ElixirLS
+    // This is the configuration file for ElixirLS
     {
-      # Disable dialyzer
+      // Disable dialyzer
       "dialyzerEnabled": false
     }
     """

--- a/apps/elixir_ls_utils/test/support/example_config_file.jsonc
+++ b/apps/elixir_ls_utils/test/support/example_config_file.jsonc
@@ -1,6 +1,6 @@
-# This is the configuration file for ElixirLS
+// This is the configuration file for ElixirLS
 {
-  # Disable dialyzer
+  // Disable dialyzer
   "dialyzerEnabled": false,
   "fetchDeps": false,
   "mixEnv": "dev"

--- a/apps/elixir_ls_utils/test/support/example_config_file.jsonc
+++ b/apps/elixir_ls_utils/test/support/example_config_file.jsonc
@@ -1,0 +1,7 @@
+# This is the configuration file for ElixirLS
+{
+  # Disable dialyzer
+  "dialyzerEnabled": false,
+  "fetchDeps": false,
+  "mixEnv": "dev"
+}

--- a/apps/elixir_ls_utils/test/support/mock_xdg.ex
+++ b/apps/elixir_ls_utils/test/support/mock_xdg.ex
@@ -1,0 +1,5 @@
+defmodule ElixirLS.Utils.Test.MockXDG do
+  def read_elixir_ls_config_file(_) do
+    {:error, :enoent}
+  end
+end

--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -7,7 +7,8 @@ defmodule ElixirLS.LanguageServer do
   @impl Application
   def start(_type, _args) do
     children = [
-      {ElixirLS.LanguageServer.Server, ElixirLS.LanguageServer.Server},
+      {ElixirLS.LanguageServer.Server,
+       name: ElixirLS.LanguageServer.Server},
       {ElixirLS.LanguageServer.JsonRpc, name: ElixirLS.LanguageServer.JsonRpc},
       {ElixirLS.LanguageServer.Providers.WorkspaceSymbols, []}
     ]

--- a/apps/language_server/lib/language_server/config_loader.ex
+++ b/apps/language_server/lib/language_server/config_loader.ex
@@ -1,0 +1,68 @@
+defmodule ElixirLS.LanguageServer.ConfigLoader do
+  @moduledoc """
+  Responsible for loading the configuration. Applies configuration in this
+  order: defaults, previously loaded configuration, user home dir configuration,
+  editor configuration
+  """
+
+  # Configuration Loading Order
+  #
+  # - Server starts up (it knows the root directory)
+  # - User provides did_change_configuration (or we fall back to defaults)
+  #   - NOTE: This is where all the configuration is loaded
+  # - Load and apply all the configuration in this order:
+  #   - Existing Server Config
+  #   - User Home Config
+  #   - Workspace Config
+  #   - Editor Config
+
+  alias ElixirLS.Utils.ConfigParser
+  alias ElixirLS.LanguageServer.JsonRpc
+
+  # Can we change this to load also from the workspace root? Note: might need multiple passes for that to work
+
+  def load(prev_config, editor_config, opts \\ []) do
+    user_home_config =
+      Keyword.get_lazy(opts, :load_user_home_config, fn ->
+        load_user_home_config()
+      end)
+
+    default_config = ConfigParser.default_config()
+    editor_config = ConfigParser.parse_config(editor_config)
+
+    config =
+      [default_config, prev_config, user_home_config, editor_config]
+      |> Enum.reduce(%{}, fn
+        {:ok, :skip}, acc ->
+          acc
+
+        {:ok, config, errors}, acc when is_map(config) ->
+          Enum.each(errors, fn {:error, {:unrecognized_configuration_key, key, value}} ->
+            JsonRpc.log_message(:warning, "Invalid configuration key: #{key} with value #{inspect value}")
+          end)
+
+          Map.merge(acc, config)
+
+        config, acc when is_map(config) ->
+          Map.merge(acc, config)
+      end)
+
+    errors = []
+    {:ok, config, errors}
+  end
+
+  defp load_user_home_config do
+    case xdg_module().read_elixir_ls_config_file("config.json") do
+      {:ok, file_contents} ->
+        ConfigParser.load_config(file_contents)
+
+      {:error, :enoent} ->
+        {:ok, :skip}
+
+      {:error, err} ->
+        {:error, err}
+    end
+  end
+
+   defp xdg_module, do: Application.fetch_env!(:language_server, :xdg_module)
+end

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -771,7 +771,21 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   defp set_settings(state, prev_settings, settings_map) do
-    {:ok, config, errors} = ConfigLoader.load(prev_settings, settings_map)
+    root_dir = SourceFile.path_from_uri(state.root_uri)
+
+    project_dir =
+      case state.project_dir || settings_map["projectDir"] do
+        nil -> root_dir
+        project_dir -> Path.join(root_dir, project_dir)
+      end
+
+    {:ok, config, errors} =
+      ConfigLoader.load(
+        project_dir,
+        prev_settings,
+        settings_map
+      )
+
     notify_configuration_errors(errors)
 
     mix_target = config.mix_target

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -15,6 +15,7 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
 
   setup do
     server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
+    ElixirLS.LanguageServer.Test.ServerTestHelpers.assert_server_does_not_crash(server)
 
     {:ok, %{server: server}}
   end

--- a/apps/language_server/test/language_server/config_loader_test.exs
+++ b/apps/language_server/test/language_server/config_loader_test.exs
@@ -1,0 +1,18 @@
+defmodule ElixirLS.LanguageServer.ConfigLoaderTest do
+  use ExUnit.Case
+
+  alias ElixirLS.LanguageServer.ConfigLoader
+
+  describe "load/2" do
+    test "dialyzer enabled is respected" do
+      changed_settings = %{
+        "dialyzerEnabled" => false
+      }
+
+      prev_settings = %{}
+
+      assert {:ok, %{dialyzer_enabled: false}, _} =
+               ConfigLoader.load(prev_settings, changed_settings)
+    end
+  end
+end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -72,15 +72,18 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     _ = :sys.get_state(server)
   end
 
-  @tag server_opts: [default_config_timeout_ms: 10]
+  @tag server_opts: [default_config_timeout_ms: 100]
   test "uses the default settings if textDocument/didChangeConfiguration with invalid configuration not called",
        %{server: server} do
-    Server.receive_packet(server, initialize_req(1, root_uri(), %{}))
-    Process.sleep(100)
+    in_fixture(__DIR__, "references", fn ->
+      Server.receive_packet(server, initialize_req(1, root_uri(), %{}))
+      Server.receive_packet(server, notification("initialized"))
+      Process.sleep(1000)
 
-    state = :sys.get_state(server)
-    assert state.settings.dialyzer_enabled == true
-    assert state.settings.dialyzer_format == "dialyxir_long"
+      state = :sys.get_state(server)
+      assert state.settings.dialyzer_enabled == true
+      assert state.settings.dialyzer_format == "dialyxir_long"
+    end)
   end
 
   test "textDocument/didChange when the client hasn't claimed ownership with textDocument/didOpen",

--- a/apps/language_server/test/support/server_test_helpers.ex
+++ b/apps/language_server/test/support/server_test_helpers.ex
@@ -6,10 +6,10 @@ defmodule ElixirLS.LanguageServer.Test.ServerTestHelpers do
   alias ElixirLS.LanguageServer.Providers.WorkspaceSymbols
   alias ElixirLS.Utils.PacketCapture
 
-  def start_server do
+  def start_server(opts \\ []) do
     packet_capture = start_supervised!({PacketCapture, self()})
 
-    server = start_supervised!({Server, nil})
+    server = start_supervised!({Server, opts})
     Process.group_leader(server, packet_capture)
 
     json_rpc = start_supervised!({JsonRpc, name: JsonRpc})
@@ -19,5 +19,25 @@ defmodule ElixirLS.LanguageServer.Test.ServerTestHelpers do
     Process.group_leader(workspace_symbols, packet_capture)
 
     server
+  end
+
+  def assert_server_does_not_crash(server) do
+    Task.start_link(fn ->
+      ref = Process.monitor(server)
+
+      receive do
+        {:DOWN, ^ref, :process, _object, :normal} ->
+          nil
+
+        {:DOWN, ^ref, :process, _object, reason} ->
+          ExUnit.Assertions.flunk("""
+          Server should not crash.
+
+          Crashed with:
+          #{inspect(reason, pretty: true)}
+          """)
+      end
+    end)
+
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,3 +15,11 @@ use Mix.Config
 #       level: :info,
 #       format: "$date $time [$level] $metadata$message\n",
 #       metadata: [:user_id]
+
+case Mix.env() do
+  :test ->
+    config :language_server, xdg_module: ElixirLS.Utils.Test.MockXDG
+
+  _ ->
+    config :language_server, xdg_module: ElixirLS.Utils.XDG
+end


### PR DESCRIPTION
Add a user configuration file that is read on startup.
Change the server settings to always be fully fleshed out. So the
ElixirLS.LanguageServer.Server state `settings` always has all the
settings (and as atoms) instead of being an empty map by default. This
consolidates the default setting logic into the new `ConfigParser`
module instead of being strewn about the Server.

TODO:
- [ ] Fix tests (I'm getting a strange error with the tests that I cannot figure out.)
- [ ] Read a configuratioon file from the repository

Note: Editor configuration always overrides the configuration file, and
the VSCode extension always sends in the full configuration. This means
that the configuration file is not currently useable with the VSCode
extension. This will probably have to be modified in the VSCode
extension because I think it is important for the extension to have the
final control of the server settings.

Fixes #60 