### PR TITLE
Support describes and tests with unevaluated names

### DIFF
--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -219,7 +219,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   defp extract_symbol(_current_module, {:test, location, [name | _]}) do
     %Info{
       type: :function,
-      name: ~s(test "#{name}"),
+      name: "test #{Macro.to_string(name)}",
       location: location,
       children: []
     }
@@ -251,7 +251,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
 
     %Info{
       type: :function,
-      name: ~s(describe "#{name}"),
+      name: "describe #{Macro.to_string(name)}",
       location: location,
       children: module_symbols
     }

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2018,7 +2018,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text, false)
   end
 
-  test "[nested] handles exunit descibe tests" do
+  test "[nested] handles exunit describe tests" do
     uri = "file:///project/test.exs"
     text = ~S[
       defmodule MyModuleTest do
@@ -2075,7 +2075,64 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
             ]} = DocumentSymbols.symbols(uri, text, true)
   end
 
-  test "[flat] handles exunit descibe tests" do
+  test "[nested] handles exunit describes and tests with unevaluated names" do
+    uri = "file:///project/test.exs"
+    text = ~S[
+      defmodule MyModuleTest do
+        use ExUnit.Case
+        describe ~S(some "descripton") do
+          test "does" <> "something", do: :ok
+        end
+      end
+    ]
+
+    assert {:ok,
+            [
+              %Protocol.DocumentSymbol{
+                children: [
+                  %Protocol.DocumentSymbol{
+                    children: [
+                      %Protocol.DocumentSymbol{
+                        children: [],
+                        kind: 12,
+                        name: "test \"does\" <> \"something\"",
+                        range: %{
+                          end: %{character: 10, line: 4},
+                          start: %{character: 10, line: 4}
+                        },
+                        selectionRange: %{
+                          end: %{character: 10, line: 4},
+                          start: %{character: 10, line: 4}
+                        }
+                      }
+                    ],
+                    kind: 12,
+                    name: "describe ~S(some \"descripton\")",
+                    range: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    },
+                    selectionRange: %{
+                      end: %{character: 8, line: 3},
+                      start: %{character: 8, line: 3}
+                    }
+                  }
+                ],
+                kind: 2,
+                name: "MyModuleTest",
+                range: %{
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
+                },
+                selectionRange: %{
+                  end: %{character: 6, line: 1},
+                  start: %{character: 6, line: 1}
+                }
+              }
+            ]} = DocumentSymbols.symbols(uri, text, true)
+  end
+
+  test "[flat] handles exunit describe tests" do
     uri = "file:///project/test.exs"
     text = ~S[
       defmodule MyModuleTest do
@@ -2110,6 +2167,45 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                   range: %{end: %{character: 10, line: 4}, start: %{character: 10, line: 4}}
                 },
                 containerName: "describe \"some descripton\""
+              }
+            ]} = DocumentSymbols.symbols(uri, text, false)
+  end
+
+  test "[flat] handles exunit describes and tests with unevaluated names" do
+    uri = "file:///project/test.exs"
+    text = ~S[
+      defmodule MyModuleTest do
+        use ExUnit.Case
+        describe ~S(some "descripton") do
+          test "does" <> "something", do: :ok
+        end
+      end
+    ]
+
+    assert {:ok,
+            [
+              %Protocol.SymbolInformation{
+                name: "MyModuleTest",
+                kind: 2,
+                location: %{
+                  range: %{end: %{character: 6, line: 1}, start: %{character: 6, line: 1}}
+                }
+              },
+              %Protocol.SymbolInformation{
+                name: "describe ~S(some \"descripton\")",
+                kind: 12,
+                location: %{
+                  range: %{end: %{character: 8, line: 3}, start: %{character: 8, line: 3}}
+                },
+                containerName: "MyModuleTest"
+              },
+              %Protocol.SymbolInformation{
+                name: "test \"does\" <> \"something\"",
+                kind: 12,
+                location: %{
+                  range: %{end: %{character: 10, line: 4}, start: %{character: 10, line: 4}}
+                },
+                containerName: "describe ~S(some \"descripton\")"
               }
             ]} = DocumentSymbols.symbols(uri, text, false)
   end


### PR DESCRIPTION
My work codebase features a number of tests formatted like this:

```elixir
test "performs some " <> "action" do
  assert work_done()
end
```

I don't really like this formatting, but it _is_ valid syntax.

However, the language server crashes with message:

    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:<>, ... ["performs some", "action"], ...

This comes from [`lib/language_server/providers/document_symbols.ex:222`](https://github.com/elixir-lsp/elixir-ls/blob/cfef8a7dec75765d899340c2518272d4361094de/apps/language_server/lib/language_server/providers/document_symbols.ex#L222) where the "name" of the test is interpolated into a string. In order for this "unevaluated" test name AST to be interpolated into a string, it must first be a string or something that the String.Chars protocol can turn into a string.

My approach here is to turn the test name AST into a string using `Macro.to_string`, which simply converts the AST back into its Elixir code equivalent.