### PR TITLE
Add indentation following "do" completion

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -156,7 +156,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         label: "do",
         kind: :keyword,
         detail: "keyword",
-        insert_text: "do\n$0\nend",
+        insert_text: "do\n\t$0\nend",
         tags: [],
         priority: 0
       }

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -156,7 +156,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         label: "do",
         kind: :keyword,
         detail: "keyword",
-        insert_text: "do\n\t$0\nend",
+        insert_text: "do\n  $0\nend",
         tags: [],
         priority: 0
       }


### PR DESCRIPTION
Related to #593, and specifically the comment by @axelson [here](https://github.com/elixir-lsp/elixir-ls/pull/593#issuecomment-912815840), this PR adds a single tab<sup>1</sup> of indentation before the cursor after the `do` autocompletion.

I'm testing exclusively in VS Code, but the behavior of this change seems to be that the editor adds one **relative** level of indentation. So, for example, the autocompletion naturally forms the following structure (using exclusively the `do` completion):

```elixir
defmodule Hello do
  def world do
    case something do
      # ...
    end
  end
end
```

It is always possible that other editors do not match this behavior. If that's the case, apologies for the confusion.

---

<sup>1</sup> According to [sources](https://stackoverflow.com/questions/44787009/snippets-with-indentation-in-visual-studio-code) and my experience while testing, using `\t` will tell VS Code to insert one `TAB`-worth of whichever form indentation is currently active in the editor. In my case, it correctly added two spaces.