### PR TITLE
Update minimum versions to Elixir 1.10 and OTP 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.8.x
-            otp: 21.3.8.20
-            tests_may_fail: false
-          - elixir: 1.9.x
-            otp: 21.3.8.23
-            tests_may_fail: false
           - elixir: 1.10.x
-            otp: 21.3.8.23
+            otp: 22.3.4.20
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.11.x
-            otp: 21.3.8.20
+            otp: 23.3.4.4
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.12.x
-            otp: 22.3.4.19
+            otp: 23.3.4.4
             tests_may_fail: false
             check_unused_deps: true
           - elixir: 1.12.x

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -32,16 +32,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir-version: '1.12'
+          - elixir-version: '1.12.1'
             otp-version: '24.0'
           - elixir-version: '1.11.4'
             otp-version: '23.3'
           - elixir-version: '1.10.4'
-            otp-version: '23.3'
-          - elixir-version: '1.9.4'
             otp-version: '22.3'
-          - elixir-version: '1.8.2'
-            otp-version: '21.3'
             default: true
 
     steps:

--- a/.release-tool-versions
+++ b/.release-tool-versions
@@ -3,5 +3,5 @@
 #
 # The versions selected here are the versions that are used to build a binary
 # release for distribution
-elixir 1.8.2-otp-21
-erlang 21.3.8.17
+elixir 1.10.4-otp-22
+erlang 22.3.4.20

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ For VSCode install the extension: https://marketplace.visualstudio.com/items?ite
 
 Elixir:
 
-- 1.8.0 minimum
+- 1.10.0 minimum
 
 Erlang:
 
-- OTP 21 minimum
+- OTP 22 minimum
 
 Installing Elixir and Erlang from [ASDF](https://github.com/asdf-vm/asdf) is generally recommended so that you can have different projects using different versions of Elixir without having to change your system-installed version. ElixirLS will detect and use the version of Elixir and Erlang that you have configured in asdf.
 

--- a/apps/elixir_ls_debugger/lib/debugger/cli.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/cli.ex
@@ -14,32 +14,24 @@ defmodule ElixirLS.Debugger.CLI do
     WireProtocol.stream_packets(&Server.receive_packet/1)
   end
 
-  # Debugging does not work on Elixir 1.10.0-1.10.2:
-  # https://github.com/elixir-lsp/elixir-ls/issues/158
   defp warn_if_unsupported_version do
-    elixir_version = System.version()
-
-    unless Version.match?(elixir_version, ">= 1.8.0") do
-      message =
-        "WARNING: Elixir versions below 1.8 are not supported. (Currently v#{elixir_version})"
-
-      Output.print_err(message)
+    with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_elixir_version() do
+      Output.print_err("WARNING: " <> message)
     end
+
+    with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_otp_version() do
+      Output.print_err("WARNING: " <> message)
+    end
+
+    # Debugging does not work on Elixir 1.10.0-1.10.2:
+    # https://github.com/elixir-lsp/elixir-ls/issues/158
+    elixir_version = System.version()
 
     if Version.match?(elixir_version, ">= 1.10.0") && Version.match?(elixir_version, "< 1.10.3") do
       message =
         "WARNING: Debugging is not supported on Elixir #{elixir_version}. Please upgrade" <>
           " to at least 1.10.3\n" <>
           "more info: https://github.com/elixir-lsp/elixir-ls/issues/158"
-
-      Output.print_err(message)
-    end
-
-    otp_release = String.to_integer(System.otp_release())
-
-    if otp_release < 21 do
-      message =
-        "WARNING: Erlang OTP releases below 21 are not supported (Currently OTP #{otp_release})"
 
       Output.print_err(message)
     end

--- a/apps/elixir_ls_debugger/mix.exs
+++ b/apps/elixir_ls_debugger/mix.exs
@@ -9,7 +9,7 @@ defmodule ElixirLS.Debugger.Mixfile do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      elixir: ">= 1.8.0",
+      elixir: ">= 1.10.0",
       build_embedded: false,
       start_permanent: true,
       build_per_environment: false,

--- a/apps/elixir_ls_utils/lib/minimum_version.ex
+++ b/apps/elixir_ls_utils/lib/minimum_version.ex
@@ -1,0 +1,19 @@
+defmodule ElixirLS.Utils.MinimumVersion do
+  def check_otp_version do
+    otp_release = String.to_integer(System.otp_release())
+
+    if otp_release < 22 do
+      {:error, "Erlang OTP releases below 22 are not supported (Currently running OTP #{otp_release})"}
+    else
+      :ok
+    end
+  end
+
+  def check_elixir_version do
+    if Version.match?(System.version(), ">= 1.10.0") do
+      :ok
+    else
+      {:error, "Elixir versions below 1.10 are not supported. (Currently running v#{System.version()})"}
+    end
+  end
+end

--- a/apps/elixir_ls_utils/lib/minimum_version.ex
+++ b/apps/elixir_ls_utils/lib/minimum_version.ex
@@ -3,7 +3,8 @@ defmodule ElixirLS.Utils.MinimumVersion do
     otp_release = String.to_integer(System.otp_release())
 
     if otp_release < 22 do
-      {:error, "Erlang OTP releases below 22 are not supported (Currently running OTP #{otp_release})"}
+      {:error,
+       "Erlang OTP releases below 22 are not supported (Currently running OTP #{otp_release})"}
     else
       :ok
     end
@@ -13,7 +14,8 @@ defmodule ElixirLS.Utils.MinimumVersion do
     if Version.match?(System.version(), ">= 1.10.0") do
       :ok
     else
-      {:error, "Elixir versions below 1.10 are not supported. (Currently running v#{System.version()})"}
+      {:error,
+       "Elixir versions below 1.10 are not supported. (Currently running v#{System.version()})"}
     end
   end
 end

--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -10,7 +10,7 @@ defmodule ElixirLS.Utils.Mixfile do
       deps_path: "../../deps",
       elixirc_paths: elixirc_paths(Mix.env()),
       lockfile: "../../mix.lock",
-      elixir: ">= 1.8.0",
+      elixir: ">= 1.10.0",
       build_embedded: false,
       start_permanent: false,
       build_per_environment: false,

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1015,20 +1015,12 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   defp show_version_warnings do
-    unless Version.match?(System.version(), ">= 1.8.0") do
-      JsonRpc.show_message(
-        :warning,
-        "Elixir versions below 1.8 are not supported. (Currently v#{System.version()})"
-      )
+    with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_elixir_version() do
+      JsonRpc.show_message(:warning, message)
     end
 
-    otp_release = String.to_integer(System.otp_release())
-
-    if otp_release < 21 do
-      JsonRpc.show_message(
-        :info,
-        "Erlang OTP releases below 21 are not supported (Currently OTP #{otp_release})"
-      )
+    with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_otp_version() do
+      JsonRpc.show_message(:warning, message)
     end
 
     case Dialyzer.check_support() do

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -5,7 +5,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
     [
       app: :language_server,
       version: "0.7.0",
-      elixir: ">= 1.8.0",
+      elixir: ">= 1.10.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ElixirLS.Mixfile do
       start_permanent: Mix.env() == :prod,
       build_per_environment: false,
       deps: deps(),
-      elixir: ">= 1.8.0",
+      elixir: ">= 1.10.0",
       dialyzer: [
         plt_add_apps: [:dialyxir, :debugger, :dialyzer, :hipe],
         flags: [


### PR DESCRIPTION
Keeps them in line with our Version Support Guidance:
https://github.com/elixir-lsp/elixir-ls/blob/be0af9dadb2c4cceeb0893fe71d8380debe33f08/DEVELOPMENT.md#version-support-guidelines

- update all the relevant test files
- create a consolidated module to test the minimum versions

Also by moving the minimum version of Elixir to 1.10 we can finally use
compilation tracers (initial PR at https://github.com/elixir-lsp/elixir_sense/pull/80)