### PR TITLE
Scope expandMacro command to ElixirLS server instance

### DIFF
--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -10,7 +10,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
     handler =
       case command do
         "spec:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
-        "expandMacro" -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
+        "expandMacro:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
         _ -> nil
       end
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -787,7 +787,7 @@ defmodule ElixirLS.LanguageServer.Server do
       "executeCommandProvider" => %{
         "commands" => [
           "spec:#{server_instance_id}",
-          "expandMacro"
+          "expandMacro:#{server_instance_id}"
         ]
       },
       "workspace" => %{


### PR DESCRIPTION
#498 introduces an issue with multi-project workspaces in VSCode. Previously, an ElixirLS process would be started for each open project. Now, after the first ElixirLS process is started, subsequent launches fail to start with the following warnings:

 * Couldn't start client ElixirLS
 * command 'expandMacro' already exists

See also: https://github.com/haskell/haskell-ide-engine/pull/629