### PR TITLE
add support for disabling automatic builds though a config

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -912,11 +912,12 @@ defmodule ElixirLS.LanguageServer.Server do
   # Build
 
   defp trigger_build(state = %__MODULE__{project_dir: project_dir}) do
+    build_automatically = Map.get(state.settings || %{}, "autoBuild", true)
     cond do
       not build_enabled?(state) ->
         state
 
-      not state.build_running? ->
+      not state.build_running? and build_automatically ->
         fetch_deps? = Map.get(state.settings || %{}, "fetchDeps", false)
 
         {_pid, build_ref} =


### PR DESCRIPTION
closes #341 

Adds a config check before starting a build in `trigger_build`.
I was hesitant to add it to `build_enabled` since it also seems to be used by `dialyzer_enabled`

I tried to follow what was outlined in this [comment](https://github.com/JakeBecker/elixir-ls/issues/120#issuecomment-482082613)

First PR on a language server, so any feedback is very welcome.
