### PR TITLE
Elixir 1.12 compatibility improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,6 @@ jobs:
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.12.x
-            otp: 23.x
-            tests_may_fail: false
-            check_unused_deps: true
-          - elixir: 1.11.x
-            otp: 23.x
-            tests_may_fail: false
-            check_unused_deps: true
-          - elixir: 1.11.x
-            otp: 24.x
-            tests_may_fail: false
-            check_unused_deps: true
-          - elixir: 1.12.x
             otp: 24.0.x
             tests_may_fail: false
             warnings_as_errors: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.12.x
+            otp: 23.x
+            tests_may_fail: false
+            check_unused_deps: true
+          - elixir: 1.11.x
+            otp: 23.x
+            tests_may_fail: false
+            check_unused_deps: true
+          - elixir: 1.11.x
+            otp: 24.x
+            tests_may_fail: false
+            check_unused_deps: true
+          - elixir: 1.12.x
             otp: 24.0.x
             tests_may_fail: false
             warnings_as_errors: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,22 @@ jobs:
             otp: 21.3.8.20
             tests_may_fail: false
           - elixir: 1.9.x
-            otp: 21.3.8.20
+            otp: 21.3.8.23
             tests_may_fail: false
           - elixir: 1.10.x
-            otp: 21.3.8.20
+            otp: 21.3.8.23
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.11.x
             otp: 21.3.8.20
             tests_may_fail: false
             check_unused_deps: true
-          - elixir: 1.11.x
-            otp: 23.2.x
+          - elixir: 1.12.x
+            otp: 22.3.4.19
+            tests_may_fail: false
+            check_unused_deps: true
+          - elixir: 1.12.x
+            otp: 24.0.x
             tests_may_fail: false
             warnings_as_errors: true
             check_formatted: true
@@ -62,8 +66,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.11.x
-            otp: 23.2.x
+          - elixir: 1.12.x
+            otp: 24.0.x
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -32,11 +32,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir-version: '1.11'
-            otp-version: '23.1'
+          - elixir-version: '1.12'
+            otp-version: '24.0'
+          - elixir-version: '1.11.4'
+            otp-version: '23.3'
           - elixir-version: '1.10.4'
-            otp-version: '23.1'
-          - elixir-version: '1.9'
+            otp-version: '23.3'
+          - elixir-version: '1.9.4'
             otp-version: '22.3'
           - elixir-version: '1.8.2'
             otp-version: '21.3'

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -326,9 +326,7 @@ defmodule ElixirLS.LanguageServer.Server do
       # close notification send before
       JsonRpc.log_message(
         :warning,
-        "Received textDocument/didOpen for file that is already open. Received uri: #{
-          inspect(uri)
-        }"
+        "Received textDocument/didOpen for file that is already open. Received uri: #{inspect(uri)}"
       )
 
       state

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -28,11 +28,11 @@ defmodule ElixirLS.LanguageServer.Mixfile do
     [
       {:elixir_ls_utils, in_umbrella: true},
       {:elixir_sense, github: "elixir-lsp/elixir_sense"},
-      {:forms, "~> 0.0.1"},
+      {:forms, "~> 0.0"},
       {:erl2ex, github: "dazuma/erl2ex"},
-      {:dialyxir, "~> 1.0.0", runtime: false},
+      {:dialyxir, "~> 1.0", runtime: false},
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
-      {:stream_data, "~> 0.5.0", only: :test}
+      {:stream_data, "~> 0.5", only: :test}
     ]
   end
 

--- a/apps/language_server/test/dialyzer_test.exs
+++ b/apps/language_server/test/dialyzer_test.exs
@@ -41,8 +41,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message1,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 1},
-                     "start" => %{"character" => 0, "line" => 1}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -50,8 +50,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message2,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 2},
-                     "start" => %{"character" => 0, "line" => 2}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -175,8 +175,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message1,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 1},
-                     "start" => %{"character" => 0, "line" => 1}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -184,8 +184,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message2,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 2},
-                     "start" => %{"character" => 0, "line" => 2}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -229,8 +229,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message1,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 1},
-                     "start" => %{"character" => 0, "line" => 1}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -238,8 +238,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message2,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 2},
-                     "start" => %{"character" => 0, "line" => 2}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -274,8 +274,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message1,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 1},
-                     "start" => %{"character" => 0, "line" => 1}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -283,8 +283,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => _error_message2,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 2},
-                     "start" => %{"character" => 0, "line" => 2}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -320,8 +320,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message1,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 1},
-                     "start" => %{"character" => 0, "line" => 1}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"
@@ -329,8 +329,8 @@ defmodule ElixirLS.LanguageServer.DialyzerTest do
                  %{
                    "message" => error_message2,
                    "range" => %{
-                     "end" => %{"character" => 0, "line" => 2},
-                     "start" => %{"character" => 0, "line" => 2}
+                     "end" => %{"character" => 0, "line" => _},
+                     "start" => %{"character" => 0, "line" => _}
                    },
                    "severity" => 2,
                    "source" => "ElixirLS Dialyzer"

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "1fb9b6b63ebc0429a1db87da2381a22707d51e3a", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "d35b08a32efea1c73f837211fd1a3e2f280b51e8", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "forms": {:hex, :forms, "0.0.1", "45f3b10b6f859f95f2c2c1a1de244d63855296d55ed8e93eb0dd116b3e86c4a6", [:rebar3], [], "hexpm", "530f63ed8ed5a171f744fc75bd69cb2e36496899d19dbef48101b4636b795868"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
+  "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
   "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "d35b08a32efea1c73f837211fd1a3e2f280b51e8", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},


### PR DESCRIPTION
Bump elixir_sense - fixes for late breaking changes (after rc-0...) and added support for stepped ranges
Run CI on elixir 1.12 and otp 24