### PR TITLE
Change minimum OTP to 22 in warning message

### DIFF
--- a/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
+++ b/apps/elixir_ls_utils/lib/mix.tasks.elixir_ls.release.ex
@@ -42,9 +42,9 @@ defmodule Mix.Tasks.ElixirLs.Release do
   defp version_warning do
     {otp_version, _} = Integer.parse(to_string(:erlang.system_info(:otp_release)))
 
-    if otp_version > 21 do
+    if otp_version > 22 do
       IO.warn(
-        "Building with Erlang/OTP #{otp_version}. Make sure to build with OTP 21 if " <>
+        "Building with Erlang/OTP #{otp_version}. Make sure to build with OTP 22 if " <>
           "publishing the compiled packages because modules built with higher versions are not " <>
           "backwards-compatible.",
         []


### PR DESCRIPTION
Change warning message when building with OTP greater than 22.