### PR TITLE
Make wrapper script more robust

### DIFF
--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 # Launches the language server. This script must be in the same directory as the compiled .ez archives.
 
-dir=$(dirname "$0")
+readlink_f () {
+  cd "$(dirname "$1")" > /dev/null
+  filename="$(basename "$1")"
+  if [ -h "$filename" ]; then
+    readlink_f "$(readlink "$filename")"
+  else
+    echo "$(pwd -P)/$filename"
+  fi
+}
+
+dir=$(dirname $(readlink_f "$0"))
 
 export ELS_MODE=language_server
 export ELS_SCRIPT="ElixirLS.LanguageServer.CLI.main()"


### PR DESCRIPTION
This makes a setup possible in which a symlink points to the file
(e.g. /usr/local/bin/elixir-ls -> /opt/elixir-ls/language_server.sh).