### PR TITLE
fix(manipulatePipes): avoid crashing upon errors

### DIFF
--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -52,7 +52,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
       {:ok, nil}
     else
       {:error, reason} ->
-        {:error, reason}
+        {:error, :parse_error, reason}
 
       error ->
         {:error, :server_error,

--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -51,12 +51,18 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
            }) do
       {:ok, nil}
     else
-      {:error, reason} ->
-        {:error, :parse_error, reason}
+      {:error, :pipe_not_found} ->
+        {:error, :parse_error, "Pipe operator not found at cursor"}
+
+      {:error, :function_call_not_found} ->
+        {:error, :parse_error, "Function call not found at cursor"}
+
+      {:error, :invalid_code} ->
+        {:error, :parse_error, "Malformed code"}
 
       error ->
         {:error, :server_error,
-         "cannot execute pipe conversion, workspace/applyEdit returned #{inspect(error)}"}
+         "Cannot execute pipe conversion, workspace/applyEdit returned #{inspect(error)}"}
     end
   end
 

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -580,7 +580,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert_never_raises(text, uri, "toPipe")
 
-      assert {:error, :parse_error, :function_call_not_found} =
+      assert {:error, :parse_error, "Function call not found at cursor"} =
                ManipulatePipes.execute(
                  ["toPipe", uri, 4, 13],
                  %Server{
@@ -1171,7 +1171,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert_never_raises(text, uri, "fromPipe")
 
-      assert {:error, :parse_error, :pipe_not_found} =
+      assert {:error, :parse_error, "Pipe operator not found at cursor"} =
                ManipulatePipes.execute(
                  ["fromPipe", uri, 4, 16],
                  %Server{

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -104,7 +104,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
              ) == edited_text
     end
 
-    test "can pipe remote calls with ulti-line args" do
+    test "can pipe remote calls with multi-line args" do
       {:ok, _} =
         JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
 
@@ -456,7 +456,6 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
       assert edited_text == expected_text
     end
 
-    # Broken
     test "to_pipe_at_cursor at end of function (with another function after)" do
       text = """
       defmodule Demo do
@@ -560,6 +559,38 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
                expected_range,
                expected_substitution
              ) == edited_text
+    end
+
+    test "converts function_call_not_found to 3-tuple" do
+      {:ok, _} =
+        JsonRpcMock.start_link(success_reply: {:ok, %{"applied" => true}}, test_pid: self())
+
+      uri = "file:/some_file.ex"
+
+      text = """
+      test = 1
+      %{
+        q:
+          if(is_nil(test),
+            do: max(test, is_nil(test)),
+            else: []
+          )
+      }
+      """
+
+      assert_never_raises(text, uri, "toPipe")
+
+      assert {:error, :parse_error, :function_call_not_found} =
+               ManipulatePipes.execute(
+                 ["toPipe", uri, 4, 13],
+                 %Server{
+                   source_files: %{
+                     uri => %SourceFile{
+                       text: text
+                     }
+                   }
+                 }
+               )
     end
 
     for {line_sep, test_name_suffix} <- [{"\r\n", "\\r\\n"}, {"\n", "\\n"}] do
@@ -1140,7 +1171,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
 
       assert_never_raises(text, uri, "fromPipe")
 
-      assert {:error, :pipe_not_found} =
+      assert {:error, :parse_error, :pipe_not_found} =
                ManipulatePipes.execute(
                  ["fromPipe", uri, 4, 16],
                  %Server{


### PR DESCRIPTION
This PR solves #570

The main issue was the command not adhering to the callback typespec for the error-tuples.