### PR TITLE
Guard against sending -1 line or column locations in LSP messages

### DIFF
--- a/apps/language_server/lib/language_server/protocol/location.ex
+++ b/apps/language_server/lib/language_server/protocol/location.ex
@@ -17,11 +17,16 @@ defmodule ElixirLS.LanguageServer.Protocol.Location do
         _ -> SourceFile.path_to_uri(file)
       end
 
+    # LSP messages are 0 indexed whilst elixir/erlang is 1 indexed.
+    # Guard against malformed line or column values.
+    line = max(line - 1, 0)
+    column = max(column - 1, 0)
+
     %Protocol.Location{
       uri: uri,
       range: %{
-        "start" => %{"line" => line - 1, "character" => column - 1},
-        "end" => %{"line" => line - 1, "character" => column - 1}
+        "start" => %{"line" => line, "character" => column},
+        "end" => %{"line" => line, "character" => column}
       }
     }
   end


### PR DESCRIPTION
**What**

Makes sure we don't send locations with line or column values that are less than 0.

**See also**

https://github.com/elixir-lsp/elixir-ls/issues/556

https://github.com/erlang/otp/pull/4893

https://github.com/neovim/neovim/pull/14737