### PR TITLE
Fix awaiting_contracts not getting responses

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -878,17 +878,16 @@ defmodule ElixirLS.LanguageServer.Server do
           state.source_files[uri].dirty?
         end)
 
-      contracts =
+      contracts_by_file =
         not_dirty
-        |> Enum.uniq()
         |> Enum.map(fn {_from, uri} -> SourceFile.path_from_uri(uri) end)
         |> Dialyzer.suggest_contracts()
+        |> Enum.group_by(fn {file, _, _, _, _} -> file end)
 
       for {from, uri} <- not_dirty do
         contracts =
-          Enum.filter(contracts, fn {file, _, _, _, _} ->
-            SourceFile.path_from_uri(uri) == file
-          end)
+          contracts_by_file
+          |> Map.get(SourceFile.path_from_uri(uri), [])
 
         GenServer.reply(from, contracts)
       end

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -874,9 +874,6 @@ defmodule ElixirLS.LanguageServer.Server do
 
       {dirty, not_dirty} =
         state.awaiting_contracts
-        |> Enum.filter(fn {_, uri} ->
-          state.source_files[uri] != nil
-        end)
         |> Enum.split_with(fn {_, uri} ->
           state.source_files[uri].dirty?
         end)


### PR DESCRIPTION
When editing the same file multiple entries would get inserted to awaiting_contracts list. This PR changes that behaviour to always respond to the previous request involving the same URI before we request a new one.
Besides that I removed a no longer necessary fix for https://github.com/JakeBecker/elixir-ls/issues/105 - source_files race conditions should no longer happen.