### PR TITLE
Elixir 1.11 support

### DIFF
--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -192,6 +192,7 @@ defmodule ElixirLS.Debugger.ServerTest do
       assert Process.alive?(server)
     end
 
+    @tag :capture_log
     test "Evaluate expression with ERROR result", %{server: server} do
       Server.receive_packet(
         server,

--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -15,7 +15,8 @@ defmodule ElixirLS.Utils.Mixfile do
       start_permanent: false,
       build_per_environment: false,
       consolidate_protocols: false,
-      deps: deps()
+      deps: deps(),
+      xref: [exclude: JasonVendored]
     ]
   end
 

--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -16,7 +16,7 @@ defmodule ElixirLS.Utils.Mixfile do
       build_per_environment: false,
       consolidate_protocols: false,
       deps: deps(),
-      xref: [exclude: JasonVendored]
+      xref: [exclude: [JasonVendored, Logger]]
     ]
   end
 

--- a/apps/elixir_ls_utils/test/support/mix_test.case.ex
+++ b/apps/elixir_ls_utils/test/support/mix_test.case.ex
@@ -80,9 +80,10 @@ defmodule ElixirLS.Utils.MixTest.Case do
       :code.set_path(get_path)
 
       for {mod, file} <- :code.all_loaded() -- previous,
-          file == :in_memory or (is_list(file) and :lists.prefix(flag, file)) do
-        purge([mod])
+          file == :in_memory or file == [] or (is_list(file) and :lists.prefix(flag, file)) do
+        mod
       end
+      |> purge
 
       restore_project_stack!(project_stack)
     end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2426,8 +2426,18 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
     end
     """
 
-    assert {:ok, document_symbols} = DocumentSymbols.symbols(uri, text, true)
-    # IO.inspect(document_symbols, label: "document_symbols")
-    # assert String.contains?(message, "Compilation error")
+    assert {:ok,
+            [
+              %Protocol.DocumentSymbol{
+                children: [
+                  %Protocol.DocumentSymbol{
+                    name: "def hello"
+                  },
+                  %Protocol.DocumentSymbol{
+                    name: "defp greetings"
+                  }
+                ]
+              }
+            ]} = DocumentSymbols.symbols(uri, text, true)
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "8c82bc726f6f0e33680287ead72390fe4a8a74dd", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "5a37db1bcc4b6d1cbc3dbbc669902af85b5d29ec", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},


### PR DESCRIPTION
TODO:
- [x] update elixir_sense https://github.com/elixir-lsp/elixir_sense/pull/109
- [x] silence/fix xref warnings
- [x] fix diagnostics normalization
- [x] investigate dialyzer_test.exs suite failures (all of the tests pass when run separately)
- [x] fix minor warnings

All in all it appears to be working fine. The only observed problem is dialyzer diagnostics. Due to https://github.com/elixir-lang/elixir/issues/10279 they are currently not usable.