### PR TITLE
Dialyzer improvements

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -212,17 +212,18 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
 
     # FIXME: Private API
     consolidation_path = Mix.Project.consolidation_path()
-    consolidated_protocol_beams = for path <- Path.join(consolidation_path, "*.beam") |> Path.wildcard do
-      Path.basename(path)
-    end
-    |> MapSet.new
+
+    consolidated_protocol_beams =
+      for path <- Path.join(consolidation_path, "*.beam") |> Path.wildcard() do
+        Path.basename(path)
+      end
+      |> MapSet.new()
 
     # FIXME: Private API
     all_paths =
       for path <- Mix.Utils.extract_files([Mix.Project.build_path()], [:beam]),
-        Path.basename(path) not in consolidated_protocol_beams or
-        Path.dirname(path) == consolidation_path
-      do
+          Path.basename(path) not in consolidated_protocol_beams or
+            Path.dirname(path) == consolidation_path do
         Path.relative_to_cwd(path)
       end
       |> MapSet.new()
@@ -391,7 +392,6 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
             {file, hash}
           end
 
-
         {active_plt, mod_deps, md5, warnings}
       end)
 
@@ -404,11 +404,9 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   defp update_mod_deps(mod_deps, new_mod_deps, removed_modules) do
-
     for {mod, deps} <- mod_deps,
-    mod not in removed_modules,
-    into: new_mod_deps
-    do
+        mod not in removed_modules,
+        into: new_mod_deps do
       {mod, deps -- removed_modules}
     end
   end

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -384,12 +384,13 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         mod_deps = update_mod_deps(mod_deps, new_mod_deps, removed_modules)
         warnings = add_warnings(warnings, raw_warnings)
 
+        md5 = Map.drop(md5, removed_files)
+
         md5 =
           for {file, {_, hash}} <- file_changes, into: md5 do
             {file, hash}
           end
 
-        md5 = remove_files(md5, removed_files)
 
         {active_plt, mod_deps, md5, warnings}
       end)
@@ -403,14 +404,13 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   defp update_mod_deps(mod_deps, new_mod_deps, removed_modules) do
-    mod_deps
-    |> Map.merge(new_mod_deps)
-    |> Map.drop(removed_modules)
-    |> Map.new(fn {mod, deps} -> {mod, deps -- removed_modules} end)
-  end
 
-  defp remove_files(md5, removed_files) do
-    Map.drop(md5, removed_files)
+    for {mod, deps} <- mod_deps,
+    mod not in removed_modules,
+    into: new_mod_deps
+    do
+      {mod, deps -- removed_modules}
+    end
   end
 
   defp add_warnings(warnings, raw_warnings) do

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -214,19 +214,17 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     consolidation_path = Mix.Project.consolidation_path()
 
     consolidated_protocol_beams =
-      for path <- Path.join(consolidation_path, "*.beam") |> Path.wildcard() do
-        Path.basename(path)
-      end
-      |> MapSet.new()
+      for path <- Path.join(consolidation_path, "*.beam") |> Path.wildcard(),
+          into: MapSet.new(),
+          do: Path.basename(path)
 
     # FIXME: Private API
     all_paths =
       for path <- Mix.Utils.extract_files([Mix.Project.build_path()], [:beam]),
           Path.basename(path) not in consolidated_protocol_beams or
-            Path.dirname(path) == consolidation_path do
-        Path.relative_to_cwd(path)
-      end
-      |> MapSet.new()
+            Path.dirname(path) == consolidation_path,
+          into: MapSet.new(),
+          do: Path.relative_to_cwd(path)
 
     removed =
       prev_paths

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -115,7 +115,8 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
     Path.join([Mix.Utils.mix_home(), "elixir-ls-#{otp_vsn()}_elixir-#{System.version()}"])
   end
 
-  @elixir_apps [:elixir, :eex, :ex_unit, :iex, :logger, :mix]
+  @elixir_apps [:elixir, :ex_unit, :mix, :iex, :logger, :eex]
+  @erlang_apps [:erts, :kernel, :stdlib, :compiler]
 
   defp build_elixir_plt() do
     JsonRpc.show_message(
@@ -123,7 +124,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
       "Building core Dialyzer Elixir PLT. This will take a few minutes (often 15+) and can be disabled in the settings."
     )
 
-    modules_to_paths = for app <- @elixir_apps,
+    modules_to_paths = for app <- @erlang_apps ++ @elixir_apps,
     path <- Path.join([Application.app_dir(app), "**/*.beam"]) |> Path.wildcard(),
     into: %{},
     do:

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -124,20 +124,22 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
       "Building core Dialyzer Elixir PLT. This will take a few minutes (often 15+) and can be disabled in the settings."
     )
 
-    modules_to_paths = for app <- @erlang_apps ++ @elixir_apps,
-    path <- Path.join([Application.app_dir(app), "**/*.beam"]) |> Path.wildcard(),
-    into: %{},
-    do:
-      {pathname_to_module(path), path |> String.to_charlist}
+    modules_to_paths =
+      for app <- @erlang_apps ++ @elixir_apps,
+          path <- Path.join([Application.app_dir(app), "**/*.beam"]) |> Path.wildcard(),
+          into: %{},
+          do: {pathname_to_module(path), path |> String.to_charlist()}
 
-    modules = modules_to_paths
-    |> Map.keys
-    |> expand_references
+    modules =
+      modules_to_paths
+      |> Map.keys()
+      |> expand_references
 
-    files = for mod <- modules,
-    path = modules_to_paths[mod] || Utils.get_beam_file(mod),
-    is_list(path),
-    do: path
+    files =
+      for mod <- modules,
+          path = modules_to_paths[mod] || Utils.get_beam_file(mod),
+          is_list(path),
+          do: path
 
     File.mkdir_p!(Path.dirname(elixir_plt_path()))
 

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -123,15 +123,20 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
       "Building core Dialyzer Elixir PLT. This will take a few minutes (often 15+) and can be disabled in the settings."
     )
 
-    files =
-      Enum.flat_map(@elixir_apps, fn app ->
-        Path.join([Application.app_dir(app), "**/*.beam"])
-        |> Path.wildcard()
-        |> Enum.map(&pathname_to_module/1)
-        |> expand_references()
-        |> Enum.map(&Utils.get_beam_file/1)
-        |> Enum.filter(&is_list/1)
-      end)
+    modules_to_paths = for app <- @elixir_apps,
+    path <- Path.join([Application.app_dir(app), "**/*.beam"]) |> Path.wildcard(),
+    into: %{},
+    do:
+      {pathname_to_module(path), path |> String.to_charlist}
+
+    modules = modules_to_paths
+    |> Map.keys
+    |> expand_references
+
+    files = for mod <- modules,
+    path = modules_to_paths[mod] || Utils.get_beam_file(mod),
+    is_list(path),
+    do: path
 
     File.mkdir_p!(Path.dirname(elixir_plt_path()))
 

--- a/apps/language_server/lib/language_server/dialyzer/utils.ex
+++ b/apps/language_server/lib/language_server/dialyzer/utils.ex
@@ -25,7 +25,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Utils do
     String.to_atom(Path.basename(path, ".beam"))
   end
 
-  def expand_references(modules, exclude \\ [], result \\ MapSet.new())
+  def expand_references(modules, exclude \\ MapSet.new(), result \\ MapSet.new())
 
   def expand_references([], _, result) do
     result
@@ -60,8 +60,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Utils do
           forms
         )
 
-      modules = for {:call, _, {:remote, _, {:atom, _, module}, _}, _} <- calls, do: module
-      Enum.uniq(modules)
+      for {:call, _, {:remote, _, {:atom, _, module}, _}, _} <- calls, uniq: true, do: module
     rescue
       _ -> []
     catch


### PR DESCRIPTION
This PR:
- adds erts, kernel, stdlib and compiled apps to PLT
They were only partially included as elixir depends on some beams from those apps. dialyxir includes those as well by default. The downside is 10% bigger PLT. Those apps in turn depends on crypto, sasl, tools, hipe etc and parts of those are included but IMO it's not worth to include them in full.
- fixes non deterministic behaviour with consolidated protocols
As protocol and consolidated protocol share the same beam file name it was not clear which one will be analyzed. After this change not consolidated protocols are dropped. This is what dialyxir does (see https://github.com/jeremyjh/dialyxir/pull/299)
- fixes a performance issue in PLT build when the beams was analyzed by expand_references for every app
- avoids some unnecessary work by utilising for comprehensions instead of multiple passes