### PR TITLE
Update Hover to return MarkupContent

### DIFF
--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -49,6 +49,9 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   end
 
   defp contents(%{docs: markdown}) do
-    markdown
+    %{
+      kind: "markdown",
+      value: markdown
+    }
   end
 end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -76,7 +76,10 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     resp = assert_receive(%{"id" => 1}, 1000)
 
     assert response(1, %{
-             "contents" => "> GenServer" <> _,
+             "contents" => %{
+               "kind" => "markdown",
+               "value" => "> GenServer" <> _
+             },
              "range" => %{
                "start" => %{"line" => 2, "character" => 12},
                "end" => %{"line" => 2, "character" => 21}


### PR DESCRIPTION
Hello! :wave: In my research into [an issue with Emacs' `lsp-ui`](https://github.com/emacs-lsp/lsp-ui/issues/478), I discovered that the "Hover" response from ElixirLS was returning the [deprecated MarkedString type](https://github.com/microsoft/language-server-protocol/blame/gh-pages/_specifications/specification-3-15.md#L3679) (technically just a string, which is a valid MarkedString and thus compliant with the spec).

The conversion from MarkedString to the non-deprecated [MarkupContent type](https://microsoft.github.io/language-server-protocol/specification#markupContent) was pretty painless, so I made the change.