### PR TITLE
fix(test lenses): No longer expect "do" on test declaration line

### DIFF
--- a/apps/language_server/lib/language_server/providers/code_lens/test.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test.ex
@@ -93,7 +93,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
         end)
 
       %{"name" => test_name} =
-        ~r/^\s*test "(?<name>.*)"(,.*)? do/
+        ~r/^\s*test "(?<name>.*)"(,.*)?/
         |> Regex.named_captures(Enum.at(source_lines, line - 1))
 
       %TestBlock{name: test_name, describe: describe, line: line}

--- a/apps/language_server/lib/language_server/providers/code_lens/test.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test.ex
@@ -48,8 +48,6 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
     end
   end
 
-  def code_lens(_uri, _text), do: {:ok, []}
-
   defp get_test_lenses(test_blocks, file_path, project_dir) do
     args = fn block ->
       %{

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -327,6 +327,29 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     end
   end
 
+  test "returns lenses for tests with multiline context parameters" do
+    text = """
+    defmodule MyModule do
+      use ExUnit.Case
+
+      test "test1", %{
+      } do
+      end
+    end
+    """
+
+    uri = "file:///project/file.ex"
+
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+
+    assert Enum.member?(
+             lenses,
+             build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "testName" => "test1"
+             })
+           )
+  end
+
   defp build_code_lens(line, target, file_path, args) do
     arguments =
       %{

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -340,7 +340,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
 
     uri = "file:///project/file.ex"
 
-    {:ok, lenses} = CodeLens.Test.code_lens(uri, text)
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
     assert Enum.member?(
              lenses,


### PR DESCRIPTION
Fixes the issue with multi-line context arguments crashing elixir-ls, as described in https://github.com/elixir-lsp/elixir-ls/issues/438. 