### PR TITLE
fix: make manipulate pipes compatible with LSP std

### DIFF
--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -9,10 +9,17 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
   def execute(command, args, state) do
     handler =
       case command do
-        "spec:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
-        "expandMacro:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
-        "manipulatePipes:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes
-        _ -> nil
+        "spec:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
+
+        "expandMacro:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
+
+        "manipulatePipes:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes
+
+        _ ->
+          nil
       end
 
     if handler do

--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -11,6 +11,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
       case command do
         "spec:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
         "expandMacro:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
+        "manipulatePipes:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes
         _ -> nil
       end
 

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -16,28 +16,25 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
   @newlines ["\r\n", "\n", "\r"]
 
   @impl ElixirLS.LanguageServer.Providers.ExecuteCommand
-  def execute(
-        %{"uri" => uri, "cursor_line" => line, "cursor_column" => col, "operation" => operation},
-        state
-      )
+  def execute([operation, uri, line, col], state)
       when is_integer(line) and is_integer(col) and is_binary(uri) and
-             operation in ["to_pipe", "from_pipe"] do
+             operation in ["toPipe", "fromPipe"] do
     # line and col are assumed to be 0-indexed
     source_file = Server.get_source_file(state, uri)
 
     {:ok, %{edited_text: edited_text, edit_range: edit_range}} =
       case operation do
-        "to_pipe" ->
+        "toPipe" ->
           to_pipe_at_cursor(source_file.text, line, col)
 
-        "from_pipe" ->
+        "fromPipe" ->
           from_pipe_at_cursor(source_file.text, line, col)
       end
 
     label =
       case operation do
-        "to_pipe" -> "Convert function call to pipe operator"
-        "from_pipe" -> "Convert pipe operator to function call"
+        "toPipe" -> "Convert function call to pipe operator"
+        "fromPipe" -> "Convert pipe operator to function call"
       end
 
     edit_result =

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -28,7 +28,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
     end
   end
 
-  describe "execute/2 to_pipe" do
+  describe "execute/2 toPipe" do
     test "can pipe remote calls in single lines" do
       {:ok, _} =
         JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
@@ -49,12 +49,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 13,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 13],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -129,12 +124,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 12,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 12],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -207,12 +197,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 2,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 2],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -288,12 +273,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
         assert {:ok, nil} =
                  ManipulatePipes.execute(
-                   %{
-                     "uri" => uri,
-                     "cursor_line" => 2,
-                     "cursor_column" => 12,
-                     "operation" => "to_pipe"
-                   },
+                   ["toPipe", uri, 2, 12],
                    %Server{
                      source_files: %{
                        uri => %SourceFile{
@@ -364,12 +344,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 14,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 14],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -420,7 +395,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
     end
   end
 
-  describe "execute/2 from_pipe" do
+  describe "execute/2 fromPipe" do
     test "can unpipe remote calls in single lines" do
       {:ok, _} =
         JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
@@ -441,12 +416,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 8,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 2, 8],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -521,12 +491,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 3,
-                   "cursor_column" => 5,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 3, 5],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -599,12 +564,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 11,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 2, 11],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -678,12 +638,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
         assert {:ok, nil} =
                  ManipulatePipes.execute(
-                   %{
-                     "uri" => uri,
-                     "cursor_line" => 3,
-                     "cursor_column" => 4,
-                     "operation" => "from_pipe"
-                   },
+                   ["fromPipe", uri, 3, 4],
                    %Server{
                      source_files: %{
                        uri => %SourceFile{
@@ -755,12 +710,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 3,
-                   "cursor_column" => 5,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 3, 5],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{


### PR DESCRIPTION
During development of https://github.com/elixir-lsp/vscode-elixir-ls/pull/182 I found some declaration and interface issues. This PR aims to fix those