### PR TITLE
Update OTP version check to 23 when releasing.

### DIFF
--- a/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
+++ b/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.ElixirLs.Release do
   defp version_warning do
     {otp_version, _} = Integer.parse(to_string(:erlang.system_info(:otp_release)))
 
-    if otp_version > 20 do
+    if otp_version > 23 do
       IO.warn(
         "Building with Erlang/OTP #{otp_version}. Make sure to build with OTP 20 if " <>
           "publishing the compiled packages because modules built with higher versions are not " <>


### PR DESCRIPTION
Hi, I’m using OTP 23. I’m able to compile and run the extension with OTP version 23. I couldn’t find any problem.