### PR TITLE
Remove deps cached only when deps in mix file changed

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -13,15 +13,14 @@ defmodule ElixirLS.LanguageServer.Build do
               IO.puts("MIX_ENV: #{Mix.env()}")
               IO.puts("MIX_TARGET: #{Mix.target()}")
 
-              prev_deps = cached_deps()
-              :ok = Mix.Project.clear_deps_cache()
-
               case reload_project() do
                 {:ok, mixfile_diagnostics} ->
                   # FIXME: Private API
                   if Keyword.get(opts, :fetch_deps?) and
-                       Mix.Dep.load_on_environment([]) != prev_deps,
-                     do: fetch_deps()
+                       Mix.Dep.load_on_environment([]) != cached_deps() do
+                    :ok = Mix.Project.clear_deps_cache()
+                    fetch_deps()
+                  end
 
                   {status, diagnostics} = compile()
 

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -18,6 +18,8 @@ defmodule ElixirLS.LanguageServer.Build do
                   # FIXME: Private API
                   if Keyword.get(opts, :fetch_deps?) and
                        Mix.Dep.load_on_environment([]) != cached_deps() do
+                    # NOTE: Clear deps cache when deps in mix.exs has change to prevent
+                    # formatter crash from clearing deps during build.
                     :ok = Mix.Project.clear_deps_cache()
                     fetch_deps()
                   end


### PR DESCRIPTION
Remove deps cached every build can cause deps cached disappear in :ets.
Fixes by move calling Mix.Project.clear_deps_cache/0 only when deps in
mix.exs was change.

Fixes #235