### PR TITLE
Don't add stream_data to archive

### DIFF
--- a/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
+++ b/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ElixirLs.Release do
 
     Mix.Task.run("archive.build.deps", [
       "--skip",
-      "mix_task_archive_deps",
+      "mix_task_archive_deps stream_data",
       "--destination",
       destination
     ])


### PR DESCRIPTION
Closes #413 

While trying to build current master on Erlang/OTP 22 Elixir 1.9.1 I encountered an error:

```
mix elixir_ls.release -o ~/elixir_ls
warning: Building with Erlang/OTP 22. Make sure to build with OTP 21 if publishing the compiled packages because modules built with higher versions are not backwards-compatible.

** (ErlangError) Erlang error: {:invalid_status, :compile}}
    lib/mix/tasks/archive/build.deps.ex:78: anonymous fn/3 in Mix.Tasks.Archive.Build.Deps.list/1
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    lib/mix/tasks/archive/build.deps.ex:53: Mix.Tasks.Archive.Build.Deps.build_archives/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    lib/mix.tasks.elixir_ls.release.ex:17: Mix.Tasks.ElixirLs.Release.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```

I debugged it and seen that it is because `mix_task_archive_deps` tries to package all dependencies except itself. But `stream_data` is a test-only dependency, so it crashes. Adding StreamData to applications ignored during packaging fixes the issue.

I thought about adding a more complex solution that automatically checks for test dependencies, but I saw that in one of the issues there is discussion if `elixir_ls` should use `mix_task_archive_deps` at all #115 . I personally believe it shouldn't hence the quick fix.
