### PR TITLE
Improve debugger stability

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/cli.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/cli.ex
@@ -6,6 +6,7 @@ defmodule ElixirLS.Debugger.CLI do
     WireProtocol.intercept_output(&Output.print/1, &Output.print_err/1)
     Launch.start_mix()
     {:ok, _} = Application.ensure_all_started(:elixir_ls_debugger, :permanent)
+
     IO.puts("Started ElixirLS debugger v#{Launch.debugger_version()}")
     Launch.print_versions()
     Launch.limit_num_schedulers()

--- a/apps/elixir_ls_debugger/lib/debugger/output.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/output.ex
@@ -51,16 +51,17 @@ defmodule ElixirLS.Debugger.Output do
   end
 
   def handle_call({:send_error_response, request_packet, message, format, variables}, _from, seq) do
-    res = WireProtocol.send(
-      error_response(
-        seq,
-        request_packet["seq"],
-        request_packet["command"],
-        message,
-        format,
-        variables
+    res =
+      WireProtocol.send(
+        error_response(
+          seq,
+          request_packet["seq"],
+          request_packet["command"],
+          message,
+          format,
+          variables
+        )
       )
-    )
 
     {:reply, res, seq + 1}
   end

--- a/apps/elixir_ls_debugger/lib/debugger/output.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/output.ex
@@ -7,7 +7,7 @@ defmodule ElixirLS.Debugger.Output do
   are sent with sequence numbers that are unique and sequential, and includes client functions for
   sending these messages.
   """
-  import ElixirLS.Utils.WireProtocol, only: [send: 1]
+  alias ElixirLS.Utils.WireProtocol
   use GenServer
   use ElixirLS.Debugger.Protocol
 
@@ -29,12 +29,12 @@ defmodule ElixirLS.Debugger.Output do
     GenServer.call(server, {:send_event, event, body})
   end
 
-  def print(server \\ __MODULE__, str) do
-    send_event(server, "output", %{"category" => "stdout", "output" => to_string(str)})
+  def print(server \\ __MODULE__, str) when is_binary(str) do
+    send_event(server, "output", %{"category" => "stdout", "output" => str})
   end
 
-  def print_err(server \\ __MODULE__, str) do
-    send_event(server, "output", %{"category" => "stderr", "output" => to_string(str)})
+  def print_err(server \\ __MODULE__, str) when is_binary(str) do
+    send_event(server, "output", %{"category" => "stderr", "output" => str})
   end
 
   ## Server callbacks
@@ -46,12 +46,12 @@ defmodule ElixirLS.Debugger.Output do
 
   @impl GenServer
   def handle_call({:send_response, request_packet, body}, _from, seq) do
-    send(response(seq, request_packet["seq"], request_packet["command"], body))
-    {:reply, :ok, seq + 1}
+    res = WireProtocol.send(response(seq, request_packet["seq"], request_packet["command"], body))
+    {:reply, res, seq + 1}
   end
 
   def handle_call({:send_error_response, request_packet, message, format, variables}, _from, seq) do
-    send(
+    res = WireProtocol.send(
       error_response(
         seq,
         request_packet["seq"],
@@ -62,11 +62,11 @@ defmodule ElixirLS.Debugger.Output do
       )
     )
 
-    {:reply, :ok, seq + 1}
+    {:reply, res, seq + 1}
   end
 
   def handle_call({:send_event, event, body}, _from, seq) do
-    send(event(seq, event, body))
-    {:reply, :ok, seq + 1}
+    res = WireProtocol.send(event(seq, event, body))
+    {:reply, res, seq + 1}
   end
 end

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -505,7 +505,7 @@ defmodule ElixirLS.Debugger.Server do
   end
 
   defp remove_paused_process(state = %__MODULE__{}, pid) do
-    {process = %PausedProcess{}, paused_processes} = Map.pop!(state.paused_processes, pid)
+    {process = %PausedProcess{}, paused_processes} = Map.pop(state.paused_processes, pid)
     true = Process.demonitor(process.ref, [:flush])
     %__MODULE__{state | paused_processes: paused_processes}
   end

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -341,7 +341,12 @@ defmodule ElixirLS.Debugger.Server do
     pid = state.threads[thread_id]
     state = remove_paused_process(state, pid)
 
-    :int.next(pid)
+    try do
+      :int.next(pid)
+    rescue
+      e in MatchError ->
+        IO.warn ":int.next failed, #{Exception.message(e)}"
+    end
     {%{}, state}
   end
 
@@ -349,7 +354,12 @@ defmodule ElixirLS.Debugger.Server do
     pid = state.threads[thread_id]
     state = remove_paused_process(state, pid)
 
-    :int.step(pid)
+    try do
+      :int.step(pid)
+    rescue
+      e in MatchError ->
+        IO.warn ":int.step failed, #{Exception.message(e)}"
+    end
     {%{}, state}
   end
 
@@ -357,7 +367,12 @@ defmodule ElixirLS.Debugger.Server do
     pid = state.threads[thread_id]
     state = remove_paused_process(state, pid)
 
-    :int.finish(pid)
+    try do
+      :int.finish(pid)
+    rescue
+      e in MatchError ->
+        IO.warn ":int.finish failed, #{Exception.message(e)}"
+    end
     {%{}, state}
   end
 

--- a/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
@@ -6,7 +6,7 @@ defmodule ElixirLS.Debugger.Stacktrace do
   defmodule Frame do
     defstruct [:level, :file, :module, :function, :args, :line, :bindings]
 
-    def name(frame) do
+    def name(%__MODULE__{} = frame) do
       "#{inspect(frame.module)}.#{frame.function}/#{Enum.count(frame.args)}"
     end
   end

--- a/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
@@ -52,7 +52,7 @@ defmodule ElixirLS.Debugger.Stacktrace do
         [first_frame | other_frames]
 
       error ->
-        IO.warn("Failed to obtain meta pid for #{inspect(pid)}: #{error}")
+        IO.warn("Failed to obtain meta pid for #{inspect(pid)}: #{inspect(error)}")
         []
     end
   end

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -386,7 +386,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                        "allThreadsStopped" => false,
                        "reason" => "breakpoint",
                        "threadId" => thread_id
-                     })
+                     }), 500
 
       assert_receive event(_, "thread", %{
                        "reason" => "exited",

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -227,7 +227,8 @@ defmodule ElixirLS.Debugger.ServerTest do
       )
 
       assert_receive(
-        response(_, 3, "setBreakpoints", %{"breakpoints" => [%{"verified" => true}]}), 1000
+        response(_, 3, "setBreakpoints", %{"breakpoints" => [%{"verified" => true}]}),
+        1000
       )
 
       Server.receive_packet(server, request(4, "setExceptionBreakpoints", %{"filters" => []}))

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -386,7 +386,8 @@ defmodule ElixirLS.Debugger.ServerTest do
                        "allThreadsStopped" => false,
                        "reason" => "breakpoint",
                        "threadId" => thread_id
-                     }), 500
+                     }),
+                     500
 
       assert_receive event(_, "thread", %{
                        "reason" => "exited",

--- a/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
+++ b/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
@@ -6,4 +6,26 @@ defmodule MixProject do
   def double(y) do
     2 * y
   end
+
+  def exit do
+    Task.start(fn ->
+      Task.start_link(fn ->
+        Process.sleep(1000)
+        raise ArgumentError
+      end)
+
+      Process.sleep(:infinity)
+    end)
+
+    Process.sleep(:infinity)
+  end
+
+  def exit_self do
+    Task.start_link(fn ->
+      Process.sleep(1000)
+      raise ArgumentError
+    end)
+
+    Process.sleep(:infinity)
+  end
 end

--- a/apps/elixir_ls_utils/lib/output_device.ex
+++ b/apps/elixir_ls_utils/lib/output_device.ex
@@ -32,19 +32,7 @@ defmodule ElixirLS.Utils.OutputDevice do
   end
 
   @impl GenServer
-  def handle_info({:io_request, from, reply_as, {:put_chars, characters}}, s) do
-    output(from, reply_as, characters, s)
-    {:noreply, s}
-  end
-
-  @impl GenServer
   def handle_info({:io_request, from, reply_as, {:put_chars, _encoding, module, func, args}}, s) do
-    output(from, reply_as, apply(module, func, args), s)
-    {:noreply, s}
-  end
-
-  @impl GenServer
-  def handle_info({:io_request, from, reply_as, {:put_chars, module, func, args}}, s) do
     output(from, reply_as, apply(module, func, args), s)
     {:noreply, s}
   end

--- a/apps/elixir_ls_utils/lib/output_device.ex
+++ b/apps/elixir_ls_utils/lib/output_device.ex
@@ -1,7 +1,7 @@
 defmodule ElixirLS.Utils.OutputDevice do
   @moduledoc """
   Intercepts IO request messages and forwards them to the Output server to be sent as events to
-  the IDE.
+  the IDE. Implements Erlang I/O Protocol https://erlang.org/doc/apps/stdlib/io_protocol.html
 
   In order to send console output to Visual Studio Code, the debug adapter needs to send events
   using the usual wire protocol. In order to intercept the debugged code's output, we replace the
@@ -10,53 +10,97 @@ defmodule ElixirLS.Utils.OutputDevice do
   server with the correct category ("stdout" or "stderr").
   """
 
-  use GenServer
-
   ## Client API
 
-  def start_link(device, output_fn, opts \\ []) do
-    GenServer.start_link(__MODULE__, {device, output_fn}, opts)
+  def start_link(device, output_fn) do
+    Task.start_link(fn -> loop({device, output_fn}) end)
   end
 
-  ## Server callbacks
+  ## Implementation
 
-  @impl GenServer
-  def init({device, output_fn}) do
-    {:ok, {device, output_fn}}
-  end
+  defp loop(state) do
+    receive do
+      {:io_request, from, reply_as, request} ->
+        result = io_request(request, state, reply_as)
+        send(from, {:io_reply, reply_as, result})
 
-  @impl GenServer
-  def handle_info({:io_request, from, reply_as, {:put_chars, _encoding, characters}}, s) do
-    output(from, reply_as, characters, s)
-    {:noreply, s}
-  end
-
-  @impl GenServer
-  def handle_info({:io_request, from, reply_as, {:put_chars, _encoding, module, func, args}}, s) do
-    output(from, reply_as, apply(module, func, args), s)
-    {:noreply, s}
-  end
-
-  @impl GenServer
-  def handle_info({:io_request, from, reply_as, {:requests, reqs}}, s) do
-    for req <- reqs do
-      handle_info({:io_request, from, reply_as, req}, s)
+        loop(state)
     end
-
-    {:noreply, s}
   end
 
-  # Any other message (get_geometry, set_opts, etc.) goes directly to original device
-  @impl GenServer
-  def handle_info(msg, {device, _} = s) do
-    send(device, msg)
-    {:noreply, s}
+  defp send_to_output(encoding, characters, {_device, output_fn}) do
+    # convert to unicode binary if necessary
+    case wrap_characters_to_binary(characters, encoding) do
+      binary when is_binary(binary) ->
+        output_fn.(binary)
+
+      _ ->
+        {:error, :put_chars}
+    end
   end
 
-  ## Helpers
+  defp io_request({:put_chars, encoding, characters}, state, _reply_as) do
+    send_to_output(encoding, characters, state)
+  end
 
-  defp output(from, reply_as, characters, {_, output_fn}) do
-    output_fn.(IO.iodata_to_binary(characters))
-    send(from, {:io_reply, reply_as, :ok})
+  defp io_request({:put_chars, encoding, module, func, args}, state, _reply_as) do
+    # apply mfa to get binary or list
+    # return error in other cases
+    try do
+      case apply(module, func, args) do
+        characters when is_list(characters) or is_binary(characters) ->
+          send_to_output(encoding, characters, state)
+
+        _ ->
+          {:error, :put_chars}
+      end
+    catch
+      _, _ -> {:error, :put_chars}
+    end
+  end
+
+  defp io_request({:requests, list}, state, reply_as) do
+    # process request sequentially until error or end of data
+    # return last result
+    case io_requests(list, {:ok, :ok}, state, reply_as) do
+      :ok -> :ok
+      {:error, error} -> {:error, error}
+      other -> {:ok, other}
+    end
+  end
+
+  defp io_request(unknown, {device, _output_fn}, reply_as) do
+    # forward requests to underlying device
+    send(device, {:io_request, self(), reply_as, unknown})
+
+    receive do
+      {:io_reply, ^reply_as, reply} -> reply
+    end
+  end
+
+  defp io_requests(_, {:error, error}, _, _), do: {:error, error}
+
+  defp io_requests([request | rest], _, state, reply_as) do
+    result = io_request(request, state, reply_as)
+    io_requests(rest, result, state, reply_as)
+  end
+
+  defp io_requests([], result, _, _), do: result
+
+  defp wrap_characters_to_binary(bin, :unicode) when is_binary(bin), do: bin
+
+  defp wrap_characters_to_binary(chars, from) do
+    # :unicode.characters_to_binary may throw, return error or incomplete result
+    try do
+      case :unicode.characters_to_binary(chars, from, :unicode) do
+        bin when is_binary(bin) ->
+          bin
+
+        _ ->
+          :error
+      end
+    catch
+      _, _ -> :error
+    end
   end
 end

--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -29,7 +29,8 @@ defmodule ElixirLS.Utils.WireProtocol do
   def intercept_output(print_fn, print_err_fn) do
     raw_user = Process.whereis(:user)
     raw_standard_error = Process.whereis(:standard_error)
-    :ok = :io.setopts(raw_user, binary: true, encoding: :latin1)
+
+    :ok = :io.setopts(raw_user, OutputDevice.get_opts())
 
     {:ok, user} = OutputDevice.start_link(raw_user, print_fn)
     {:ok, standard_error} = OutputDevice.start_link(raw_user, print_err_fn)

--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -32,7 +32,7 @@ defmodule ElixirLS.Utils.WireProtocol do
     :ok = :io.setopts(raw_user, binary: true, encoding: :latin1)
 
     {:ok, user} = OutputDevice.start_link(raw_user, print_fn)
-    {:ok, standard_error} = OutputDevice.start_link(raw_standard_error, print_err_fn)
+    {:ok, standard_error} = OutputDevice.start_link(raw_user, print_err_fn)
 
     Process.unregister(:user)
     Process.register(raw_user, :raw_user)

--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -10,19 +10,12 @@ defmodule ElixirLS.Utils.WireProtocol do
     pid = io_dest()
     body = JasonVendored.encode_to_iodata!(packet)
 
-    case IO.binwrite(pid, [
-           "Content-Length: ",
-           IO.iodata_length(body) |> Integer.to_string(),
-           @separator,
-           body
-         ]) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        IO.warn("Unable to write to the device: #{inspect(reason)}")
-        :ok
-    end
+    IO.binwrite(pid, [
+      "Content-Length: ",
+      IO.iodata_length(body) |> Integer.to_string(),
+      @separator,
+      body
+    ])
   end
 
   defp io_dest do

--- a/apps/elixir_ls_utils/test/output_device_test.exs
+++ b/apps/elixir_ls_utils/test/output_device_test.exs
@@ -1,0 +1,256 @@
+defmodule ElixirLS.Utils.OutputDeviceTest do
+  use ExUnit.Case, async: false
+
+  alias ElixirLS.Utils.OutputDevice
+
+  defmodule FakeOutput do
+    use GenServer
+
+    def start_link(args) do
+      GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    end
+
+    def set_responses(responses) do
+      GenServer.call(__MODULE__, {:set_responses, responses})
+    end
+
+    def get_requests() do
+      GenServer.call(__MODULE__, :get_requests)
+    end
+
+    @impl GenServer
+    def init(_) do
+      {:ok, {[], []}}
+    end
+
+    @impl GenServer
+    def handle_call({:set_responses, responses}, _from, _state) do
+      {:reply, :ok, {[], responses}}
+    end
+
+    def handle_call(:get_requests, _from, state = {requests, _}) do
+      {:reply, requests |> Enum.reverse(), state}
+    end
+
+    @impl GenServer
+    def handle_info({:io_request, from, reply_as, req}, {requests, [resp | responses]}) do
+      send(from, {:io_reply, reply_as, resp})
+      {:noreply, {[req | requests], responses}}
+    end
+  end
+
+  defmodule FakeWireProtocol do
+    use GenServer
+
+    def start_link(args) do
+      GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    end
+
+    def send(msg) do
+      GenServer.call(__MODULE__, {:send, msg})
+    end
+
+    def get() do
+      GenServer.call(__MODULE__, :get)
+    end
+
+    @impl GenServer
+    def init(_), do: {:ok, []}
+
+    @impl GenServer
+    def handle_call({:send, msg}, _from, state) do
+      {:reply, :ok, [msg | state]}
+    end
+
+    def handle_call(:get, _from, state) do
+      {:reply, state |> Enum.reverse(), state}
+    end
+  end
+
+  setup do
+    {:ok, fake_user} = FakeOutput.start_link([])
+    {:ok, fake_wire_protocol} = FakeWireProtocol.start_link([])
+    {:ok, output_device} = OutputDevice.start_link(fake_user, &FakeWireProtocol.send/1)
+
+    {:ok,
+     %{
+       output_device: output_device,
+       fake_wire_protocol: fake_wire_protocol,
+       fake_user: fake_user
+     }}
+  end
+
+  test "passes optional io_request to underlying device", %{
+    output_device: output_device
+  } do
+    FakeOutput.set_responses([[:some_opt], {:error, :enotsup}])
+
+    send(output_device, {:io_request, self(), 123, :getopts})
+    assert_receive({:io_reply, 123, [:some_opt]})
+
+    send(output_device, {:io_request, self(), 123, {:setopts, [:abc]}})
+    assert_receive({:io_reply, 123, {:error, :enotsup}})
+
+    assert FakeOutput.get_requests() == [:getopts, {:setopts, [:abc]}]
+  end
+
+  describe "handles multi requests" do
+    test "all passed, all succeed, last response returned naked `:ok`", %{
+      output_device: output_device
+    } do
+      FakeOutput.set_responses([:ok, :ok])
+
+      requests = [
+        {:setopts, [:abc]},
+        {:setopts, [:cde]}
+      ]
+
+      send(output_device, {:io_request, self(), 123, {:requests, requests}})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeOutput.get_requests() == [{:setopts, [:abc]}, {:setopts, [:cde]}]
+    end
+
+    test "all passed, all succeed, last response returned wrapped", %{
+      output_device: output_device
+    } do
+      FakeOutput.set_responses([:ok, [:abc]])
+
+      requests = [
+        {:setopts, [:abc]},
+        :getopts
+      ]
+
+      send(output_device, {:io_request, self(), 123, {:requests, requests}})
+      assert_receive({:io_reply, 123, {:ok, [:abc]}})
+
+      assert FakeOutput.get_requests() == [{:setopts, [:abc]}, :getopts]
+    end
+
+    test "all passed, error breaks processing, last response returned", %{
+      output_device: output_device
+    } do
+      FakeOutput.set_responses([{:error, :notsup}])
+
+      requests = [
+        {:setopts, [:abc]},
+        :getopts
+      ]
+
+      send(output_device, {:io_request, self(), 123, {:requests, requests}})
+      assert_receive({:io_reply, 123, {:error, :notsup}})
+
+      assert FakeOutput.get_requests() == [{:setopts, [:abc]}]
+    end
+  end
+
+  def get_chars_list("abc"), do: 'some'
+  def get_chars_binary("abc"), do: "some"
+  def get_chars_invalid("abc"), do: :some
+  def get_chars_raise("abc"), do: raise(ArgumentError)
+  def get_chars_throw("abc"), do: throw(:foo)
+
+  describe "put_chars mfa" do
+    test "mfa list", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, __MODULE__, :get_chars_list, ["abc"]}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["some"]
+    end
+
+    test "mfa binary", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, __MODULE__, :get_chars_binary, ["abc"]}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["some"]
+    end
+
+    test "mfa invalid result", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, __MODULE__, :get_chars_invalid, ["abc"]}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, {:error, :put_chars}})
+
+      assert FakeWireProtocol.get() == []
+    end
+
+    test "mfa throw", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, __MODULE__, :get_chars_throw, ["abc"]}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, {:error, :put_chars}})
+
+      assert FakeWireProtocol.get() == []
+    end
+
+    test "mfa raise", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, __MODULE__, :get_chars_raise, ["abc"]}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, {:error, :put_chars}})
+
+      assert FakeWireProtocol.get() == []
+    end
+  end
+
+  describe "put_chars" do
+    test "unicode binary", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, "sąme👨‍👩‍👦"}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["sąme👨‍👩‍👦"]
+    end
+
+    test "unicode list", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :unicode, 'sąme👨‍👩‍👦'}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["sąme👨‍👩‍👦"]
+    end
+
+    test "latin1 binary", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :latin1, "some"}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["some"]
+    end
+
+    test "latin1 list", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :latin1, 'some'}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, :ok})
+
+      assert FakeWireProtocol.get() == ["some"]
+    end
+
+    test "latin1 list with chars > 255", %{
+      output_device: output_device
+    } do
+      request = {:put_chars, :latin1, 'sąme👨‍👩‍👦'}
+      send(output_device, {:io_request, self(), 123, request})
+      assert_receive({:io_reply, 123, {:error, :put_chars}})
+
+      assert FakeWireProtocol.get() == []
+    end
+  end
+end

--- a/apps/language_server/lib/language_server/json_rpc.ex
+++ b/apps/language_server/lib/language_server/json_rpc.ex
@@ -108,12 +108,12 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
   end
 
   # Used to intercept :user/:standard_io output
-  def print(str) do
+  def print(str) when is_binary(str) do
     log_message(:log, String.replace_suffix(str, "\n", ""))
   end
 
   # Used to intercept :standard_error output
-  def print_err(str) do
+  def print_err(str) when is_binary(str) do
     log_message(:warning, String.replace_suffix(str, "\n", ""))
   end
 


### PR DESCRIPTION
This PR introduces stability and reliability improvements to debugger.
- I added some safe checking in the debugger code
- Made the server not crash when handling invalid request (e.g. when threadId, variablesReference or frameId is not found)
- Adds handling of `:int` module crashes. Some operations crash with `MatchError` when the operation results in a step out of interpreted code
- Made debugger aware of process exits. If a paused process dies now the debugger is notified and able to send `thread` event with reason `exited`. vscode UI is no longer stuck in paused state
- Refactored and added tests to `OutputDevice`. The module now now more closely adheres to erlang I/O protocol (see https://erlang.org/doc/apps/stdlib/io_protocol.html). Most importantly:
  - handling of encoding was broken - no care was taken to check if data is unicode or latin1
  - in case of multiple requests the protocol expects only one response and that processing is stopped on first error - all responses was returned

Fixes #452
Fixes #454
Fixes #455
Fixes #456