### PR TITLE
fix: expose manipulate pipes command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ### Unreleased
 
+Improvements:
+- Use fuzzy matching for function completion (thanks [Po Chen](https://github.com/princemaple)) [#491](https://github.com/elixir-lsp/elixir-ls/pull/491/files)
+  - For example: "valp" will match `validate_password` and "Enum.chub" will match `Enum.chunk_by/2`
+  - Note: the plan is to extend this fuzzy matching to other types of completion in the future
+- Support auto-generating folding ranges (textDocument/foldingRange) (thanks [billylanchantin](https://github.com/billylanchantin)) [#492](https://github.com/elixir-lsp/elixir-ls/pull/492)
+- Snippet variants with n-1 placeholders to use after pipe (thanks [Leonardo Donelli](https://github.com/LeartS)) [#501](https://github.com/elixir-lsp/elixir-ls/pull/501)
+- Make launcher script more robust and support symlinks... more robustly (thanks [Joshua Trees](https://github.com/jtrees)) [#473](https://github.com/elixir-lsp/elixir-ls/pull/473)
+
+Bug Fixes:
+- Make expandMacro a custom command (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#498](https://github.com/elixir-lsp/elixir-ls/pull/498)
+  - Scope expandMacro command to ElixirLS server instance (thanks [Tom Crossland](https://github.com/tcrossland)) [#505](https://github.com/elixir-lsp/elixir-ls/pull/505)
+- Suppress setup script stdout output on windows(thanks [Po Chen](https://github.com/princemaple)) [#497](https://github.com/elixir-lsp/elixir-ls/pull/497)
+
+Housekeeping:
+- Improved support for OTP 24 (thanks [Tom Crossland](https://github.com/tcrossland)) [#504](https://github.com/elixir-lsp/elixir-ls/pull/504)
+  - Note that OTP 24 isn't officially supported since it is not yet released
+- Add meta-test to ensure that all commands include the server instance id (thanks [Jason Axelson](https://github.com/axelson)) [#507](https://github.com/elixir-lsp/elixir-ls/pull/507)
+- Fix test flakiness by ensuring build is complete (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#511](https://github.com/elixir-lsp/elixir-ls/pull/511)
+
+VSCode:
+- Fix test lens shell escaping on Windows (thanks [Étienne Lévesque](https://github.com/Blond11516)) [#175](https://github.com/elixir-lsp/vscode-elixir-ls/pull/175)
+-  Add hrl to watched files (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#177](https://github.com/elixir-lsp/vscode-elixir-ls/pull/177)
+- Fix CI issues (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#178](https://github.com/elixir-lsp/vscode-elixir-ls/pull/178)
+- Add support for `expandMacro` command (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#176](https://github.com/elixir-lsp/vscode-elixir-ls/pull/176)
+
+**Deprecations**
+Deprecate non-standard `elixirDocument/macroExpansion` command. It is being replaced with the `expandMacro` custom command. See [#498](https://github.com/elixir-lsp/elixir-ls/pull/498) for details. It is planned to be fully removed in 0.8
+
 ### v0.6.5: 9 February 2021
 
 Bug Fixes:

--- a/apps/elixir_ls_utils/test/changelog_test.exs
+++ b/apps/elixir_ls_utils/test/changelog_test.exs
@@ -1,0 +1,18 @@
+defmodule ElixirLS.Utils.ChangelogTest do
+  use ExUnit.Case, async: true
+
+  test "changelog pull requests are correctly linked" do
+    contents = File.read!("../../CHANGELOG.md")
+
+    String.split(contents, "\n", trim: true)
+    |> Enum.each(fn line ->
+      case Regex.run(~r/\/pull\/(\d+)/, line, capture: :all_but_first) do
+        [pr_number] ->
+          assert String.match?(line, ~r/\[.*#{pr_number}\]/)
+
+        _ ->
+          nil
+      end
+    end)
+  end
+end

--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -9,9 +9,17 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
   def execute(command, args, state) do
     handler =
       case command do
-        "spec:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
-        "expandMacro:" <> _ -> ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
-        _ -> nil
+        "spec:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec
+
+        "expandMacro:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacro
+
+        "manipulatePipes:" <> _ ->
+          ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes
+
+        _ ->
+          nil
       end
 
     if handler do

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -1,0 +1,308 @@
+defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
+  @moduledoc """
+  This module implements a custom command for converting function calls
+  to pipe operators and pipes to function calls.
+
+  Returns a formatted source fragment.
+  """
+  import ElixirLS.LanguageServer.Protocol
+
+  alias ElixirLS.LanguageServer.{JsonRpc, Server}
+
+  alias __MODULE__.AST
+
+  @behaviour ElixirLS.LanguageServer.Providers.ExecuteCommand
+
+  @newlines ["\r\n", "\n", "\r"]
+
+  @impl ElixirLS.LanguageServer.Providers.ExecuteCommand
+  def execute(
+        %{"uri" => uri, "cursor_line" => line, "cursor_column" => col, "operation" => operation},
+        state
+      )
+      when is_integer(line) and is_integer(col) and is_binary(uri) and
+             operation in ["to_pipe", "from_pipe"] do
+    # line and col are assumed to be 0-indexed
+    source_file = Server.get_source_file(state, uri)
+
+    {:ok, %{edited_text: edited_text, edit_range: edit_range}} =
+      case operation do
+        "to_pipe" ->
+          to_pipe_at_cursor(source_file.text, line, col)
+
+        "from_pipe" ->
+          from_pipe_at_cursor(source_file.text, line, col)
+      end
+
+    label =
+      case operation do
+        "to_pipe" -> "Convert function call to pipe operator"
+        "from_pipe" -> "Convert pipe operator to function call"
+      end
+
+    edit_result =
+      JsonRpc.send_request("workspace/applyEdit", %{
+        "label" => label,
+        "edit" => %{
+          "changes" => %{
+            uri => [%{"range" => edit_range, "newText" => edited_text}]
+          }
+        }
+      })
+
+    case edit_result do
+      {:ok, %{"applied" => true}} ->
+        {:ok, nil}
+
+      other ->
+        {:error, :server_error,
+         "cannot insert spec, workspace/applyEdit returned #{inspect(other)}"}
+    end
+  end
+
+  defp to_pipe_at_cursor(text, line, col) do
+    result =
+      ElixirSense.Core.Source.walk_text(
+        text,
+        %{walked_text: "", function_call: nil, range: nil},
+        fn current_char, remaining_text, current_line, current_col, acc ->
+          if current_line - 1 == line and current_col - 1 == col do
+            {:ok, function_call, call_range} =
+              get_function_call(line, col, acc.walked_text, current_char, remaining_text)
+
+            {remaining_text,
+             %{
+               acc
+               | walked_text: acc.walked_text <> current_char,
+                 function_call: function_call,
+                 range: call_range
+             }}
+          else
+            {remaining_text, %{acc | walked_text: acc.walked_text <> current_char}}
+          end
+        end
+      )
+
+    case result do
+      %{function_call: nil} ->
+        {:error, :function_call_not_found}
+
+      %{function_call: function_call, range: range} ->
+        piped_text = AST.to_pipe(function_call)
+
+        {:ok, %{edited_text: piped_text, edit_range: range}}
+    end
+  end
+
+  defp from_pipe_at_cursor(text, line, col) do
+    result =
+      ElixirSense.Core.Source.walk_text(
+        text,
+        %{walked_text: "", pipe_call: nil, range: nil},
+        fn current_char, remaining_text, current_line, current_col, acc ->
+          if current_line - 1 == line and current_col - 1 == col do
+            {:ok, pipe_call, call_range} =
+              get_pipe_call(line, col, acc.walked_text, current_char, remaining_text)
+
+            {remaining_text,
+             %{
+               acc
+               | walked_text: acc.walked_text <> current_char,
+                 pipe_call: pipe_call,
+                 range: call_range
+             }}
+          else
+            {remaining_text, %{acc | walked_text: acc.walked_text <> current_char}}
+          end
+        end
+      )
+
+    case result do
+      %{pipe_call: nil} ->
+        {:error, :pipe_not_found}
+
+      %{pipe_call: pipe_call, range: range} ->
+        unpiped_text = AST.from_pipe(pipe_call)
+
+        {:ok, %{edited_text: unpiped_text, edit_range: range}}
+    end
+  end
+
+  defp get_function_call(line, col, head, current, original_tail) do
+    tail = do_get_function_call(original_tail, "(", ")")
+
+    {end_line, end_col} =
+      if String.contains?(tail, @newlines) do
+        tail_list = String.split(tail, @newlines)
+        end_line = line + length(tail_list) - 1
+        end_col = tail_list |> Enum.at(-1) |> String.length()
+        {end_line, end_col}
+      else
+        {line, col + String.length(tail) + 1}
+      end
+
+    text = head <> current <> tail
+
+    call = get_function_call_before(text)
+
+    {head, _tail} = String.split_at(call, -String.length(tail))
+
+    col = if head == "", do: col + 2, else: col - String.length(head) + 1
+
+    {:ok, call, range(line, col, end_line, end_col)}
+  end
+
+  defp do_get_function_call(text, start_char, end_char) do
+    text
+    |> do_get_function_call(start_char, end_char, %{paren_count: 0, text: ""})
+    |> Map.get(:text)
+    |> IO.iodata_to_binary()
+  end
+
+  defp do_get_function_call(<<c::binary-size(1), tail::bitstring>>, start_char, end_char, acc)
+       when c == start_char do
+    do_get_function_call(tail, start_char, end_char, %{
+      acc
+      | paren_count: acc.paren_count + 1,
+        text: [acc.text | [c]]
+    })
+  end
+
+  defp do_get_function_call(<<c::binary-size(1), tail::bitstring>>, start_char, end_char, acc)
+       when c == end_char do
+    acc = %{acc | paren_count: acc.paren_count - 1, text: [acc.text | [c]]}
+
+    if acc.paren_count <= 0 do
+      acc
+    else
+      do_get_function_call(tail, start_char, end_char, acc)
+    end
+  end
+
+  defp do_get_function_call(<<c::binary-size(1), tail::bitstring>>, start_char, end_char, acc) do
+    do_get_function_call(tail, start_char, end_char, %{acc | text: [acc.text | [c]]})
+  end
+
+  defp get_pipe_call(line, col, head, current, tail) do
+    pipe_right = do_get_function_call(tail, "(", ")")
+
+    pipe_left =
+      head
+      |> String.reverse()
+      |> :unicode.characters_to_binary(:utf8, :utf16)
+      |> do_get_pipe_call()
+      |> :unicode.characters_to_binary(:utf16, :utf8)
+
+    pipe_left =
+      if String.contains?(pipe_left, ")") do
+        get_function_call_before(head)
+      else
+        pipe_left
+      end
+
+    pipe_left = String.trim_leading(pipe_left)
+
+    pipe_call = pipe_left <> current <> pipe_right
+
+    {line_offset, tail_length} =
+      pipe_left
+      |> String.reverse()
+      |> count_newlines_and_get_tail()
+
+    start_line = line - line_offset
+
+    start_col =
+      if line_offset != 0 do
+        head
+        |> String.trim_trailing(pipe_left)
+        |> String.split(["\r\n", "\n", "\r"])
+        |> Enum.at(-1, "")
+        |> String.length()
+      else
+        col - tail_length
+      end
+
+    {line_offset, tail_length} = (current <> pipe_right) |> count_newlines_and_get_tail()
+
+    end_line = line + line_offset
+
+    end_col =
+      if line_offset != 0 do
+        tail_length
+      else
+        col + tail_length
+      end
+
+    {:ok, pipe_call, range(start_line, start_col, end_line, end_col)}
+  end
+
+  # do_get_pipe_call(text :: utf16 binary, {utf16 binary, has_passed_through_whitespace, should_halt})
+  defp do_get_pipe_call(text, acc \\ {"", false, false})
+
+  defp do_get_pipe_call(_text, {acc, _, true}), do: acc
+  defp do_get_pipe_call("", {acc, _, _}), do: acc
+
+  defp do_get_pipe_call(<<?\r::utf16, ?\n::utf16, _::bitstring>>, {acc, true, _}),
+    do: <<?\r::utf16, ?\n::utf16, acc::bitstring>>
+
+  defp do_get_pipe_call(<<0, c::utf8, _::bitstring>>, {acc, true, _})
+       when c in [?\t, ?\v, ?\r, ?\n, ?\s],
+       do: <<c::utf16, acc::bitstring>>
+
+  defp do_get_pipe_call(<<0, ?\r, 0, ?\n, text::bitstring>>, {acc, false, _}),
+    do: do_get_pipe_call(text, {<<?\r::utf16, ?\n::utf16, acc::bitstring>>, false, false})
+
+  defp do_get_pipe_call(<<0, c::utf8, text::bitstring>>, {acc, false, _})
+       when c in [?\t, ?\v, ?\n, ?\s],
+       do: do_get_pipe_call(text, {<<c::utf16, acc::bitstring>>, false, false})
+
+  defp do_get_pipe_call(<<0, c::utf8, text::bitstring>>, {acc, _, _})
+       when c in [?|, ?>],
+       do: do_get_pipe_call(text, {<<c::utf16, acc::bitstring>>, false, false})
+
+  defp do_get_pipe_call(<<c::utf16, text::bitstring>>, {acc, _, _}),
+    do: do_get_pipe_call(text, {<<c::utf16, acc::bitstring>>, true, false})
+
+  defp get_function_call_before(head) do
+    call_without_function_name =
+      head
+      |> String.reverse()
+      |> do_get_function_call(")", "(")
+      |> String.reverse()
+
+    function_name =
+      head
+      |> String.trim_trailing(call_without_function_name)
+      |> get_function_name_from_tail()
+
+    function_name <> call_without_function_name
+  end
+
+  defp get_function_name_from_tail(s) do
+    s
+    |> String.reverse()
+    |> String.graphemes()
+    |> Enum.reduce_while([], fn c, acc ->
+      if String.match?(c, ~r/\s/) do
+        {:halt, acc}
+      else
+        {:cont, [c | acc]}
+      end
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp count_newlines_and_get_tail(s, acc \\ {0, 0})
+
+  defp count_newlines_and_get_tail("", acc), do: acc
+
+  defp count_newlines_and_get_tail(s, {line_count, tail_length}) do
+    case String.next_grapheme(s) do
+      {g, tail} when g in ["\r\n", "\r", "\n"] ->
+        count_newlines_and_get_tail(tail, {line_count + 1, 0})
+
+      {_, tail} ->
+        count_newlines_and_get_tail(tail, {line_count, tail_length + 1})
+    end
+  end
+end

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -141,6 +141,16 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
     end
   end
 
+  defp get_function_call(line, col, head, cur, original_tail) when cur in ["\n", "\r", "\r\n"] do
+    {head, new_cur} = String.split_at(head, -1)
+    get_function_call(line, col - 1, head, new_cur, cur <> original_tail)
+  end
+
+  defp get_function_call(line, col, head, ")", original_tail) do
+    {head, cur} = String.split_at(head, -1)
+    get_function_call(line, col - 1, head, cur, ")" <> original_tail)
+  end
+
   defp get_function_call(line, col, head, current, original_tail) do
     tail = do_get_function_call(original_tail, "(", ")")
 

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -16,28 +16,25 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
   @newlines ["\r\n", "\n", "\r"]
 
   @impl ElixirLS.LanguageServer.Providers.ExecuteCommand
-  def execute(
-        %{"uri" => uri, "cursor_line" => line, "cursor_column" => col, "operation" => operation},
-        state
-      )
+  def execute([operation, uri, line, col], state)
       when is_integer(line) and is_integer(col) and is_binary(uri) and
-             operation in ["to_pipe", "from_pipe"] do
+             operation in ["toPipe", "fromPipe"] do
     # line and col are assumed to be 0-indexed
     source_file = Server.get_source_file(state, uri)
 
     {:ok, %{edited_text: edited_text, edit_range: edit_range}} =
       case operation do
-        "to_pipe" ->
+        "toPipe" ->
           to_pipe_at_cursor(source_file.text, line, col)
 
-        "from_pipe" ->
+        "fromPipe" ->
           from_pipe_at_cursor(source_file.text, line, col)
       end
 
     label =
       case operation do
-        "to_pipe" -> "Convert function call to pipe operator"
-        "from_pipe" -> "Convert pipe operator to function call"
+        "toPipe" -> "Convert function call to pipe operator"
+        "fromPipe" -> "Convert pipe operator to function call"
       end
 
     edit_result =

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -92,7 +92,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
 
       <<"sigil_", name>> when name >= ?a and name <= ?z ->
         args = sigil_args(args, fun)
-        formatted = "~" <> <<name>> <> interpolate(parts, left, right, fun) <> args
+        formatted = "~" <> <<name>> <> interpolate(parts, left, right) <> args
         {:ok, fun.(ast, formatted)}
 
       _ ->
@@ -115,15 +115,15 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
   defp sigil_args([], _fun), do: ""
   defp sigil_args(args, fun), do: fun.(args, List.to_string(args))
 
-  defp interpolate({:<<>>, _, [parts]}, left, right, _) when left in [~s["""\n], ~s['''\n]] do
+  defp interpolate({:<<>>, _, [parts]}, left, right) when left in [~s["""\n], ~s['''\n]] do
     <<left::binary, parts::binary, right::binary>>
   end
 
-  defp interpolate({:<<>>, _, parts}, left, right, fun) do
+  defp interpolate({:<<>>, _, parts}, left, right) do
     parts =
       Enum.map_join(parts, "", fn
         {:"::", _, [{{:., _, [Kernel, :to_string]}, _, [arg]}, {:binary, _, _}]} ->
-          "\#{" <> Macro.to_string(arg, fun) <> "}"
+          "\#{" <> ast_to_string(arg) <> "}"
 
         binary when is_binary(binary) ->
           escape_sigil(binary, left)

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -66,6 +66,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
   end
 
   defp fix_escape_chars(parsed, original) do
+    # This fix is needed because up until Elixir 1.11 Macro.to_string
+    # escapes all \ occurrences inside sigils (i.e. "~r/\\/" becomes "~r/\\\\/")
     original_count = original |> String.replace(~r/[^\\]/, "") |> String.length()
     parsed_count = parsed |> String.replace(~r/[^\\]/, "") |> String.length()
 

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -11,7 +11,10 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
       |> Code.string_to_quoted!()
       |> Macro.prewalk(%{has_piped: false}, &do_to_pipe/2)
 
-    ast_to_string(piped_ast)
+    {:ok, ast_to_string(piped_ast)}
+  rescue
+    _ ->
+      {:error, :invalid_code}
   end
 
   @doc "Parses a string and converts the first pipe call, post-order depth-first, into a function call."
@@ -31,7 +34,10 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
           {node, acc}
       end)
 
-    ast_to_string(unpiped_ast)
+    {:ok, ast_to_string(unpiped_ast)}
+  rescue
+    _ ->
+      {:error, :invalid_code}
   end
 
   defp do_to_pipe({:|>, line, [left, right]}, %{has_piped: false} = acc) do

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -1,0 +1,67 @@
+defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST do
+  @moduledoc """
+  AST manipulation helpers for the `ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes`\
+  command.
+  """
+
+  @doc "Parses a string and converts the first function call, pre-order depth-first, into a pipe."
+  def to_pipe(code_string) do
+    {piped_ast, _} =
+      code_string
+      |> Code.string_to_quoted!()
+      |> Macro.prewalk(%{has_piped: false}, &do_to_pipe/2)
+
+    Macro.to_string(piped_ast)
+  end
+
+  @doc "Parses a string and converts the first pipe call, post-order depth-first, into a function call."
+  def from_pipe(code_string) do
+    {unpiped_ast, _} =
+      code_string
+      |> Code.string_to_quoted!()
+      |> Macro.postwalk(%{has_unpiped: false}, fn
+        {:|>, line, [h, {{:., line, [{_, _, nil}]} = anonymous_function_node, line, t}]},
+        %{has_unpiped: false} = acc ->
+          {{anonymous_function_node, line, [h | t]}, Map.put(acc, :has_unpiped, true)}
+
+        {:|>, line, [left, {function, _, args}]}, %{has_unpiped: false} = acc ->
+          {{function, line, [left | args]}, Map.put(acc, :has_unpiped, true)}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Macro.to_string(unpiped_ast)
+  end
+
+  defp do_to_pipe({:|>, line, [left, right]}, %{has_piped: false} = acc) do
+    {{:|>, line, [left |> do_to_pipe(acc) |> elem(0), right]}, Map.put(acc, :has_piped, true)}
+  end
+
+  defp do_to_pipe(
+         {{:., line, [{_, _, nil}]} = anonymous_function_node, _meta, [h | t]},
+         %{has_piped: false} = acc
+       ) do
+    {{:|>, line, [h, {anonymous_function_node, line, t}]}, Map.put(acc, :has_piped, true)}
+  end
+
+  defp do_to_pipe({{:., line, _args} = function, _meta, args}, %{has_piped: false} = acc)
+       when args != [] do
+    {{:|>, line, [hd(args), {function, line, tl(args)}]}, Map.put(acc, :has_piped, true)}
+  end
+
+  defp do_to_pipe({function, line, [h | t]} = node, %{has_piped: false} = acc)
+       when is_atom(function) and function not in [:., :__aliases__, :"::", :{}, :|>] and t != [] do
+    with :error <- Code.Identifier.binary_op(function),
+         :error <- Code.Identifier.unary_op(function) do
+      {{:|>, line, [h, {function, line, t}]}, Map.put(acc, :has_piped, true)}
+    else
+      _ ->
+        {node, acc}
+    end
+  end
+
+  defp do_to_pipe(node, acc) do
+    {node, acc}
+  end
+end

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -57,7 +57,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
   end
 
   defp do_to_pipe({function, line, [h | t]} = node, %{has_piped: false} = acc)
-       when is_atom(function) and function not in [:., :__aliases__, :"::", :{}, :|>] and t != [] do
+       when is_atom(function) and function not in [:., :__aliases__, :"::", :{}, :|>] do
     with :error <- Code.Identifier.binary_op(function),
          :error <- Code.Identifier.unary_op(function) do
       {{:|>, line, [h, {function, line, t}]}, Map.put(acc, :has_piped, true)}

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes/ast.ex
@@ -80,6 +80,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST d
     end)
   end
 
+  # TODO: remove this when only Elixir >= 1.13 is supported
   # The code below is copied from the Elixir source-code because a
   # fix which was introduced in
   # https://github.com/elixir-lang/elixir/commit/88d82f059756ed1eb56a562fae7092f77d941de8

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -317,9 +317,7 @@ defmodule ElixirLS.LanguageServer.Server do
       # close notification send before
       JsonRpc.log_message(
         :warning,
-        "Received textDocument/didOpen for file that is already open. Received uri: #{
-          inspect(uri)
-        }"
+        "Received textDocument/didOpen for file that is already open. Received uri: #{inspect(uri)}"
       )
 
       state

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -799,7 +799,8 @@ defmodule ElixirLS.LanguageServer.Server do
       "executeCommandProvider" => %{
         "commands" => [
           "spec:#{server_instance_id}",
-          "expandMacro:#{server_instance_id}"
+          "expandMacro:#{server_instance_id}",
+          "manipulatePipes:#{server_instance_id}"
         ]
       },
       "workspace" => %{

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -1,0 +1,201 @@
+defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTest do
+  use ExUnit.Case
+
+  alias ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST
+
+  describe "to_pipe/1" do
+    test "single-line selection with two args in named function" do
+      assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a(), b)") ==
+               "A.B.C.a() |> X.Y.Z.function_name(b)"
+    end
+
+    test "single-line selection with single arg in named function" do
+      assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a())") == "A.B.C.a() |> X.Y.Z.function_name()"
+    end
+
+    test "single-line selection with two args in anonymous function" do
+      assert AST.to_pipe("function_name.(A.B.C.a(), b)") ==
+               "A.B.C.a() |> function_name.(b)"
+    end
+
+    test "single-line selection with single arg in anonymous function" do
+      assert AST.to_pipe("function_name.(A.B.C.a())") == "A.B.C.a() |> function_name.()"
+    end
+
+    test "multi-line selection with two args in named function" do
+      assert AST.to_pipe("""
+               X.Y.Z.function_name(
+               X.Y.Z.a(),
+               b,
+               c
+             )
+             """) == "X.Y.Z.a() |> X.Y.Z.function_name(b, c)"
+    end
+
+    test "multi-line with \r as separator and \r\n inside strings raises syntax error" do
+      # This test shows that the parser is limited to Elixir's parser's capabilities
+      assert_raise SyntaxError, fn ->
+        AST.to_pipe(~s{X.Y.Z.function_name(\r1,\r"asdf\nghjk")})
+      end
+    end
+
+    test "on 0 arity function call" do
+      assert AST.to_pipe("f.()") == "f.()"
+      assert AST.to_pipe("f()") == "f()"
+      assert AST.to_pipe("My.Nested.Module.f()") == "My.Nested.Module.f()"
+    end
+
+    test "on atom" do
+      assert AST.to_pipe(":asdf") == ":asdf"
+      assert AST.to_pipe("MyModule") == "MyModule"
+    end
+
+    test "calls with no parens" do
+      assert AST.to_pipe("f 1, 2") == "1 |> f(2)"
+      assert AST.to_pipe("MyModule.f 1, 2") == "1 |> MyModule.f(2)"
+    end
+
+    test "already a piped call (idempotency check)" do
+      assert AST.to_pipe("1 |> f(2)") == "1 |> f(2)"
+      assert AST.to_pipe("1 |> MyModule.f(2)") == "1 |> MyModule.f(2)"
+      assert AST.to_pipe("g(1) |> MyModule.f(2)") == "g(1) |> MyModule.f(2)"
+    end
+
+    test "does not pipe operators" do
+      assert AST.to_pipe("1 + 2") == "1 + 2"
+      assert AST.to_pipe("+2") == "+2"
+      # ensure that fully qualified operators are piped
+      assert AST.to_pipe("Kernel.+(1, 2)") == "1 |> Kernel.+(2)"
+    end
+  end
+
+  describe "from_pipe/1 single-line" do
+    test "does not change code without pipes" do
+      code = "f(a, b, c)"
+
+      assert AST.from_pipe(code) == code
+    end
+
+    test "three args in named function" do
+      piped = "a |> function_name(b, c) |> after_call"
+      unpiped = "function_name(a, b, c) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "pipe chain" do
+      piped = "a |> b() |> function_name(c, d) |> after_call"
+      unpiped = "b(a) |> function_name(c, d) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "pipe chain with no raw start" do
+      piped = "b(a) |> function_name(c, d) |> after_call"
+      unpiped = "function_name(b(a), c, d) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in named function" do
+      piped = "a |> function_name() |> after_call"
+      unpiped = "function_name(a) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "three args in anonymous function" do
+      piped = "a |> function_name.(b, c) |> after_call"
+      unpiped = "function_name.(a, b, c) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in anonymous function" do
+      piped = "a |> function_name.() |> after_call"
+      unpiped = "function_name.(a) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "three args in named function and statement before call" do
+      piped = "a |> function_name(b, c) |> after_call"
+      unpiped = "function_name(a, b, c) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in named function and statement before call" do
+      piped = "a |> function_name() |> after_call"
+      unpiped = "function_name(a) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "three args in anonymous function and statement before call" do
+      piped = "a |> function_name.(b, c) |> after_call"
+      unpiped = "function_name.(a, b, c) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in anonymous function and statement before call" do
+      piped = "a |> function_name.() |> after_call"
+      unpiped = "function_name.(a) |> after_call"
+      assert AST.from_pipe(piped) == unpiped
+    end
+  end
+
+  describe "from_pipe/1 multi-line" do
+    test "three args in named function" do
+      piped = """
+      a
+      |> function_name(b, c)
+      |> after_call
+      """
+
+      unpiped = "function_name(a, b, c) |> after_call"
+
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in named function" do
+      piped = """
+      a
+      |> function_name()
+      |> after_call
+      """
+
+      unpiped = "function_name(a) |> after_call"
+
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "three args in anonymous function" do
+      piped = """
+      a
+      |> function_name.(b, c)
+      |> after_call
+      """
+
+      unpiped = "function_name.(a, b, c) |> after_call"
+
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "single arg in anonymous function" do
+      piped = """
+      MyModule.f(a)
+      |> function_name.()
+      |> after_call
+      """
+
+      unpiped = "function_name.(MyModule.f(a)) |> after_call"
+
+      assert AST.from_pipe(piped) == unpiped
+    end
+
+    test "function call piped into another function" do
+      piped = """
+      f(a)
+      |> g(b, c)
+      |> after_call
+      """
+
+      unpiped = "g(f(a), b, c) |> after_call"
+
+      assert AST.from_pipe(piped) == unpiped
+    end
+  end
+end

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -62,7 +62,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
     test "already a piped call (idempotency check)" do
       assert AST.to_pipe("1 |> f(2)") == {:ok, "1 |> f(2)"}
       assert AST.to_pipe("1 |> MyModule.f(2)") == {:ok, "1 |> MyModule.f(2)"}
-      assert AST.to_pipe("g(1) |> MyModule.f(2)") == {:ok, "g(1) |> MyModule.f(2)"}
+      assert AST.to_pipe("1 |> g() |> MyModule.f(2)") == {:ok, "1 |> g() |> MyModule.f(2)"}
     end
 
     test "does not pipe operators" do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -5,8 +5,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
   describe "to_pipe/1" do
     test "treats macro.to_string escaping chars" do
-      assert AST.to_pipe("String.split(text, ~r{\"\\a\"}, trim: true)") ==
-               "text |> String.split(~r{\"\\a\"}, trim: true)"
+      assert AST.to_pipe("String.split(text, ~r\"\\\"\\a\\\"\", trim: true)") ==
+               "text |> String.split(~r\"\\\"\\a\\\"\", trim: true)"
     end
 
     test "single-line selection with two args in named function" do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -70,6 +70,11 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
   end
 
   describe "from_pipe/1 single-line" do
+    test "Show that Macro.to_string messes up escaped sigils" do
+      assert AST.from_pipe("text |> String.split(~r/\\a/, trim: true)") ==
+               "String.split(text, ~r/\\\\a/, trim: true)"
+    end
+
     test "does not change code without pipes" do
       code = "f(a, b, c)"
 

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -71,8 +71,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
   describe "from_pipe/1 single-line" do
     test "Show that Macro.to_string messes up escaped sigils" do
-      assert AST.from_pipe("text |> String.split(~r/\\a/, trim: true)") ==
-               "String.split(text, ~r/\\\\a/, trim: true)"
+      assert AST.from_pipe("text |> String.split(~r\"\\a\", trim: true)") ==
+               "String.split(text, ~r\"\\\\a\", trim: true)"
     end
 
     test "does not change code without pipes" do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -5,13 +5,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
   describe "to_pipe/1" do
     test "treats macro.to_string escaping chars" do
-      assert AST.to_pipe("String.split(text, ~r\"\\a\", trim: true)") ==
-               "text |> String.split(~r\"\\a\", trim: true)"
-    end
-
-    test "treats macro.to_string escaping chars sigil" do
-      assert AST.to_pipe(~s[String.split(text, ~r{"\\a"}, trim: true)]) ==
-               ~s[text |> String.split(~r{"\\a"}, trim: true)]
+      assert AST.to_pipe("String.split(text, ~r{\"\\a\"}, trim: true)") ==
+               "text |> String.split(~r{\"\\a\"}, trim: true)"
     end
 
     test "single-line selection with two args in named function" do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -4,6 +4,11 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
   alias ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.AST
 
   describe "to_pipe/1" do
+    test "treats macro.to_string escaping chars" do
+      assert AST.to_pipe("String.split(text, ~r\"\\a\", trim: true)") ==
+               "text |> String.split(~r\"\\a\", trim: true)"
+    end
+
     test "single-line selection with two args in named function" do
       assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a(), b)") ==
                "A.B.C.a() |> X.Y.Z.function_name(b)"
@@ -70,9 +75,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
   end
 
   describe "from_pipe/1 single-line" do
-    test "Show that Macro.to_string messes up escaped sigils" do
+    test "treats macro.to_string escaping chars" do
       assert AST.from_pipe("text |> String.split(~r\"\\a\", trim: true)") ==
-               "String.split(text, ~r\"\\\\a\", trim: true)"
+               "String.split(text, ~r\"\\a\", trim: true)"
     end
 
     test "does not change code without pipes" do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -6,25 +6,26 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
   describe "to_pipe/1" do
     test "treats macro.to_string escaping chars" do
       assert AST.to_pipe("String.split(text, ~r\"\\\"\\a\\\"\", trim: true)") ==
-               "text |> String.split(~r\"\\\"\\a\\\"\", trim: true)"
+               {:ok, "text |> String.split(~r\"\\\"\\a\\\"\", trim: true)"}
     end
 
     test "single-line selection with two args in named function" do
       assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a(), b)") ==
-               "A.B.C.a() |> X.Y.Z.function_name(b)"
+               {:ok, "A.B.C.a() |> X.Y.Z.function_name(b)"}
     end
 
     test "single-line selection with single arg in named function" do
-      assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a())") == "A.B.C.a() |> X.Y.Z.function_name()"
+      assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a())") ==
+               {:ok, "A.B.C.a() |> X.Y.Z.function_name()"}
     end
 
     test "single-line selection with two args in anonymous function" do
       assert AST.to_pipe("function_name.(A.B.C.a(), b)") ==
-               "A.B.C.a() |> function_name.(b)"
+               {:ok, "A.B.C.a() |> function_name.(b)"}
     end
 
     test "single-line selection with single arg in anonymous function" do
-      assert AST.to_pipe("function_name.(A.B.C.a())") == "A.B.C.a() |> function_name.()"
+      assert AST.to_pipe("function_name.(A.B.C.a())") == {:ok, "A.B.C.a() |> function_name.()"}
     end
 
     test "multi-line selection with two args in named function" do
@@ -34,116 +35,114 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
                b,
                c
              )
-             """) == "X.Y.Z.a() |> X.Y.Z.function_name(b, c)"
+             """) == {:ok, "X.Y.Z.a() |> X.Y.Z.function_name(b, c)"}
     end
 
     test "multi-line with \r as separator and \r\n inside strings raises syntax error" do
       # This test shows that the parser is limited to Elixir's parser's capabilities
-      assert_raise SyntaxError, fn ->
-        AST.to_pipe(~s{X.Y.Z.function_name(\r1,\r"asdf\nghjk")})
-      end
+      assert {:error, :invalid_code} = AST.to_pipe(~s{X.Y.Z.function_name(\r1,\r"asdf\nghjk")})
     end
 
     test "on 0 arity function call" do
-      assert AST.to_pipe("f.()") == "f.()"
-      assert AST.to_pipe("f()") == "f()"
-      assert AST.to_pipe("My.Nested.Module.f()") == "My.Nested.Module.f()"
+      assert AST.to_pipe("f.()") == {:ok, "f.()"}
+      assert AST.to_pipe("f()") == {:ok, "f()"}
+      assert AST.to_pipe("My.Nested.Module.f()") == {:ok, "My.Nested.Module.f()"}
     end
 
     test "on atom" do
-      assert AST.to_pipe(":asdf") == ":asdf"
-      assert AST.to_pipe("MyModule") == "MyModule"
+      assert AST.to_pipe(":asdf") == {:ok, ":asdf"}
+      assert AST.to_pipe("MyModule") == {:ok, "MyModule"}
     end
 
     test "calls with no parens" do
-      assert AST.to_pipe("f 1, 2") == "1 |> f(2)"
-      assert AST.to_pipe("MyModule.f 1, 2") == "1 |> MyModule.f(2)"
+      assert AST.to_pipe("f 1, 2") == {:ok, "1 |> f(2)"}
+      assert AST.to_pipe("MyModule.f 1, 2") == {:ok, "1 |> MyModule.f(2)"}
     end
 
     test "already a piped call (idempotency check)" do
-      assert AST.to_pipe("1 |> f(2)") == "1 |> f(2)"
-      assert AST.to_pipe("1 |> MyModule.f(2)") == "1 |> MyModule.f(2)"
-      assert AST.to_pipe("g(1) |> MyModule.f(2)") == "g(1) |> MyModule.f(2)"
+      assert AST.to_pipe("1 |> f(2)") == {:ok, "1 |> f(2)"}
+      assert AST.to_pipe("1 |> MyModule.f(2)") == {:ok, "1 |> MyModule.f(2)"}
+      assert AST.to_pipe("g(1) |> MyModule.f(2)") == {:ok, "g(1) |> MyModule.f(2)"}
     end
 
     test "does not pipe operators" do
-      assert AST.to_pipe("1 + 2") == "1 + 2"
-      assert AST.to_pipe("+2") == "+2"
+      assert AST.to_pipe("1 + 2") == {:ok, "1 + 2"}
+      assert AST.to_pipe("+2") == {:ok, "+2"}
       # ensure that fully qualified operators are piped
-      assert AST.to_pipe("Kernel.+(1, 2)") == "1 |> Kernel.+(2)"
+      assert AST.to_pipe("Kernel.+(1, 2)") == {:ok, "1 |> Kernel.+(2)"}
     end
   end
 
   describe "from_pipe/1 single-line" do
     test "treats macro.to_string escaping chars" do
       assert AST.from_pipe("text |> String.split(~r\"\\a\", trim: true)") ==
-               "String.split(text, ~r\"\\a\", trim: true)"
+               {:ok, "String.split(text, ~r\"\\a\", trim: true)"}
     end
 
     test "does not change code without pipes" do
       code = "f(a, b, c)"
 
-      assert AST.from_pipe(code) == code
+      assert AST.from_pipe(code) == {:ok, code}
     end
 
     test "three args in named function" do
       piped = "a |> function_name(b, c) |> after_call"
       unpiped = "function_name(a, b, c) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "pipe chain" do
       piped = "a |> b() |> function_name(c, d) |> after_call"
       unpiped = "b(a) |> function_name(c, d) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "pipe chain with no raw start" do
       piped = "b(a) |> function_name(c, d) |> after_call"
       unpiped = "function_name(b(a), c, d) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in named function" do
       piped = "a |> function_name() |> after_call"
       unpiped = "function_name(a) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "three args in anonymous function" do
       piped = "a |> function_name.(b, c) |> after_call"
       unpiped = "function_name.(a, b, c) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in anonymous function" do
       piped = "a |> function_name.() |> after_call"
       unpiped = "function_name.(a) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "three args in named function and statement before call" do
       piped = "a |> function_name(b, c) |> after_call"
       unpiped = "function_name(a, b, c) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in named function and statement before call" do
       piped = "a |> function_name() |> after_call"
       unpiped = "function_name(a) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "three args in anonymous function and statement before call" do
       piped = "a |> function_name.(b, c) |> after_call"
       unpiped = "function_name.(a, b, c) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in anonymous function and statement before call" do
       piped = "a |> function_name.() |> after_call"
       unpiped = "function_name.(a) |> after_call"
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
   end
 
@@ -157,7 +156,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
       unpiped = "function_name(a, b, c) |> after_call"
 
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in named function" do
@@ -169,7 +168,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
       unpiped = "function_name(a) |> after_call"
 
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "three args in anonymous function" do
@@ -181,7 +180,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
       unpiped = "function_name.(a, b, c) |> after_call"
 
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "single arg in anonymous function" do
@@ -193,7 +192,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
       unpiped = "function_name.(MyModule.f(a)) |> after_call"
 
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
     end
 
     test "function call piped into another function" do
@@ -205,7 +204,12 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
 
       unpiped = "g(f(a), b, c) |> after_call"
 
-      assert AST.from_pipe(piped) == unpiped
+      assert AST.from_pipe(piped) == {:ok, unpiped}
+    end
+
+    test "multi-line with \r as separator and \r\n inside strings raises syntax error" do
+      # This test shows that the parser is limited to Elixir's parser's capabilities
+      assert {:error, :invalid_code} = AST.from_pipe(~s{X.Y.Z.function_name(\r1,\r"asdf\nghjk")})
     end
   end
 end

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes/ast_test.exs
@@ -9,6 +9,11 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes.ASTTe
                "text |> String.split(~r\"\\a\", trim: true)"
     end
 
+    test "treats macro.to_string escaping chars sigil" do
+      assert AST.to_pipe(~s[String.split(text, ~r{"\\a"}, trim: true)]) ==
+               ~s[text |> String.split(~r{"\\a"}, trim: true)]
+    end
+
     test "single-line selection with two args in named function" do
       assert AST.to_pipe("X.Y.Z.function_name(A.B.C.a(), b)") ==
                "A.B.C.a() |> X.Y.Z.function_name(b)"

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -28,7 +28,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
     end
   end
 
-  describe "execute/2 to_pipe" do
+  describe "execute/2 toPipe" do
     test "can pipe remote calls in single lines" do
       {:ok, _} =
         JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
@@ -49,12 +49,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 13,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 13],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -129,12 +124,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 12,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 12],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -207,12 +197,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 2,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 2],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -288,12 +273,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
         assert {:ok, nil} =
                  ManipulatePipes.execute(
-                   %{
-                     "uri" => uri,
-                     "cursor_line" => 2,
-                     "cursor_column" => 12,
-                     "operation" => "to_pipe"
-                   },
+                   ["toPipe", uri, 2, 12],
                    %Server{
                      source_files: %{
                        uri => %SourceFile{
@@ -364,12 +344,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 14,
-                   "operation" => "to_pipe"
-                 },
+                 ["toPipe", uri, 2, 14],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -420,7 +395,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
     end
   end
 
-  describe "execute/2 from_pipe" do
+  describe "execute/2 fromPipe" do
     test "can unpipe remote calls in single lines" do
       {:ok, _} =
         JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
@@ -441,12 +416,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 8,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 2, 8],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -521,12 +491,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 3,
-                   "cursor_column" => 5,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 3, 5],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -599,12 +564,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 2,
-                   "cursor_column" => 11,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 2, 11],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{
@@ -678,12 +638,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
         assert {:ok, nil} =
                  ManipulatePipes.execute(
-                   %{
-                     "uri" => uri,
-                     "cursor_line" => 3,
-                     "cursor_column" => 4,
-                     "operation" => "from_pipe"
-                   },
+                   ["fromPipe", uri, 3, 4],
                    %Server{
                      source_files: %{
                        uri => %SourceFile{
@@ -755,12 +710,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert {:ok, nil} =
                ManipulatePipes.execute(
-                 %{
-                   "uri" => uri,
-                   "cursor_line" => 3,
-                   "cursor_column" => 5,
-                   "operation" => "from_pipe"
-                 },
+                 ["fromPipe", uri, 3, 5],
                  %Server{
                    source_files: %{
                      uri => %SourceFile{

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -75,9 +75,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -152,9 +152,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -325,9 +325,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -403,9 +403,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                  "edit" => %{
                    "changes" => %{
                      uri => [
-                       %{
-                         "newText" => expected_substitution,
-                         "range" => expected_range
+                       %TextEdit{
+                         newText: expected_substitution,
+                         range: expected_range
                        }
                      ]
                    }
@@ -476,9 +476,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -548,9 +548,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -624,9 +624,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -701,9 +701,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }
@@ -852,9 +852,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                  "edit" => %{
                    "changes" => %{
                      uri => [
-                       %{
-                         "newText" => expected_substitution,
-                         "range" => expected_range
+                       %TextEdit{
+                         newText: expected_substitution,
+                         range: expected_range
                        }
                      ]
                    }
@@ -961,9 +961,9 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                "edit" => %{
                  "changes" => %{
                    uri => [
-                     %{
-                       "newText" => expected_substitution,
-                       "range" => expected_range
+                     %TextEdit{
+                       newText: expected_substitution,
+                       range: expected_range
                      }
                    ]
                  }

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -271,7 +271,16 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
       end
       """
 
-      expected_text = text
+      expected_text = """
+      defmodule Demo do
+        def my_fun(data) do
+          Track |> Ash.Changeset.for_create(:create, data)
+          |> GenTracker.API.create()
+        end
+
+        def next_fun(), do: 42
+      end
+      """
 
       {:ok, text_edit} = ManipulatePipes.to_pipe_at_cursor(text, 2, 49)
 

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -1266,8 +1266,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
   end
 
   def line_char(text, line, char) do
-      String.split(text, "\n")
-      |> Enum.at(line)
-      |> String.slice(char, ?\n)
+    String.split(text, "\n")
+    |> Enum.at(line)
+    |> String.slice(char, ?\n)
   end
 end

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -232,7 +232,31 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
       assert edited_text == expected_text
     end
 
-    # Broken
+    test "to_pipe_at_cursor end of line" do
+      text = """
+      defmodule Demo do
+        def my_fun(data) do
+          Ash.Changeset.for_create(Track, :create, data)\s
+          |> GenTracker.API.create()
+        end
+      end
+      """
+
+      expected_text = """
+      defmodule Demo do
+        def my_fun(data) do
+          Track |> Ash.Changeset.for_create(:create, data)
+          |> GenTracker.API.create()
+        end
+      end
+      """
+
+      {:ok, text_edit} = ManipulatePipes.to_pipe_at_cursor(text, 2, 50)
+
+      edited_text = ElixirLS.LanguageServer.Test.TestUtils.apply_text_edit(text, text_edit)
+      assert edited_text == expected_text
+    end
+
     test "to_pipe_at_cursor near end of line" do
       text = """
       defmodule Demo do

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -443,7 +443,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
         "start" => %{"character" => 16, "line" => 4}
       }
 
-      expected_substitution = "to_string(a |> add_num(12))"
+      expected_substitution = "add_num(a, 12) |> to_string()"
 
       assert params == %{
                "edit" => %{
@@ -464,7 +464,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
         def add(a) do
           require Logger
 
-          Logger.info(to_string(a |> add_num(12)))
+          Logger.info(add_num(a, 12) |> to_string())
         end
 
         def add_num(a, num), do: a + num

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -1,0 +1,813 @@
+defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest do
+  use ExUnit.Case
+
+  alias ElixirLS.LanguageServer.{Server, SourceFile}
+  alias ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes
+
+  defmodule JsonRpcMock do
+    use GenServer
+
+    def init(args), do: {:ok, args}
+
+    def start_link(args) do
+      GenServer.start_link(__MODULE__, args, name: ElixirLS.LanguageServer.JsonRpc)
+    end
+
+    def handle_call(
+          msg,
+          _from,
+          state
+        ) do
+      send(state[:test_pid], msg)
+
+      if state[:should_fail] do
+        {:reply, state[:error_reply], state}
+      else
+        {:reply, state[:success_reply], state}
+      end
+    end
+  end
+
+  describe "execute/2 to_pipe" do
+    test "can pipe remote calls in single lines" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:///some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          Kernel.+(x, 1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 13,
+                   "operation" => "to_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 18, "line" => 2},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "x |> Kernel.+(1)"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert function call to pipe operator"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          x |> Kernel.+(1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    test "can pipe remote calls when there are multi-line args" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          Kernel.+(
+            x,
+            1
+          )
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 12,
+                   "operation" => "to_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 5, "line" => 5},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "x |> Kernel.+(1)"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert function call to pipe operator"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          x |> Kernel.+(1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    test "can pipe local calls in single line" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          g(h(x, 2), h(3, 4))
+          |> Kernel.+(2)
+        end
+
+        def g(x, y), do: x + y
+
+        def h(a, b), do: a - b
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 2,
+                   "operation" => "to_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 23, "line" => 2},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "h(x, 2) |> g(h(3, 4))"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert function call to pipe operator"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          h(x, 2) |> g(h(3, 4))
+          |> Kernel.+(2)
+        end
+
+        def g(x, y), do: x + y
+
+        def h(a, b), do: a - b
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    for {line_sep, test_name_suffix} <- [{"\r\n", "\\r\\n"}, {"\n", "\\n"}] do
+      test "can pipe correctly when the line separator is #{test_name_suffix}" do
+        {:ok, _} =
+          JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+        uri = "file:/some_file.ex"
+
+        base_code = [
+          "defmodule A do",
+          "  def f(x)  do",
+          "    Kernel.+(",
+          "      x,",
+          "      y",
+          "    )",
+          "    |> B.g()",
+          "  end",
+          "end"
+        ]
+
+        text = Enum.join(base_code, unquote(line_sep))
+
+        assert {:ok, nil} =
+                 ManipulatePipes.execute(
+                   %{
+                     "uri" => uri,
+                     "cursor_line" => 2,
+                     "cursor_column" => 12,
+                     "operation" => "to_pipe"
+                   },
+                   %Server{
+                     source_files: %{
+                       uri => %SourceFile{
+                         text: text
+                       }
+                     }
+                   }
+                 )
+
+        assert_receive {:request, "workspace/applyEdit", params}
+
+        expected_range = %{
+          "end" => %{"character" => 5, "line" => 5},
+          "start" => %{"character" => 4, "line" => 2}
+        }
+
+        expected_substitution = "x |> Kernel.+(y)"
+
+        assert params == %{
+                 "edit" => %{
+                   "changes" => %{
+                     uri => [
+                       %{
+                         "newText" => expected_substitution,
+                         "range" => expected_range
+                       }
+                     ]
+                   }
+                 },
+                 "label" => "Convert function call to pipe operator"
+               }
+
+        expected_base_code = [
+          "defmodule A do",
+          "  def f(x)  do",
+          "    x |> Kernel.+(y)",
+          "    |> B.g()",
+          "  end",
+          "end"
+        ]
+
+        edited_text = Enum.join(expected_base_code, unquote(line_sep))
+
+        assert edited_text ==
+                 ElixirLS.LanguageServer.SourceFile.apply_edit(
+                   text,
+                   expected_range,
+                   expected_substitution
+                 )
+      end
+    end
+
+    test "can handle utf 16 characters" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          g("éééççç", x)
+        end
+
+        def g(a, b), do: a <> b
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 14,
+                   "operation" => "to_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 18, "line" => 2},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = ~s{"éééççç" |> g(x)}
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert function call to pipe operator"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          "éééççç" |> g(x)
+        end
+
+        def g(a, b), do: a <> b
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+  end
+
+  describe "execute/2 from_pipe" do
+    test "can unpipe remote calls in single lines" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          g(1) |> Kernel.+(1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 8,
+                   "operation" => "from_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 23, "line" => 2},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "Kernel.+(g(1), 1)"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert pipe operator to function call"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          Kernel.+(g(1), 1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    test "can unpipe remote calls when there are multi-line args" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          x
+          |> Kernel.+(
+            1
+          )
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 3,
+                   "cursor_column" => 5,
+                   "operation" => "from_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 5, "line" => 5},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "Kernel.+(x, 1)"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert pipe operator to function call"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          Kernel.+(x, 1)
+          |> Kernel.+(2)
+          |> g()
+        end
+
+        def g(y), do: y
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    test "can unpipe local calls in single line" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          h(x, 2) |> g(h(3, 4))
+          |> Kernel.+(2)
+        end
+
+        def g(x, y), do: x + y
+
+        def h(a, b), do: a - b
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 2,
+                   "cursor_column" => 11,
+                   "operation" => "from_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 25, "line" => 2},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = "g(h(x, 2), h(3, 4))"
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert pipe operator to function call"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          g(h(x, 2), h(3, 4))
+          |> Kernel.+(2)
+        end
+
+        def g(x, y), do: x + y
+
+        def h(a, b), do: a - b
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+
+    for {line_sep, test_name_suffix} <- [{"\r\n", "\\r\\n"}, {"\n", "\\n"}] do
+      test "can unpipe correctly when the line separator is #{test_name_suffix}" do
+        {:ok, _} =
+          JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+        uri = "file:/some_file.ex"
+
+        base_code = [
+          "defmodule A do",
+          "  def f(x)  do",
+          "    x",
+          "    |> Kernel.+(y)",
+          "    |> B.g()",
+          "  end",
+          "end"
+        ]
+
+        text = Enum.join(base_code, unquote(line_sep))
+
+        assert {:ok, nil} =
+                 ManipulatePipes.execute(
+                   %{
+                     "uri" => uri,
+                     "cursor_line" => 3,
+                     "cursor_column" => 4,
+                     "operation" => "from_pipe"
+                   },
+                   %Server{
+                     source_files: %{
+                       uri => %SourceFile{
+                         text: text
+                       }
+                     }
+                   }
+                 )
+
+        assert_receive {:request, "workspace/applyEdit", params}
+
+        expected_range = %{
+          "end" => %{"character" => 18, "line" => 3},
+          "start" => %{"character" => 4, "line" => 2}
+        }
+
+        expected_substitution = "Kernel.+(x, y)"
+
+        assert params == %{
+                 "edit" => %{
+                   "changes" => %{
+                     uri => [
+                       %{
+                         "newText" => expected_substitution,
+                         "range" => expected_range
+                       }
+                     ]
+                   }
+                 },
+                 "label" => "Convert pipe operator to function call"
+               }
+
+        expected_base_code = [
+          "defmodule A do",
+          "  def f(x)  do",
+          "    Kernel.+(x, y)",
+          "    |> B.g()",
+          "  end",
+          "end"
+        ]
+
+        edited_text = Enum.join(expected_base_code, unquote(line_sep))
+
+        assert edited_text ==
+                 ElixirLS.LanguageServer.SourceFile.apply_edit(
+                   text,
+                   expected_range,
+                   expected_substitution
+                 )
+      end
+    end
+
+    test "can handle utf 16 characters" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      defmodule A do
+        def f(x) do
+          x
+          |> g("éééççç")
+        end
+
+        def g(a, b), do: a <> b
+      end
+      """
+
+      assert {:ok, nil} =
+               ManipulatePipes.execute(
+                 %{
+                   "uri" => uri,
+                   "cursor_line" => 3,
+                   "cursor_column" => 5,
+                   "operation" => "from_pipe"
+                 },
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
+
+      assert_receive {:request, "workspace/applyEdit", params}
+
+      expected_range = %{
+        "end" => %{"character" => 18, "line" => 3},
+        "start" => %{"character" => 4, "line" => 2}
+      }
+
+      expected_substitution = ~s{g(x, "éééççç")}
+
+      assert params == %{
+               "edit" => %{
+                 "changes" => %{
+                   uri => [
+                     %{
+                       "newText" => expected_substitution,
+                       "range" => expected_range
+                     }
+                   ]
+                 }
+               },
+               "label" => "Convert pipe operator to function call"
+             }
+
+      edited_text = """
+      defmodule A do
+        def f(x) do
+          g(x, "éééççç")
+        end
+
+        def g(a, b), do: a <> b
+      end
+      """
+
+      assert ElixirLS.LanguageServer.SourceFile.apply_edit(
+               text,
+               expected_range,
+               expected_substitution
+             ) == edited_text
+    end
+  end
+end


### PR DESCRIPTION
This PR also adds a test that shows a bug which seems to be in Macro.to_string itself :( I've opened an issue in the Elixir repo https://github.com/elixir-lang/elixir/issues/10864 for discussion. Maybe this is expected and is something we have to deal with