### PR TITLE
Add support for .formatter.exs in subdirectories

### DIFF
--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -54,10 +54,16 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
 
     inputs
     |> Stream.flat_map(fn glob ->
-      [
+      globs = [
         Path.join([project_dir, glob]),
         Path.join([project_dir, "apps", "*", glob])
       ]
+
+      if String.starts_with?(file, project_dir) do
+        globs ++ [Path.join([Path.dirname(file), glob])]
+      else
+        globs
+      end
     end)
     |> Stream.flat_map(&Path.wildcard(&1, match_dot: true))
     |> Enum.any?(&(file == &1))


### PR DESCRIPTION
When try to format Ecto migration script that generate project from
Phoenix, it will returns inputs "*.exs". But the glob list just detect
it only the root of project and apps directory which for umbrella
project. This cause make migration script won't match any glob pattern.

This changes fixes by add directory of file that want to format to the end
of glob list.

Fixes #361