### PR TITLE
add quick search to hexdocs.pm

### DIFF
--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -51,25 +51,167 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   defp contents(%{docs: markdown}, subject) do
     %{
       kind: "markdown",
-      value: format_query(markdown, subject)
+      value: add_hexdocs_link(markdown, subject)
     }
   end
 
-  defp title(s) do
-    s |> String.split("\n\n") |> hd()
+  defp add_hexdocs_link(markdown, subject) do
+    IO.inspect(subject)
+
+    [hd | tail] = markdown |> String.split("\n\n")
+
+    link = hexdocs_link(markdown, subject)
+
+    case link do
+      "" ->
+        markdown
+
+      _ ->
+        hd <> "  [view on hexdocs](#{link})\n\n" <> Enum.join(tail, "")
+    end
   end
 
-  defp format_query(markdown, subject) do
-    t = markdown |> title()
+  defp hexdocs_link(markdown, subject) do
+    t = markdown |> String.split("\n\n") |> hd() |> String.replace(">", "") |> String.trim()
 
-    String.replace(
-      markdown,
-      t,
-      "[#{t}](https://hexdocs.pm/elixir/search.html?q=#{remove_special_symbol(subject)})"
-    )
+    cond do
+      func?(t) ->
+        mod_name = module_name(t)
+
+        if elixir_module?(mod_name) do
+          "https://hexdocs.pm/elixir/#{module_name(subject)}.html##{func_name(subject)}/#{params_cnt(t)}"
+        else
+          ""
+        end
+
+      true ->
+        if elixir_module?(t) do
+          "https://hexdocs.pm/elixir/#{t}.html"
+        else
+          ""
+        end
+    end
   end
 
   defp remove_special_symbol(s) do
     s |> String.replace("!", "") |> String.replace("?", "")
+  end
+
+  defp groups_for_modules do
+    [
+      Kernel: [Kernel, Kernel.SpecialForms],
+      "Basic Types": [
+        Atom,
+        Base,
+        Bitwise,
+        Date,
+        DateTime,
+        Exception,
+        Float,
+        Function,
+        Integer,
+        Module,
+        NaiveDateTime,
+        Record,
+        Regex,
+        String,
+        Time,
+        Tuple,
+        URI,
+        Version,
+        Version.Requirement
+      ],
+      "Collections & Enumerables": [
+        Access,
+        Date.Range,
+        Enum,
+        Keyword,
+        List,
+        Map,
+        MapSet,
+        Range,
+        Stream
+      ],
+      "IO & System": [
+        File,
+        File.Stat,
+        File.Stream,
+        IO,
+        IO.ANSI,
+        IO.Stream,
+        OptionParser,
+        Path,
+        Port,
+        StringIO,
+        System
+      ],
+      Calendar: [
+        Calendar,
+        Calendar.ISO,
+        Calendar.TimeZoneDatabase,
+        Calendar.UTCOnlyTimeZoneDatabase
+      ],
+      "Processes & Applications": [
+        Agent,
+        Application,
+        Config,
+        Config.Provider,
+        Config.Reader,
+        DynamicSupervisor,
+        GenServer,
+        Node,
+        Process,
+        Registry,
+        Supervisor,
+        Task,
+        Task.Supervisor
+      ],
+      Protocols: [
+        Collectable,
+        Enumerable,
+        Inspect,
+        Inspect.Algebra,
+        Inspect.Opts,
+        List.Chars,
+        Protocol,
+        String.Chars
+      ],
+      "Code & Macros": [
+        Code,
+        Kernel.ParallelCompiler,
+        Macro,
+        Macro.Env
+      ]
+    ]
+  end
+
+  defp func?(s) do
+    s =~ ~r/.*\..*\(.*\)/
+  end
+
+  defp elixir_module?(s) do
+    groups_for_modules()
+    |> Enum.map(fn x -> elem(x, 1) end)
+    |> Enum.reduce(fn x, y -> x ++ y end)
+    |> Enum.any?(fn x ->
+      x == String.to_atom("Elixir." <> s)
+    end)
+  end
+
+  defp module_name(s) do
+    [_ | tail] = s |> String.split(".") |> Enum.reverse()
+    Enum.join(tail, ".")
+  end
+
+  defp func_name(s) do
+    s |> String.split(".") |> Enum.reverse() |> hd()
+  end
+
+  defp params_cnt(s) do
+    cond do
+      true == (s =~ ~r/\(\)/) -> 0
+      false == String.contains?(s, ",") -> 1
+      true -> s |> String.split(",") |> length()
+    end
   end
 end

--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -6,7 +6,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   """
 
   @hex_base_url "https://hexdocs.pm"
-  @buildin_flag [
+  @builtin_flag [
                   "elixir",
                   "eex",
                   "ex_unit",
@@ -152,7 +152,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   end
 
   defp builtin?(source) do
-    @buildin_flag |> Enum.any?(fn y -> String.contains?(source, y) end)
+    @builtin_flag |> Enum.any?(fn y -> String.contains?(source, y) end)
   end
 
   def builtin_dep_name(source) do

--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -81,22 +81,30 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   end
 
   defp hexdocs_link(hd, subject, project_dir) do
-    t = hd |> String.replace(">", "") |> String.trim() |> URI.encode()
-    dep = subject |> root_module_name() |> dep_name(project_dir) |> URI.encode()
+    title = hd |> String.replace(">", "") |> String.trim() |> URI.encode()
 
     cond do
-      func?(t) ->
-        if dep != "" do
-          "#{@hex_base_url}/#{dep}/#{module_name(subject)}.html##{func_name(subject)}/#{params_cnt(t)}"
-        else
-          ""
-        end
+      erlang_module?(subject) ->
+        # erlang moudle is not support now.
+        ""
 
       true ->
-        if dep != "" do
-          "#{@hex_base_url}/#{dep}/#{t}.html"
-        else
-          ""
+        dep = subject |> root_module_name() |> dep_name(project_dir) |> URI.encode()
+
+        cond do
+          func?(title) ->
+            if dep != "" do
+              "#{@hex_base_url}/#{dep}/#{module_name(subject)}.html##{func_name(subject)}/#{params_cnt(title)}"
+            else
+              ""
+            end
+
+          true ->
+            if dep != "" do
+              "#{@hex_base_url}/#{dep}/#{title}.html"
+            else
+              ""
+            end
         end
     end
   end
@@ -155,8 +163,12 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
     @builtin_flag |> Enum.any?(fn y -> String.contains?(source, y) end)
   end
 
-  def builtin_dep_name(source) do
+  defp builtin_dep_name(source) do
     [_, name | _] = String.split(source, "/lib/")
     name
+  end
+
+  defp erlang_module?(subject) do
+    subject |> root_module_name() |> String.starts_with?(":")
   end
 end

--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -55,7 +55,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
     end)
   end
 
-  defp contents(%{docs: "No documentation available\n"}, subject) do
+  defp contents(%{docs: "No documentation available\n"}, _subject) do
     []
   end
 
@@ -99,10 +99,6 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
           ""
         end
     end
-  end
-
-  defp remove_special_symbol(s) do
-    s |> String.replace("!", "") |> String.replace("?", "")
   end
 
   defp func?(s) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -600,7 +600,7 @@ defmodule ElixirLS.LanguageServer.Server do
     source_file = get_source_file(state, uri)
 
     fun = fn ->
-      Hover.hover(source_file.text, line, character)
+      Hover.hover(source_file.text, line, character, state.project_dir)
     end
 
     {:async, fun, state}

--- a/apps/language_server/test/providers/hover_test.exs
+++ b/apps/language_server/test/providers/hover_test.exs
@@ -61,7 +61,7 @@ defmodule ElixirLS.LanguageServer.Providers.HoverTest do
            )
   end
 
-  test "Third deps module hover" do
+  test "Umbrella projects: Third deps module hover" do
     text = """
     defmodule MyModule do
       def hello() do
@@ -81,7 +81,7 @@ defmodule ElixirLS.LanguageServer.Providers.HoverTest do
            )
   end
 
-  test "Third deps function hover" do
+  test "Umbrella projects: Third deps function hover" do
     text = """
     defmodule MyModule do
       def hello() do
@@ -98,6 +98,26 @@ defmodule ElixirLS.LanguageServer.Providers.HoverTest do
     assert String.starts_with?(
              v,
              "> StreamData.integer()  [view on hexdocs](https://hexdocs.pm/stream_data/StreamData.html#integer/0)"
+           )
+  end
+
+  test "Erlang module hover is not support now" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        :timer.sleep(1000)
+      end
+    end
+    """
+
+    {line, char} = {2, 10}
+
+    assert {:ok, %{"contents" => %{kind: "markdown", value: v}}} =
+             Hover.hover(text, line, char, fake_dir())
+
+    assert not String.contains?(
+             v,
+             "[view on hexdocs]"
            )
   end
 end

--- a/apps/language_server/test/providers/hover_test.exs
+++ b/apps/language_server/test/providers/hover_test.exs
@@ -1,0 +1,103 @@
+defmodule ElixirLS.LanguageServer.Providers.HoverTest do
+  use ElixirLS.Utils.MixTest.Case, async: false
+  import ElixirLS.LanguageServer.Test.PlatformTestHelpers
+
+  alias ElixirLS.LanguageServer.Providers.Hover
+  # mix cmd --app language_server mix test test/providers/hover_test.exs
+
+  def fake_dir() do
+    Path.join(__DIR__, "../../../..") |> Path.expand() |> maybe_convert_path_separators()
+  end
+
+  test "blank hover" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        IO.inspect("hello world")
+      end
+    end
+    """
+
+    {line, char} = {2, 1}
+
+    assert {:ok, resp} = Hover.hover(text, line, char, fake_dir())
+    assert nil == resp
+  end
+
+  test "Elixir builtin module hover" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        IO.inspect("hello world")
+      end
+    end
+    """
+
+    {line, char} = {2, 5}
+
+    assert {:ok, %{"contents" => %{kind: "markdown", value: v}}} =
+             Hover.hover(text, line, char, fake_dir())
+
+    assert String.starts_with?(v, "> IO  [view on hexdocs](https://hexdocs.pm/elixir/IO.html)")
+  end
+
+  test "Elixir builtin function hover" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        IO.inspect("hello world")
+      end
+    end
+    """
+
+    {line, char} = {2, 10}
+
+    assert {:ok, %{"contents" => %{kind: "markdown", value: v}}} =
+             Hover.hover(text, line, char, fake_dir())
+
+    assert String.starts_with?(
+             v,
+             "> IO.inspect(item, opts \\\\\\\\ [])  [view on hexdocs](https://hexdocs.pm/elixir/IO.html#inspect/2)"
+           )
+  end
+
+  test "Third deps module hover" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        StreamData.integer() |> Stream.map(&abs/1) |> Enum.take(3) |> IO.inspect()
+      end
+    end
+    """
+
+    {line, char} = {2, 10}
+
+    assert {:ok, %{"contents" => %{kind: "markdown", value: v}}} =
+             Hover.hover(text, line, char, fake_dir())
+
+    assert String.starts_with?(
+             v,
+             "> StreamData  [view on hexdocs](https://hexdocs.pm/stream_data/StreamData.html)"
+           )
+  end
+
+  test "Third deps function hover" do
+    text = """
+    defmodule MyModule do
+      def hello() do
+        StreamData.integer() |> Stream.map(&abs/1) |> Enum.take(3) |> IO.inspect()
+      end
+    end
+    """
+
+    {line, char} = {2, 18}
+
+    assert {:ok, %{"contents" => %{kind: "markdown", value: v}}} =
+             Hover.hover(text, line, char, fake_dir())
+
+    assert String.starts_with?(
+             v,
+             "> StreamData.integer()  [view on hexdocs](https://hexdocs.pm/stream_data/StreamData.html#integer/0)"
+           )
+  end
+end


### PR DESCRIPTION
Change-Id: Ifd888136b0c7cd9936bf02612bd87fdcce639ba7

this pr is a hover enhancement. 

before 
![image](https://user-images.githubusercontent.com/6822558/126041193-fc0f6901-66de-4614-9592-0d402849bc0c.png)

and after this pr
![image](https://user-images.githubusercontent.com/6822558/126041231-43cb51b8-bfec-4198-9271-3bd27908783b.png)

we can click this hyperlink to hexdocs.pm search page, like this: https://hexdocs.pm/elixir/search.html?q=File.write
![image](https://user-images.githubusercontent.com/6822558/126041277-333a8fe1-9634-449c-b1ee-d0c0d9235c6b.png)
