### PR TITLE
Add auto publish release with asset

### DIFF
--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -6,17 +6,48 @@ on:
       - 'v*'
 
 jobs:
+  release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{steps.create_release.outputs.upload_url}}
+
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+
   build:
     name: Build and publish release asset
     runs-on: ubuntu-latest
+    needs: release
+
+    strategy:
+      matrix:
+        include:
+          - elixir-version: '1.11'
+            otp-version: '23.1'
+          - elixir-version: '1.10.4'
+            otp-version: '23.1'
+          - elixir-version: '1.9'
+            otp-version: '22.3'
+          - elixir-version: '1.8.2'
+            otp-version: '21.3'
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: '1.8.2'
-          otp-version: '21.3.8.17'
+          elixir-version: ${{ matrix.elixir-version }}
+          otp-version: ${{ matrix.otp-version }}
 
       - name: Restore dependencies cache
         uses: actions/cache@v2
@@ -32,26 +63,15 @@ jobs:
         run: |
           mkdir ./release
           mix compile
-          mix elixir_ls.release -o ./release
+          MIX_ENV=prod mix elixir_ls.release -o ./release
           zip -jr elixir-ls.zip ./release
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: false
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./elixir-ls.zip
-          asset_name: elixir-ls.zip
+          asset_name: elixir-ls-${{ matrix.elixir-version }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: '1.8.2-otp-21'
+          elixir-version: '1.8.2'
           otp-version: '21.3.8.17'
 
       - name: Restore dependencies cache

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -1,0 +1,57 @@
+name: Elixir CI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build and publish release asset
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Elixir
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: '1.10.4'
+          otp-version: '23.1'
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Build release
+        run: |
+          mkdir ./release
+          mix compile
+          mix elixir_ls.release -o ./release
+          zip -jr elixir-ls.zip ./release
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./elixir-ls.zip
+          asset_name: elixir-ls.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -40,6 +40,7 @@ jobs:
             otp-version: '22.3'
           - elixir-version: '1.8.2'
             otp-version: '21.3'
+            default: true
 
     steps:
       - uses: actions/checkout@v2
@@ -74,4 +75,15 @@ jobs:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./elixir-ls.zip
           asset_name: elixir-ls-${{ matrix.elixir-version }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Default Release Asset
+        if: ${{ matrix.default == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./elixir-ls.zip
+          asset_name: elixir-ls.zip
           asset_content_type: application/zip

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: '1.10.4'
-          otp-version: '23.1'
+          elixir-version: '1.8.2-otp-21'
+          otp-version: '21.3.8.17'
 
       - name: Restore dependencies cache
         uses: actions/cache@v2

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
 
       - name: Upload Release Asset


### PR DESCRIPTION
When a tag is pushed, this automatically builds the asset, creates a draft release on the tag, and upload the asset to the release.
You can then modify the release description and publish.

Feel free to close if it's unwanted.
I used it in my own fork while debugging the formatting issue on Windows. https://github.com/princemaple/elixir-ls/releases