### PR TITLE
Change formatter to attempt to acquire a build lock

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -110,8 +110,8 @@ defmodule ElixirLS.LanguageServer.Build do
     }
   end
 
-  def with_build_lock(func) do
-    :global.trans({__MODULE__, self()}, func)
+  def with_build_lock(func, retries \\ :infinity) do
+    :global.trans({__MODULE__, self()}, func, [node()], retries)
   end
 
   defp reload_project do

--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -34,22 +34,18 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
   end
 
   def try_format(func) do
-    if Mix.Project.umbrella?() do
-      Build.with_build_lock(func, 3)
-      |> case do
-        :aborted ->
-          JsonRpc.log_message(
-            :warning,
-            "[ElixirLS Formatter] Failed to acquire build lock during formatting and will not format."
-          )
+    Build.with_build_lock(func, 3)
+    |> case do
+      :aborted ->
+        JsonRpc.log_message(
+          :warning,
+          "[ElixirLS Formatter] Failed to acquire build lock during formatting and will not format."
+        )
 
-          {:ok, []}
+        {:ok, []}
 
-        result ->
-          result
-      end
-    else
-      func.()
+      result ->
+        result
     end
   end
 


### PR DESCRIPTION
Potential approach to fixing #252. I hate to bring a global lock into the picture again, but I think the strange race conditions with `File.cwd` are out of our hands since Elixir itself is using the current working directory to find the `.formatter.exs` configs.

This PR attempts to acquire a build lock as a means of delaying formatting until compilation completes. It makes three retries and Erlang will use a [graduated delay](https://github.com/blackberry/Erlang-OTP/blob/master/lib/kernel/src/global.erl#L2074) between them of 250ms, 500ms, and 1000ms.

I hammered changes as fast as I could (at a rate that was truly unrealistic) and on my project/machine I found this improves things immensely. I only tested on an umbrella project of decent size.

From what I can see this makes things better, even if they're not perfect. It'd be good to see how this behaves for others.

I am by no means tied to this solution, I just wanted to get something out there. I won't be hurt if you close it :)
