### PR TITLE
List all workspace symbols when an empty query comes in

### DIFF
--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -348,13 +348,8 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
   end
 
   defp query(query, server) do
-    case String.trim(query) do
-      "" ->
-        []
-
-      trimmed ->
-        GenServer.call(server, {:query, trimmed})
-    end
+    trimmed =  String.trim(query)
+    GenServer.call(server, {:query, trimmed})
   end
 
   defp index(module_paths) do
@@ -435,6 +430,11 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
       end)
 
     :ok
+  end
+
+  @spec get_results(state_t, String.t()) :: [symbol_information_t]
+  defp get_results(state, "") do
+    (state.modules ++ state.functions ++ state.types ++ state.callbacks)
   end
 
   @spec get_results(state_t, String.t()) :: [symbol_information_t]

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -35,7 +35,9 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
   end
 
   test "empty query", %{server: server} do
-    assert {:ok, []} == WorkspaceSymbols.symbols("", server)
+    {status, all_symbols} = WorkspaceSymbols.symbols("", server)
+    assert :ok == status
+    assert 11 == length(all_symbols)
 
     assert_receive %{
       "method" => "window/logMessage",


### PR DESCRIPTION
According to the specification the workspace symbols provider should
accept an empty query string and return all the symbols in that case

https://microsoft.github.io/language-server-protocol/specification#workspace_symbol

```
/**
 * The parameters of a Workspace Symbol Request.
 */
interface WorkspaceSymbolParams extends WorkDoneProgressParams,
	PartialResultParams {
	/**
	 * A query string to filter symbols by. Clients may send an empty
	 * string here to request all symbols.
	 */
	query: string;
}
```
The test is quite primitive as I am an Elixir beginner. If this feature is of interest I would appreciate some help improving them.