### PR TITLE
Add a `do` autocompletion

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -159,6 +159,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         tags: [],
         priority: 0
       }
+
       [item | completion_items]
     else
       completion_items

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -137,6 +137,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       ElixirSense.suggestions(text, line + 1, character + 1)
       |> maybe_reject_derived_functions(context, options)
       |> Enum.map(&from_completion_item(&1, context, options))
+      |> maybe_add_do(context)
 
     items_json =
       items
@@ -146,6 +147,22 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       |> items_to_json(options)
 
     {:ok, %{"isIncomplete" => is_incomplete(items_json), "items" => items_json}}
+  end
+
+  defp maybe_add_do(completion_items, context) do
+    if String.ends_with?(context.text_before_cursor, " do") && context.text_after_cursor == "" do
+      item = %__MODULE__{
+        label: "do",
+        kind: :keyword,
+        detail: "keyword",
+        insert_text: "do\n$0\nend",
+        tags: [],
+        priority: 0
+      }
+      [item | completion_items]
+    else
+      completion_items
+    end
   end
 
   ## Helpers

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -341,7 +341,9 @@ defmodule ElixirLS.LanguageServer.Server do
       # close notification send before
       JsonRpc.log_message(
         :warning,
-        "Received textDocument/didOpen for file that is already open. Received uri: #{inspect(uri)}"
+        "Received textDocument/didOpen for file that is already open. Received uri: #{
+          inspect(uri)
+        }"
       )
 
       state

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -341,9 +341,7 @@ defmodule ElixirLS.LanguageServer.Server do
       # close notification send before
       JsonRpc.log_message(
         :warning,
-        "Received textDocument/didOpen for file that is already open. Received uri: #{
-          inspect(uri)
-        }"
+        "Received textDocument/didOpen for file that is already open. Received uri: #{inspect(uri)}"
       )
 
       state

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -44,7 +44,10 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
 
     {line, char} = {3, 12}
     TestUtils.assert_has_cursor_char(text, line, char)
-    {:ok, %{"items" => [first_item | _items]}} = Completion.completion(text, line, char, @supports)
+
+    {:ok, %{"items" => [first_item | _items]}} =
+      Completion.completion(text, line, char, @supports)
+
     assert first_item["label"] == "do"
   end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -31,6 +31,23 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
     end
   end
 
+  test "do is returned" do
+    text = """
+    defmodule MyModule do
+      require Logger
+
+      def fun do
+        #       ^
+      end
+    end
+    """
+
+    {line, char} = {3, 12}
+    TestUtils.assert_has_cursor_char(text, line, char)
+    {:ok, %{"items" => [first_item | _items]}} = Completion.completion(text, line, char, @supports)
+    assert first_item["label"] == "do"
+  end
+
   test "returns all Logger completions on normal require" do
     text = """
     defmodule MyModule do


### PR DESCRIPTION
For some clients typing `do` will result in autocompletion which is typically not what the developer wants, an example autocompletion is `defoverridable`. So this PR works around that by adding `do` as an autocompletion when the exact text entered is `"do"`.

I'm curious if anyone has any better/different ideas on how to solve this.