### PR TITLE
Fix doc false for folding ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug Fixes:
 - Support exunit describe and test calls with unevaluated names (thanks [Jonathan Arnett](https://github.com/J3RN)) [#537](https://github.com/elixir-lsp/elixir-ls/pull/537)
 - Improve test runner to use exunit testPaths and testPattern (thanks [Étienne Lévesque](https://github.com/Blond11516)) [#500](https://github.com/elixir-lsp/elixir-ls/pull/500)
 - Fix race-condition in suggest contracts (thanks [Łukasz Samson](https://github.com/lukaszsamson)) [#544](https://github.com/elixir-lsp/elixir-ls/pull/544)
+- Fix `@doc false` and `@moduledoc false` for folding ranges (thanks [Jason Axelson](https://github.com/axelson/)) [#580](https://github.com/elixir-lsp/elixir-ls/pull/580)
 
 Housekeeping:
 - Minor iteration/performance improvements (thanks [Andrew Summers](https://github.com/asummers)) [#527](https://github.com/elixir-lsp/elixir-ls/pull/527)

--- a/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
@@ -18,6 +18,8 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
     :sigil
   ]
 
+  @docs [:moduledoc, :typedoc, :doc]
+
   @doc """
   Provides ranges based on "special" tokens
 
@@ -60,15 +62,15 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
 
   defp do_group_tokens([], acc), do: acc
 
-  # Don't create folding ranges from `@doc false` and `@moduledoc false`
+  # Don't create folding ranges for docs
   defp do_group_tokens([{:identifier, _, doc_identifier}, {false, _, _} | rest], acc)
-       when doc_identifier in [:doc, :moduledoc] do
+       when doc_identifier in @docs do
     do_group_tokens(rest, acc)
   end
 
   # Start a folding range for `@doc` and `@moduledoc`
   defp do_group_tokens([{:identifier, _, doc_identifier} = token | rest], acc)
-       when doc_identifier in [:doc, :moduledoc] do
+       when doc_identifier in @docs do
     acc = [[token] | acc]
     do_group_tokens(rest, acc)
   end

--- a/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
@@ -55,23 +55,46 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
 
   @spec group_tokens([Token.t()]) :: [[Token.t()]]
   defp group_tokens(tokens) do
-    tokens
-    |> Enum.reduce([], fn
-      {:identifier, _, identifier} = token, acc when identifier in [:doc, :moduledoc] ->
-        [[token] | acc]
+    do_group_tokens(tokens, [])
+  end
 
-      {k, _, _} = token, [[{:identifier, _, _}] = head | tail] when k in @kinds ->
-        [[token | head] | tail]
+  defp do_group_tokens([], acc), do: acc
 
-      {k, _, _} = token, acc when k in @kinds ->
-        [[token] | acc]
+  # Don't create folding ranges from `@doc false` and `@moduledoc false`
+  defp do_group_tokens([{:identifier, _, doc_identifier}, {false, _, _} | rest], acc)
+       when doc_identifier in [:doc, :moduledoc] do
+    do_group_tokens(rest, acc)
+  end
 
-      {:eol, _, _} = token, [[{k, _, _} | _] = head | tail] when k in @kinds ->
-        [[token | head] | tail]
+  # Start a folding range for `@doc` and `@moduledoc`
+  defp do_group_tokens([{:identifier, _, doc_identifier} = token | rest], acc)
+       when doc_identifier in [:doc, :moduledoc] do
+    acc = [[token] | acc]
+    do_group_tokens(rest, acc)
+  end
 
-      _, acc ->
-        acc
-    end)
+  # Amend the folding range
+  defp do_group_tokens([{k, _, _} = token | rest], [[{:identifier, _, _}] = head | tail])
+       when k in @kinds do
+    acc = [[token | head] | tail]
+    do_group_tokens(rest, acc)
+  end
+
+  # Start a new folding range
+  defp do_group_tokens([{k, _, _} = token | rest], acc) when k in @kinds do
+    acc = [[token] | acc]
+    do_group_tokens(rest, acc)
+  end
+
+  # Finish the open folding range
+  defp do_group_tokens([{:eol, _, _} = token | rest], [[{k, _, _} | _] = head | tail])
+       when k in @kinds do
+    acc = [[token | head] | tail]
+    do_group_tokens(rest, acc)
+  end
+
+  defp do_group_tokens([_unmatched_token | rest], acc) do
+    do_group_tokens(rest, acc)
   end
 
   @spec convert_groups_to_ranges([[Token.t()]]) :: [FoldingRange.t()]

--- a/apps/language_server/test/providers/folding_range_test.exs
+++ b/apps/language_server/test/providers/folding_range_test.exs
@@ -504,7 +504,10 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRangeTest do
            end
          end
          """
-    test "@moduledoc false does not create a folding range", %{ranges_result: ranges_result, text: text} do
+    test "@moduledoc false does not create a folding range", %{
+      ranges_result: ranges_result,
+      text: text
+    } do
       assert {:ok, ranges} = ranges_result
       expected = [{0, 6, :region}, {3, 5, :region}]
       assert compare_condensed_ranges(ranges, expected, text)

--- a/apps/language_server/test/providers/folding_range_test.exs
+++ b/apps/language_server/test/providers/folding_range_test.exs
@@ -479,6 +479,37 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRangeTest do
       assert compare_condensed_ranges(ranges, expected, text)
     end
 
+    @tag text: """
+         defmodule A do
+           @doc false
+           def init(_) do
+             IO.puts("Hello World!")
+             {:ok, []}
+           end
+         end
+         """
+    test "@doc false does not create a folding range", %{ranges_result: ranges_result, text: text} do
+      assert {:ok, ranges} = ranges_result
+      expected = [{0, 5, :region}, {2, 4, :region}]
+      assert compare_condensed_ranges(ranges, expected, text)
+    end
+
+    @tag text: """
+         defmodule A do
+           @moduledoc false
+
+           def init(_) do
+             IO.puts("Hello World!")
+             {:ok, []}
+           end
+         end
+         """
+    test "@moduledoc false does not create a folding range", %{ranges_result: ranges_result, text: text} do
+      assert {:ok, ranges} = ranges_result
+      expected = [{0, 6, :region}, {3, 5, :region}]
+      assert compare_condensed_ranges(ranges, expected, text)
+    end
+
     defp fold_text(%{text: _text} = context) do
       ranges_result = FoldingRange.provide(context)
       {:ok, Map.put(context, :ranges_result, ranges_result)}
@@ -537,12 +568,12 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRangeTest do
       end)
 
     result_condensed
-    |> Enum.map(fn {line_start, line_end, :any} ->
+    |> Enum.map(fn {line_start, line_end, descriptor} ->
       out =
         Enum.slice(lines, line_start, line_end - line_start + 2)
         |> Enum.join("\n")
 
-      IO.puts("Folding lines #{line_start}, #{line_end}:")
+      IO.puts("Folding lines #{line_start}, #{line_end} (#{descriptor}):")
       IO.puts(out)
       IO.puts("\n")
     end)

--- a/apps/language_server/test/providers/folding_range_test.exs
+++ b/apps/language_server/test/providers/folding_range_test.exs
@@ -496,6 +496,23 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRangeTest do
 
     @tag text: """
          defmodule A do
+           @typedoc false
+           @type t :: %{}
+
+           def init(_) do
+             IO.puts("Hello World!")
+             {:ok, []}
+           end
+         end
+         """
+    test "@typedoc example", %{ranges_result: ranges_result, text: text} do
+      assert {:ok, ranges} = ranges_result
+      expected = [{0, 7, :region}, {4, 6, :region}]
+      assert compare_condensed_ranges(ranges, expected, text)
+    end
+
+    @tag text: """
+         defmodule A do
            @moduledoc false
 
            def init(_) do


### PR DESCRIPTION
Previously an invalid folding range would be returned

Move to custom recursion so we can do a "lookahead" to handle the `@doc false` and `@moduledoc false` cases.

Minor fixes to test helpers to work with more input.