### PR TITLE
use ASDF_DIR variable to support Homebrew installs

### DIFF
--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -11,7 +11,9 @@
 
 did_relaunch=$1
 
-asdf_vm="${HOME}/.asdf/asdf.sh"
+ASDF_DIR=${ASDF_DIR:-"${HOME}/.asdf"}
+
+asdf_vm="${ASDF_DIR}/asdf.sh"
 if test -f "${asdf_vm}"
 then
   # asdf-vm does not support the plain posix shell. Figure out


### PR DESCRIPTION
Currently the `launch.sh` script will check for asdf in my home directory.
As I am a Homebrew user, my asdf got installed to `/usr/local/opt/asdf`.

For `launch.sh` to be able to detect it I've modified it for the use of `ASDF_DIR` if available and fall-back to the current behaviour if that's not set.

asdf will set the [`ASDF_DIR` (see upstream source)][1] variable when it initializes, so this seems to be a reliable way to detect all sorts of customized asdf installations.

[1]: https://github.com/asdf-vm/asdf/blob/master/asdf.sh#L14