### PR TITLE
Check tests for warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
       echo "Not checking formatting"
     fi
   - mix test
+  - mix deps.unlock --check-unused
   - |
     if [[ "$RUN_DIALYZER" -eq 1 ]]
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ script:
       echo "Not checking formatting"
     fi
   - mix test
+  - |
+    if [[ "$CHECK_UNUSED_DEPS" -eq 1 ]]
+    then
+      mix deps.unlock --check-unused
+    else
+      echo "Not checking unused deps"
+    fi
   - mix deps.unlock --check-unused
   - |
     if [[ "$RUN_DIALYZER" -eq 1 ]]
@@ -33,8 +40,11 @@ matrix:
       elixir: 1.9.4
     - otp_release: 23.0.4
       elixir: 1.10.4
+      env:
+        - CHECK_UNUSED_DEPS=1
     - otp_release: 23.0.4
       elixir: 1.11.1
       env:
         - CHECK_FORMATTED=1
         - RUN_DIALYZER=1
+        - CHECK_UNUSED_DEPS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
     else
       echo "Not checking unused deps"
     fi
-  - mix deps.unlock --check-unused
   - |
     if [[ "$RUN_DIALYZER" -eq 1 ]]
     then

--- a/apps/elixir_ls_debugger/test/test_helper.exs
+++ b/apps/elixir_ls_debugger/test/test_helper.exs
@@ -1,2 +1,6 @@
+if Version.match?(System.version(), ">= 1.10.0") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 Application.put_env(:elixir_ls_debugger, :test_mode, true)
 ExUnit.start(exclude: [pending: true])

--- a/apps/elixir_ls_debugger/test/test_helper.exs
+++ b/apps/elixir_ls_debugger/test/test_helper.exs
@@ -1,4 +1,4 @@
-if Version.match?(System.version(), ">= 1.10.0") do
+if Version.match?(System.version(), ">= 1.11.0") do
   Code.put_compiler_option(:warnings_as_errors, true)
 end
 

--- a/apps/elixir_ls_utils/test/test_helper.exs
+++ b/apps/elixir_ls_utils/test/test_helper.exs
@@ -1,1 +1,5 @@
+if Version.match?(System.version(), ">= 1.10.0") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 ExUnit.start(exclude: [pending: true])

--- a/apps/elixir_ls_utils/test/test_helper.exs
+++ b/apps/elixir_ls_utils/test/test_helper.exs
@@ -1,4 +1,4 @@
-if Version.match?(System.version(), ">= 1.10.0") do
+if Version.match?(System.version(), ">= 1.11.0") do
   Code.put_compiler_option(:warnings_as_errors, true)
 end
 

--- a/apps/language_server/test/test_helper.exs
+++ b/apps/language_server/test/test_helper.exs
@@ -1,4 +1,4 @@
-if Version.match?(System.version(), ">= 1.10.0") do
+if Version.match?(System.version(), ">= 1.11.0") do
   Code.put_compiler_option(:warnings_as_errors, true)
 end
 

--- a/apps/language_server/test/test_helper.exs
+++ b/apps/language_server/test/test_helper.exs
@@ -1,3 +1,7 @@
+if Version.match?(System.version(), ">= 1.10.0") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 Application.put_env(:language_server, :test_mode, true)
 Application.ensure_started(:stream_data)
 ExUnit.start(exclude: [pending: true])


### PR DESCRIPTION
Code is based on this blog post:
https://dashbit.co/blog/tests-with-warnings-as-errors

`Code.put_compiler_option/2` is only available on 1.10.0 so this check is only added when running under 1.10.0 or greater