### PR TITLE
Adds a "projectDir" arg to test code lenses

### DIFF
--- a/apps/language_server/lib/language_server/providers/code_lens.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens.ex
@@ -13,7 +13,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens do
   def spec_code_lens(server_instance_id, uri, text),
     do: CodeLens.TypeSpec.code_lens(server_instance_id, uri, text)
 
-  def test_code_lens(uri, text), do: CodeLens.Test.code_lens(uri, text)
+  def test_code_lens(uri, text, project_dir), do: CodeLens.Test.code_lens(uri, text, project_dir)
 
   def build_code_lens(line, title, command, argument) do
     %{

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -796,7 +796,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp get_test_code_lenses(state, uri, source_file) do
     if state.settings["enableTestLenses"] == true do
-      CodeLens.test_code_lens(uri, source_file.text)
+      CodeLens.test_code_lens(uri, source_file.text, state.project_dir)
     else
       {:ok, []}
     end

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -4,6 +4,8 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
   import ElixirLS.LanguageServer.Test.PlatformTestHelpers
   alias ElixirLS.LanguageServer.Providers.CodeLens
 
+  @project_dir "/project"
+
   setup context do
     ElixirLS.LanguageServer.Build.load_all_modules()
 
@@ -29,7 +31,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert lenses ==
              [
@@ -55,7 +57,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert lenses ==
              [
@@ -76,7 +78,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert lenses == []
   end
@@ -96,7 +98,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert Enum.member?(
              lenses,
@@ -128,7 +130,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert Enum.member?(
              lenses,
@@ -159,7 +161,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
     """
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert Enum.member?(
              lenses,
@@ -300,7 +302,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     test "returns module lens on the module declaration line", %{text: text} do
       uri = "file:///project/file.ex"
 
-      {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+      {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
       assert Enum.member?(
                lenses,
@@ -313,7 +315,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     test "returns test lenses with describe info", %{text: text} do
       uri = "file:///project/file.ex"
 
-      {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+      {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
       assert Enum.member?(
                lenses,
@@ -328,7 +330,8 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
   defp build_code_lens(line, target, file_path, args) do
     arguments =
       %{
-        "filePath" => file_path
+        "filePath" => file_path,
+        "projectDir" => @project_dir
       }
       |> Map.merge(args)
 

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -1152,8 +1152,9 @@ defmodule ElixirLS.LanguageServer.ServerTest do
       file_uri = SourceFile.path_to_uri(file_path)
       file_absolute_path = SourceFile.path_from_uri(file_uri)
       text = File.read!(file_path)
+      project_dir = SourceFile.path_from_uri(root_uri())
 
-      fake_initialize(server)
+      initialize(server)
 
       Server.receive_packet(
         server,
@@ -1175,7 +1176,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                    "arguments" => [
                      %{
                        "filePath" => ^file_absolute_path,
-                       "testName" => "fixture test"
+                       "testName" => "fixture test",
+                       "projectDir" => ^project_dir
                      }
                    ],
                    "command" => "elixir.lens.test.run",
@@ -1191,7 +1193,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                    "arguments" => [
                      %{
                        "filePath" => ^file_absolute_path,
-                       "module" => "Elixir.TestCodeLensTest"
+                       "module" => "Elixir.TestCodeLensTest",
+                       "projectDir" => ^project_dir
                      }
                    ],
                    "command" => "elixir.lens.test.run",


### PR DESCRIPTION
This allows clients to easily navigate to the current project's folder before executing tests, which fixes the issue with multi-root workspaces, as described in issues https://github.com/elixir-lsp/elixir-ls/issues/438 and https://github.com/elixir-lsp/vscode-elixir-ls/issues/161.