### PR TITLE
Make wrapper script more robust... more robustly

### DIFF
--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 # Launches the debugger. This script must be in the same directory as the compiled .ez archives.
 
+readlink_f () {
+  cd "$(dirname "$1")" > /dev/null || exit 1
+  filename="$(basename "$1")"
+  if [ -h "$filename" ]; then
+    readlink_f "$(readlink "$filename")"
+  else
+    echo "$(pwd -P)/$filename"
+  fi
+}
+
 if [ -z "${ELS_INSTALL_PREFIX}" ]; then
-  dir=$(dirname "$0")
+  dir="$(dirname "$(readlink_f "$0")")"
 else
   dir=${ELS_INSTALL_PREFIX}
 fi

--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 # Launches the language server. This script must be in the same directory as the compiled .ez archives.
 
+readlink_f () {
+  cd "$(dirname "$1")" > /dev/null || exit 1
+  filename="$(basename "$1")"
+  if [ -h "$filename" ]; then
+    readlink_f "$(readlink "$filename")"
+  else
+    echo "$(pwd -P)/$filename"
+  fi
+}
+
 if [ -z "${ELS_INSTALL_PREFIX}" ]; then
-  dir=$(dirname "$0")
+  dir="$(dirname "$(readlink_f "$0")")"
 else
   dir=${ELS_INSTALL_PREFIX}
 fi

--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -52,7 +52,7 @@ fi
 # include the local .ez files, and then do what we were asked to do.
 
 readlink_f () {
-  cd "$(dirname "$1")" > /dev/null
+  cd "$(dirname "$1")" > /dev/null || exit 1
   filename="$(basename "$1")"
   if [ -h "$filename" ]; then
     readlink_f "$(readlink "$filename")"


### PR DESCRIPTION
This makes a setup possible in which a symlink points to the file (e.g. /usr/local/bin/elixir-ls -> /opt/elixir-ls/language_server.sh).

It's a rehash of a previous PR (#445) that was reverted since it broke setups where the language server was installed in a path containing spaces (e.g. /opt/Elixir Language Server/). This variant takes that possibility into account.

Hopefully, this fixes #470.