### PR TITLE
Trigger signature_help on comma

### DIFF
--- a/apps/language_server/lib/language_server/providers/signature_help.ex
+++ b/apps/language_server/lib/language_server/providers/signature_help.ex
@@ -1,7 +1,7 @@
 defmodule ElixirLS.LanguageServer.Providers.SignatureHelp do
   alias ElixirLS.LanguageServer.SourceFile
 
-  def trigger_characters(), do: ["("]
+  def trigger_characters(), do: ["(", ","]
 
   def signature(%SourceFile{} = source_file, line, character) do
     response =


### PR DESCRIPTION
Fixes an issue where some tools are not properly triggered for signature help. 

See https://github.com/ray-x/lsp_signature.nvim/issues/38