### PR TITLE
Fix invalid value set in write_manifest_pid

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -125,7 +125,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
       if not is_nil(state.build_ref) do
         do_analyze(state)
       else
-        cancel_write_manifest(state)
+        maybe_cancel_write_manifest(state)
 
         {:ok, pid} =
           Manifest.write(state.root_path, active_plt, mod_deps, md5, warnings, timestamp)
@@ -192,7 +192,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
 
   defp do_analyze(state) do
     # Cancel writing to the manifest, since we'll end up overwriting it anyway
-    cancel_write_manifest(state)
+    maybe_cancel_write_manifest(state)
 
     parent = self()
     analysis_pid = spawn_link(fn -> compile(parent, state) end)
@@ -538,9 +538,9 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     :calendar.gregorian_seconds_to_datetime(seconds - 1)
   end
 
-  defp cancel_write_manifest(%{write_manifest_pid: nil}), do: :ok
+  defp maybe_cancel_write_manifest(%{write_manifest_pid: nil}), do: :ok
 
-  defp cancel_write_manifest(%{write_manifest_pid: pid}) do
+  defp maybe_cancel_write_manifest(%{write_manifest_pid: pid}) do
     Process.unlink(pid)
     Process.exit(pid, :kill)
   end

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -126,7 +126,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         do_analyze(state)
       else
         if state.write_manifest_pid, do: Process.exit(state.write_manifest_pid, :kill)
-        pid = Manifest.write(state.root_path, active_plt, mod_deps, md5, warnings, timestamp)
+        {:ok, pid} = Manifest.write(state.root_path, active_plt, mod_deps, md5, warnings, timestamp)
         %{state | write_manifest_pid: pid}
       end
 

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -19,7 +19,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   end
 
   def write(_, _, _, _, _, nil) do
-    nil
+    {:ok, nil}
   end
 
   def write(root_path, active_plt, mod_deps, md5, warnings, timestamp) do

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -82,7 +82,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
 
         assert_receive notification("window/logMessage", %{
                          "message" => "[ElixirLS Dialyzer] Analyzing 2 modules: [A, B]"
-                       }), 40000
+                       }),
+                       40000
 
         # Stop while we're still capturing logs to avoid log leakage
         GenServer.stop(server)

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -73,6 +73,7 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
 
         b_uri = SourceFile.path_to_uri("lib/b.ex")
         Server.receive_packet(server, did_open(b_uri, "elixir", 1, b_text))
+        Process.sleep(1500)
         File.write!("lib/b.ex", b_text)
 
         Server.receive_packet(server, did_save(b_uri))
@@ -81,7 +82,7 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
 
         assert_receive notification("window/logMessage", %{
                          "message" => "[ElixirLS Dialyzer] Analyzing 2 modules: [A, B]"
-                       })
+                       }), 40000
 
         # Stop while we're still capturing logs to avoid log leakage
         GenServer.stop(server)


### PR DESCRIPTION
Without fixing it
https://github.com/elixir-lsp/elixir-ls/blob/5b2d23622614b8470293cb7cadba530170f8f70f/apps/language_server/lib/language_server/dialyzer.ex#L128
will crash with ArgumentError and
https://github.com/elixir-lsp/elixir-ls/blob/5b2d23622614b8470293cb7cadba530170f8f70f/apps/language_server/lib/language_server/dialyzer.ex#L192
will have no effect, which was actually good as exiting a linked process will bring down the caller