### PR TITLE
Remove tmp dir from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@ erl_crash.dump
 /release
 
 # Also ignore temp files created during testing
-**/test/tmp
 .tmp


### PR DESCRIPTION
After #463 was merged, there is nothing actually using the tmp directory
for tests. And any current contributors who pull down master will still
have the issue, so by removing `tmp` from .gitignore it is a signal to
contributors to clean up that directory (and then their tests will work
again).