### PR TITLE
Print a message when done fetching deps

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -238,6 +238,10 @@ defmodule ElixirLS.LanguageServer.Build do
       )
 
       Mix.Task.run("deps.get")
+      JsonRpc.show_message(
+        :info,
+        "Done fetching deps"
+      )
     end
 
     :ok

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -238,6 +238,7 @@ defmodule ElixirLS.LanguageServer.Build do
       )
 
       Mix.Task.run("deps.get")
+
       JsonRpc.show_message(
         :info,
         "Done fetching deps"


### PR DESCRIPTION
Otherwise the user doesn't know when the server is done, and running a command like "mix deps.get" at the same time is the server can result in corrupted files.