### PR TITLE
Bypass file_server for some file existence checks

### DIFF
--- a/apps/language_server/lib/language_server/diagnostics.ex
+++ b/apps/language_server/lib/language_server/diagnostics.ex
@@ -114,7 +114,7 @@ defmodule ElixirLS.LanguageServer.Diagnostics do
   defp file_path(file, root_path) do
     path = Path.join([root_path, file])
 
-    if File.exists?(path) do
+    if File.exists?(path, [:raw]) do
       {:ok, path}
     else
       file_path_in_umbrella(file, root_path)

--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -253,7 +253,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
       with true <- Code.ensure_loaded?(module),
            path when not is_nil(path) <- module.module_info(:compile)[:source],
            path_binary = List.to_string(path),
-           true <- File.exists?(path_binary) do
+           true <- File.exists?(path_binary, [:raw]) do
         path_binary
       else
         _ -> nil
@@ -265,7 +265,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
       with beam_file when not is_nil(beam_file) <-
              ErlangSourceFile.get_beam_file(module, beam_file),
            erl_file = ErlangSourceFile.beam_file_to_erl_file(beam_file),
-           true <- File.exists?(erl_file) do
+           true <- File.exists?(erl_file, [:raw]) do
         erl_file
       else
         _ -> nil


### PR DESCRIPTION
This addresses what I believe is the root cause of #381. 

During indexing the `WorkspaceSymbols` genserver works its way through the result of `:code.all_loaded/0`, calling `File.exists?` in the course of its work for each entry in the list of loaded modules. This occurs concurrently across `n` processes where `n` is the scheduler count. On my current project of decent size `:code.all_loaded/0` returns 550 entries.

The `File.exists?` checks are filling the message queue of Erlang's `file_server` process, and I think this is causing other file operations to block until it can work through the queue. If you launch the Observer you can see this happen on the process tab, and it would explain why seemingly independent parts of the Elixir LS application are blocking each other.

I think the regression itself would have been introduced in #110 with the introduction of workspace symbols support. I'm unclear on why it got worse for people in the latest Elixir LS release, but as I mentioned in #381 I wonder if the Elixir and OTP upgrade is a piece of the puzzle? Maybe someone has a better idea.

This PR passes the `:raw` option to `File.exists?`, which causes the file existence check to [bypass the Erlang file server](https://erlang.org/doc/man/file.html#read_file_info-1), which I believe is safe under these circumstances.

This seemed to resolve the specific issue I outlined in #381. On my machine it also reduced the cumulative workspace symbol indexing time by 50% for the initial indexing phase and 70% for subsequent updates. I suspect this is because the individual tasks spawned by WorkspaceSymbols aren't blocking each other's `File.exists?` checks.

As an aside on the subject of performance — after this change I tried `Task.async_stream` as well as the custom `process_chunked` family of functions and found no difference between them. It may be worth revisiting if we can simply use `Task.async_stream` since it will be familiar to more people. It is, of course, also possible I measured incorrectly!

Perhaps @benwilson512 or @bluehotdog could give this change a try to see if it helps?
