### PR TITLE
Make launcher easier wrappable for different install locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ accomplished by adding `>/dev/null` and/or `2>/dev/null` at the end of any line 
 output, and for a windows batch script you will want `@echo off` at the top and `>nul` on every
 line.
 
+## Environment variables
+
+* `ELS_INSTALL_PREFIX`: The folder where the language server got installed to. If set eq. through a wrapper script, it makes maintaining multiple versions/instances on the same host much easier. If not set or empty, a heuristic will be used to discover the install location.
+
 ## Acknowledgements and related projects
 
 ElixirLS isn't the first frontend-independent server for Elixir language support. The original was [Alchemist Server](https://github.com/tonini/alchemist-server/), which powers the [Alchemist](https://github.com/tonini/alchemist.el) plugin for Emacs. Another project, [Elixir Sense](https://github.com/elixir-lsp/elixir_sense), builds upon Alchemist and powers the [Elixir plugin for Atom](https://github.com/msaraiva/atom-elixir) as well as another VS Code plugin, [VSCode Elixir](https://github.com/fr1zle/vscode-elixir). ElixirLS uses Elixir Sense for several code insight features. Credit for those projects goes to their respective authors.

--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # Launches the debugger. This script must be in the same directory as the compiled .ez archives.
 
-dir=$(dirname "$0")
+if [ -z "${ELS_INSTALL_PREFIX}" ]; then
+  dir=$(dirname $(readlink_f "$0"))
+else
+  dir=${ELS_INSTALL_PREFIX}
+fi
 
 export ELS_MODE=debugger
 export ELS_SCRIPT="ElixirLS.Debugger.CLI.main()"

--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -2,7 +2,7 @@
 # Launches the debugger. This script must be in the same directory as the compiled .ez archives.
 
 if [ -z "${ELS_INSTALL_PREFIX}" ]; then
-  dir=$(dirname $(readlink_f "$0"))
+  dir=$(dirname "$0")
 else
   dir=${ELS_INSTALL_PREFIX}
 fi

--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # Launches the language server. This script must be in the same directory as the compiled .ez archives.
 
-dir=$(dirname "$0")
+if [ -z "${ELS_INSTALL_PREFIX}" ]; then
+  dir=$(dirname "$0")
+else
+  dir=${ELS_INSTALL_PREFIX}
+fi
 
 export ELS_MODE=language_server
 export ELS_SCRIPT="ElixirLS.LanguageServer.CLI.main()"

--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -61,8 +61,12 @@ readlink_f () {
   fi
 }
 
-SCRIPT=$(readlink_f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
+if [ -z "${ELS_INSTALL_PREFIX}" ]; then
+  SCRIPT=$(readlink_f "$0")
+  SCRIPTPATH=$(dirname "$SCRIPT")
+else
+  SCRIPTPATH=${ELS_INSTALL_PREFIX}
+fi
 export ERL_LIBS="$SCRIPTPATH:$ERL_LIBS"
 
 exec elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none"  -e "$ELS_SCRIPT"

--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -67,6 +67,7 @@ if [ -z "${ELS_INSTALL_PREFIX}" ]; then
 else
   SCRIPTPATH=${ELS_INSTALL_PREFIX}
 fi
+
 export ERL_LIBS="$SCRIPTPATH:$ERL_LIBS"
 
 exec elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none"  -e "$ELS_SCRIPT"


### PR DESCRIPTION
This makes the elixir-ls scripts check the `$ELS_INSTALL_PREFIX`
variable to know where the LSP got installed.

This change makes it easier for external packagers to install ExLS to
locations appropriate to their packaging system, as then all they need
to do is to provide a small wrapper script that adjusts the
aforementioned variable in the environment.

The launcher will fall back to its default behaviour if the variable
is unset/empty in the environment.

- [X] Change the launcher script to accept the new variable
- [ ] document its existence and usage in the README
