### PR TITLE
Debugger: Allow disabling auto interpreting

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -881,9 +881,7 @@ defmodule ElixirLS.Debugger.Server do
           {:error, error} ->
             IO.puts(
               :standard_error,
-              "Unable to compile file pattern (#{inspect(pattern)}) into a regex. Received error: #{
-                inspect(error)
-              }"
+              "Unable to compile file pattern (#{inspect(pattern)}) into a regex. Received error: #{inspect(error)}"
             )
 
             []

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -673,7 +673,7 @@ defmodule ElixirLS.Debugger.Server do
     prev_env = Mix.env()
     task = config["task"]
     task_args = config["taskArgs"]
-    auto_interpret_files? = Map.get(config, "autoInterpretFiles", true)
+    auto_interpret_files? = Map.get(config, "debugAutoInterpretAllModules", true)
 
     set_stack_trace_mode(config["stackTraceMode"])
     set_env_vars(config["env"])
@@ -721,8 +721,8 @@ defmodule ElixirLS.Debugger.Server do
 
     if required_files = config["requireFiles"], do: require_files(required_files)
 
-    if interpret_modules_pattern = config["interpretModulesPatterns"],
-      do: interpret_modules_pattern(interpret_modules_pattern)
+    if interpret_modules_patterns = config["debugInterpretModulesPatterns"],
+      do: interpret_modules_patterns(interpret_modules_patterns)
 
     ElixirLS.Debugger.Output.send_event("initialized", %{})
   end
@@ -871,7 +871,7 @@ defmodule ElixirLS.Debugger.Server do
         do: save_and_reload(module, beam_bin)
   end
 
-  defp interpret_modules_pattern(file_patterns) do
+  defp interpret_modules_patterns(file_patterns) do
     regexes =
       Enum.flat_map(file_patterns, fn pattern ->
         case Regex.compile(pattern) do

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -872,9 +872,7 @@ defmodule ElixirLS.Debugger.Server do
           {:error, error} ->
             IO.puts(
               :standard_error,
-              "Unable to compile file pattern (#{inspect(pattern)}) into a regex. Received error: #{
-                inspect(error)
-              }"
+              "Unable to compile file pattern (#{inspect(pattern)}) into a regex. Received error: #{inspect(error)}"
             )
 
             []

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -943,7 +943,7 @@ defmodule ElixirLS.Debugger.Server do
     modules
     |> Enum.each(fn mod ->
       if should_interpret?(mod, exclude_module_pattern) do
-        interpret_module()
+        interpret_module(mod)
       end
     end)
   end

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -673,6 +673,7 @@ defmodule ElixirLS.Debugger.Server do
     prev_env = Mix.env()
     task = config["task"]
     task_args = config["taskArgs"]
+    auto_interpret_files? = Map.get(config, "autoInterpretFiles", true)
 
     set_stack_trace_mode(config["stackTraceMode"])
     set_env_vars(config["env"])
@@ -714,7 +715,9 @@ defmodule ElixirLS.Debugger.Server do
       config
       |> Map.get("excludeModules", [])
 
-    interpret_modules_in(Mix.Project.build_path(), exclude_module_names)
+    if auto_interpret_files? do
+      interpret_modules_in(Mix.Project.build_path(), exclude_module_names)
+    end
 
     if required_files = config["requireFiles"], do: require_files(required_files)
 


### PR DESCRIPTION
On larger projects, the overhead of interpreting all the modules in the project (including all dependencies) causes an unbearable slowdown.

This commit makes it possible to disable the auto interpreting of modules and instead rely on files that are in `requireFiles` (which are interpreted)

**WARNING**: Any modules that don't have a breakpoint and are not in `requireFiles` cannot be stepped into while debugging.

TODO:
- [x] Create matching elixir-lsp/vscode-elixir-ls PR (https://github.com/elixir-lsp/vscode-elixir-ls/pull/214)
- [x] Clean up PR
- [x] Update setting names to match vscode pr

Fixes #615