### PR TITLE
Don't use all of the available schedulers

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/cli.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/cli.ex
@@ -8,6 +8,7 @@ defmodule ElixirLS.Debugger.CLI do
     {:ok, _} = Application.ensure_all_started(:elixir_ls_debugger, :permanent)
     IO.puts("Started ElixirLS debugger v#{Launch.debugger_version()}")
     Launch.print_versions()
+    Launch.limit_num_schedulers()
     warn_if_unsupported_version()
     WireProtocol.stream_packets(&Server.receive_packet/1)
   end

--- a/apps/elixir_ls_utils/lib/launch.ex
+++ b/apps/elixir_ls_utils/lib/launch.ex
@@ -31,6 +31,16 @@ defmodule ElixirLS.Utils.Launch do
     get_version(:elixir_ls_debugger)
   end
 
+  def limit_num_schedulers do
+    case System.schedulers_online() do
+      num_schedulers when num_schedulers >= 4 ->
+        :erlang.system_flag(:schedulers_online, num_schedulers - 2)
+
+      _ ->
+        :ok
+    end
+  end
+
   defp get_version(app) do
     case :application.get_key(app, :vsn) do
       {:ok, version} -> List.to_string(version)

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -10,6 +10,7 @@ defmodule ElixirLS.LanguageServer.CLI do
 
     IO.puts("Started ElixirLS v#{Launch.language_server_version()}")
     Launch.print_versions()
+    Launch.limit_num_schedulers()
 
     Mix.shell(ElixirLS.LanguageServer.MixShell)
     # FIXME: Private API


### PR DESCRIPTION
This will make ElixirLS less resource-intensive because it isn't expected to be the only program running on the user's machine.

Fixes #96