### PR TITLE
'test' snippet includes double quotes

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -52,7 +52,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
     {"Kernel", "defstruct"} => "defstruct $1: $2",
     {"ExUnit.Callbacks", "setup"} => "setup ${1:%{$2\\}} do\n\t$3\nend",
     {"ExUnit.Callbacks", "setup_all"} => "setup_all ${1:%{$2\\}} do\n\t$3\nend",
-    {"ExUnit.Case", "test"} => "test $1 do\n\t$0\nend",
+    {"ExUnit.Case", "test"} => "test \"$1\" do\n\t$0\nend",
     {"ExUnit.Case", "describe"} => "describe \"$1\" do\n\t$0\nend"
   }
 


### PR DESCRIPTION
The 'test' snippet did not complete the quotes for the test name. This
was an inconsistency compared to the 'describe` snippet, which included
the double quotes.
