### PR TITLE
feat: exclude modules by wildcard name

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -621,7 +621,6 @@ defmodule ElixirLS.Debugger.Server do
     module_name = module |> Atom.to_string()
 
     Enum.any?(exclude_module_pattern, &Regex.match?(&1, module_name))
-    |> IO.inspect(label: "exclude '" <> module_name <> "'?")
   end
 
   defp prefix_module_name(module_name) when is_binary(module_name) do


### PR DESCRIPTION
With this PR I'd like to introduce the possibility for modules to be excluded without knowing their full name.

Example:

```
{
            "type": "mix_task",
            "name": "mix phx.server",
            "request": "launch",
            "task": "phx.server",
            "projectDir": "${workspaceRoot}",
            "excludeModules": [
                ":phoenix",
                "Phoenix",
                "Phoenix.*"
            ]
}
```

This helped me to use the debugging feature of the vscode-elixir-ls extension which kept failing for our team. Without this feature I was unable/unwilling to collect all the modules names that need to be excluded. The only approach, to gather the required module names, seemed to be trial and error based, which combined with the debuggers starting times felt disproportionate.