### PR TITLE
Allow running a setup script on Windows analogous to setup.sh on Linux

### DIFF
--- a/apps/elixir_ls_utils/priv/debugger.bat
+++ b/apps/elixir_ls_utils/priv/debugger.bat
@@ -1,4 +1,8 @@
 @echo off & setlocal enabledelayedexpansion
 
+IF EXIST "%APPDATA%\elixir_ls\setup.bat" (
+    CALL "%APPDATA%\elixir_ls\setup.bat"
+)
+
 SET ERL_LIBS=%~dp0;%ERL_LIBS%
 elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none" -e "ElixirLS.Debugger.CLI.main()"

--- a/apps/elixir_ls_utils/priv/language_server.bat
+++ b/apps/elixir_ls_utils/priv/language_server.bat
@@ -1,4 +1,8 @@
 @echo off & setlocal enabledelayedexpansion
 
+IF EXIST "%APPDATA%\elixir_ls\setup.bat" (
+    CALL "%APPDATA%\elixir_ls\setup.bat"
+)
+
 SET ERL_LIBS=%~dp0;%ERL_LIBS%
 elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none" -e "ElixirLS.LanguageServer.CLI.main()"


### PR DESCRIPTION
Script is located at `%APPDATA%/elixir_ls/setup.bat` which usually translates to `C:\Users\<username>\AppData\Roaming\elixir_ls`

Example use-case:

```bat
@echo off
CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
```

Very useful for nifs.