### PR TITLE
Fix some test lenses bugs

### DIFF
--- a/apps/language_server/lib/language_server/providers/code_lens/test.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test.ex
@@ -123,6 +123,9 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
     lines_to_env
     |> Enum.group_by(fn {_line, env} -> env.module end)
     |> Enum.filter(fn {_module, module_lines_to_env} -> is_test_module?(module_lines_to_env) end)
+    |> Enum.map(fn {module, module_lines_to_env} ->
+      {module, Enum.sort_by(module_lines_to_env, &elem(&1, 0))}
+    end)
     |> Enum.map(fn {module, [{line, _env} | _rest]} -> {module, line} end)
   end
 

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -153,6 +153,141 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
            )
   end
 
+  test "returns module lens on the module declaration line in large files" do
+    uri = "file://project/file.ex"
+
+    text = """
+    defmodule ElixirLS.LanguageServer.DiagnosticsTest do
+      alias ElixirLS.LanguageServer.Diagnostics
+      use ExUnit.Case
+
+      describe "normalize/2" do
+        test "extract the stacktrace from the message and format it" do
+          root_path = Path.join(__DIR__, "fixtures/build_errors")
+          file = Path.join(root_path, "lib/has_error.ex")
+          position = 2
+
+          message = \"""
+          ** (CompileError) some message
+
+              Hint: Some hint
+              (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+              (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
+              (elixir 1.10.1) expanding macro: Kernel.|>/2
+              expanding macro: SomeModule.sigil_L/2
+              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+          \"""
+
+          [diagnostic | _] =
+            [build_diagnostic(message, file, position)]
+            |> Diagnostics.normalize(root_path)
+
+          assert diagnostic.message == \"""
+                 (CompileError) some message
+
+                     Hint: Some hint
+
+                 Stacktrace:
+                   │ (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+                   │ (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
+                   │ (elixir 1.10.1) expanding macro: Kernel.|>/2
+                   │ expanding macro: SomeModule.sigil_L/2
+                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+                 \"""
+        end
+
+        test "update file and position if file is present in the message" do
+          root_path = Path.join(__DIR__, "fixtures/build_errors")
+          file = Path.join(root_path, "lib/has_error.ex")
+          position = 2
+
+          message = \"""
+          ** (CompileError) lib/has_error.ex:3: some message
+              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+          \"""
+
+          [diagnostic | _] =
+            [build_diagnostic(message, file, position)]
+            |> Diagnostics.normalize(root_path)
+
+          assert diagnostic.message == \"""
+                 (CompileError) some message
+
+                 Stacktrace:
+                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+                 \"""
+
+          assert diagnostic.position == 3
+        end
+
+        test "update file and position if file is present in the message (umbrella)" do
+          root_path = Path.join(__DIR__, "fixtures/umbrella")
+          file = Path.join(root_path, "lib/file_to_be_replaced.ex")
+          position = 3
+
+          message = \"""
+          ** (CompileError) lib/app2.ex:5: some message
+              (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+          \"""
+
+          [diagnostic | _] =
+            [build_diagnostic(message, file, position)]
+            |> Diagnostics.normalize(root_path)
+
+          assert diagnostic.message =~ "(CompileError) some message"
+          assert diagnostic.file =~ "umbrella/apps/app2/lib/app2.ex"
+          assert diagnostic.position == 5
+        end
+
+        test "don't update file nor position if file in message does not exist" do
+          root_path = Path.join(__DIR__, "fixtures/build_errors_on_external_resource")
+          file = Path.join(root_path, "lib/has_error.ex")
+          position = 2
+
+          message = \"""
+          ** (CompileError) lib/non_existing.ex:3: some message
+              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+          \"""
+
+          [diagnostic | _] =
+            [build_diagnostic(message, file, position)]
+            |> Diagnostics.normalize(root_path)
+
+          assert diagnostic.message == \"""
+                 (CompileError) lib/non_existing.ex:3: some message
+
+                 Stacktrace:
+                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+                 \"""
+
+          assert diagnostic.position == 2
+        end
+
+        defp build_diagnostic(message, file, position) do
+          %Mix.Task.Compiler.Diagnostic{
+            compiler_name: "Elixir",
+            details: nil,
+            file: file,
+            message: message,
+            position: position,
+            severity: :error
+          }
+        end
+      end
+    end
+    """
+
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+
+    assert Enum.member?(
+             lenses,
+             build_code_lens(0, :module, "/file.ex", %{
+               "module" => ElixirLS.LanguageServer.DiagnosticsTest
+             })
+           )
+  end
+
   defp build_code_lens(line, target, file_path, args) do
     arguments =
       %{

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -153,139 +153,159 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
            )
   end
 
-  test "returns module lens on the module declaration line in large files" do
-    uri = "file://project/file.ex"
+  describe "in large files" do
+    setup do
+      text = """
+      defmodule ElixirLS.LanguageServer.DiagnosticsTest do
+        alias ElixirLS.LanguageServer.Diagnostics
+        use ExUnit.Case
 
-    text = """
-    defmodule ElixirLS.LanguageServer.DiagnosticsTest do
-      alias ElixirLS.LanguageServer.Diagnostics
-      use ExUnit.Case
+        describe "normalize/2" do
+          test "extract the stacktrace from the message and format it" do
+            root_path = Path.join(__DIR__, "fixtures/build_errors")
+            file = Path.join(root_path, "lib/has_error.ex")
+            position = 2
 
-      describe "normalize/2" do
-        test "extract the stacktrace from the message and format it" do
-          root_path = Path.join(__DIR__, "fixtures/build_errors")
-          file = Path.join(root_path, "lib/has_error.ex")
-          position = 2
+            message = \"""
+            ** (CompileError) some message
 
-          message = \"""
-          ** (CompileError) some message
+            Hint: Some hint
+            (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+            (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
+            (elixir 1.10.1) expanding macro: Kernel.|>/2
+            expanding macro: SomeModule.sigil_L/2
+            lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-              Hint: Some hint
-              (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
-              (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
-              (elixir 1.10.1) expanding macro: Kernel.|>/2
-              expanding macro: SomeModule.sigil_L/2
-              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-          \"""
+            [diagnostic | _] =
+              [build_diagnostic(message, file, position)]
+              |> Diagnostics.normalize(root_path)
 
-          [diagnostic | _] =
-            [build_diagnostic(message, file, position)]
-            |> Diagnostics.normalize(root_path)
+            assert diagnostic.message == \"""
+            (CompileError) some message
 
-          assert diagnostic.message == \"""
-                 (CompileError) some message
+            Hint: Some hint
 
-                     Hint: Some hint
+            Stacktrace:
+            │ (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+            │ (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
+            │ (elixir 1.10.1) expanding macro: Kernel.|>/2
+            │ expanding macro: SomeModule.sigil_L/2
+            │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
+          end
 
-                 Stacktrace:
-                   │ (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
-                   │ (stdlib 3.7.1) lists.erl:1263: :lists.foldl/3
-                   │ (elixir 1.10.1) expanding macro: Kernel.|>/2
-                   │ expanding macro: SomeModule.sigil_L/2
-                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-                 \"""
-        end
+          test "update file and position if file is present in the message" do
+            root_path = Path.join(__DIR__, "fixtures/build_errors")
+            file = Path.join(root_path, "lib/has_error.ex")
+            position = 2
 
-        test "update file and position if file is present in the message" do
-          root_path = Path.join(__DIR__, "fixtures/build_errors")
-          file = Path.join(root_path, "lib/has_error.ex")
-          position = 2
+            message = \"""
+            ** (CompileError) lib/has_error.ex:3: some message
+            lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-          message = \"""
-          ** (CompileError) lib/has_error.ex:3: some message
-              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-          \"""
+            [diagnostic | _] =
+              [build_diagnostic(message, file, position)]
+              |> Diagnostics.normalize(root_path)
 
-          [diagnostic | _] =
-            [build_diagnostic(message, file, position)]
-            |> Diagnostics.normalize(root_path)
+            assert diagnostic.message == \"""
+            (CompileError) some message
 
-          assert diagnostic.message == \"""
-                 (CompileError) some message
+            Stacktrace:
+            │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-                 Stacktrace:
-                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-                 \"""
+            assert diagnostic.position == 3
+          end
 
-          assert diagnostic.position == 3
-        end
+          test "update file and position if file is present in the message (umbrella)" do
+            root_path = Path.join(__DIR__, "fixtures/umbrella")
+            file = Path.join(root_path, "lib/file_to_be_replaced.ex")
+            position = 3
 
-        test "update file and position if file is present in the message (umbrella)" do
-          root_path = Path.join(__DIR__, "fixtures/umbrella")
-          file = Path.join(root_path, "lib/file_to_be_replaced.ex")
-          position = 3
+            message = \"""
+            ** (CompileError) lib/app2.ex:5: some message
+            (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
+            lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-          message = \"""
-          ** (CompileError) lib/app2.ex:5: some message
-              (elixir 1.10.1) lib/macro.ex:304: Macro.pipe/3
-              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-          \"""
+            [diagnostic | _] =
+              [build_diagnostic(message, file, position)]
+              |> Diagnostics.normalize(root_path)
 
-          [diagnostic | _] =
-            [build_diagnostic(message, file, position)]
-            |> Diagnostics.normalize(root_path)
+            assert diagnostic.message =~ "(CompileError) some message"
+            assert diagnostic.file =~ "umbrella/apps/app2/lib/app2.ex"
+            assert diagnostic.position == 5
+          end
 
-          assert diagnostic.message =~ "(CompileError) some message"
-          assert diagnostic.file =~ "umbrella/apps/app2/lib/app2.ex"
-          assert diagnostic.position == 5
-        end
+          test "don't update file nor position if file in message does not exist" do
+            root_path = Path.join(__DIR__, "fixtures/build_errors_on_external_resource")
+            file = Path.join(root_path, "lib/has_error.ex")
+            position = 2
 
-        test "don't update file nor position if file in message does not exist" do
-          root_path = Path.join(__DIR__, "fixtures/build_errors_on_external_resource")
-          file = Path.join(root_path, "lib/has_error.ex")
-          position = 2
+            message = \"""
+            ** (CompileError) lib/non_existing.ex:3: some message
+            lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-          message = \"""
-          ** (CompileError) lib/non_existing.ex:3: some message
-              lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-          \"""
+            [diagnostic | _] =
+              [build_diagnostic(message, file, position)]
+              |> Diagnostics.normalize(root_path)
 
-          [diagnostic | _] =
-            [build_diagnostic(message, file, position)]
-            |> Diagnostics.normalize(root_path)
+            assert diagnostic.message == \"""
+            (CompileError) lib/non_existing.ex:3: some message
 
-          assert diagnostic.message == \"""
-                 (CompileError) lib/non_existing.ex:3: some message
+            Stacktrace:
+            │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
+            \"""
 
-                 Stacktrace:
-                   │ lib/my_app/my_module.ex:10: MyApp.MyModule.render/1
-                 \"""
+            assert diagnostic.position == 2
+          end
 
-          assert diagnostic.position == 2
-        end
-
-        defp build_diagnostic(message, file, position) do
-          %Mix.Task.Compiler.Diagnostic{
-            compiler_name: "Elixir",
-            details: nil,
-            file: file,
-            message: message,
-            position: position,
-            severity: :error
-          }
+          defp build_diagnostic(message, file, position) do
+            %Mix.Task.Compiler.Diagnostic{
+              compiler_name: "Elixir",
+              details: nil,
+              file: file,
+              message: message,
+              position: position,
+              severity: :error
+            }
+          end
         end
       end
+      """
+
+      %{text: text}
     end
-    """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    test "returns module lens on the module declaration line", %{text: text} do
+      uri = "file://project/file.ex"
 
-    assert Enum.member?(
-             lenses,
-             build_code_lens(0, :module, "/file.ex", %{
-               "module" => ElixirLS.LanguageServer.DiagnosticsTest
-             })
-           )
+      {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+
+      assert Enum.member?(
+               lenses,
+               build_code_lens(0, :module, "/file.ex", %{
+                 "module" => ElixirLS.LanguageServer.DiagnosticsTest
+               })
+             )
+    end
+
+    test "returns test lenses with describe info", %{text: text} do
+      uri = "file://project/file.ex"
+
+      {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+
+      assert Enum.member?(
+               lenses,
+               build_code_lens(5, :test, "/file.ex", %{
+                 "testName" => "extract the stacktrace from the message and format it",
+                 "describe" => "normalize/2"
+               })
+             )
+    end
   end
 
   defp build_code_lens(line, target, file_path, args) do


### PR DESCRIPTION
A few parts of the test lenses generation assumed that the environment information received from elixir_sense was sorted, but that was not always the case as the info is returned as a map.

Sorting the list from the start should fix issues 2 and 4 from #438.