### PR TITLE
Elixir 1.13 support

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -158,8 +158,7 @@ defmodule ElixirLS.LanguageServer.Build do
         # The project may override our logger config, so we reset it after loading their config
         logger_config = Application.get_all_env(:logger)
         Mix.Task.run("loadconfig")
-        # NOTE: soft-deprecated in v1.10
-        Mix.Config.persist(logger: logger_config)
+        Application.put_all_env([logger: logger_config], persistent: true)
       end
 
       {status, diagnostics}

--- a/apps/language_server/lib/language_server/mix_shell.ex
+++ b/apps/language_server/lib/language_server/mix_shell.ex
@@ -38,7 +38,7 @@ defmodule ElixirLS.LanguageServer.MixShell do
   end
 
   @impl Mix.Shell
-  def yes?(message) do
+  def yes?(message, options \\ []) do
     if WireProtocol.io_intercepted?() do
       response =
         JsonRpc.show_message_request(:info, message, [
@@ -55,7 +55,7 @@ defmodule ElixirLS.LanguageServer.MixShell do
           true
       end
     else
-      Mix.Shell.IO.yes?(message)
+      Mix.Shell.IO.yes?(message, options)
     end
   end
 end

--- a/apps/language_server/lib/language_server/mix_shell.ex
+++ b/apps/language_server/lib/language_server/mix_shell.ex
@@ -55,10 +55,11 @@ defmodule ElixirLS.LanguageServer.MixShell do
           true
       end
     else
+      # TODO converto to normal call when we require elixir 1.13
       if Version.match?(System.version(), "< 1.13.0-rc.0") do
-        Mix.Shell.IO.yes?(message)
+        apply(Mix.Shell.IO, :yes?, [message])
       else
-        Mix.Shell.IO.yes?(message, options)
+        apply(Mix.Shell.IO, :yes?, [message, options])
       end
     end
   end

--- a/apps/language_server/lib/language_server/mix_shell.ex
+++ b/apps/language_server/lib/language_server/mix_shell.ex
@@ -55,7 +55,11 @@ defmodule ElixirLS.LanguageServer.MixShell do
           true
       end
     else
-      Mix.Shell.IO.yes?(message, options)
+      if Version.match?(System.version(), "< 1.13.0-rc.0") do
+        Mix.Shell.IO.yes?(message)
+      else
+        Mix.Shell.IO.yes?(message, options)
+      end
     end
   end
 end

--- a/apps/language_server/lib/language_server/mix_shell.ex
+++ b/apps/language_server/lib/language_server/mix_shell.ex
@@ -55,7 +55,7 @@ defmodule ElixirLS.LanguageServer.MixShell do
           true
       end
     else
-      # TODO converto to normal call when we require elixir 1.13
+      # TODO convert to to normal call when we require elixir 1.13
       if Version.match?(System.version(), "< 1.13.0-rc.0") do
         apply(Mix.Shell.IO, :yes?, [message])
       else

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -151,6 +151,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
         [{:when, _, [{:"::", _, [{_, _, _} = type_head, _]}, _]}] ->
           Macro.to_string(type_head)
       end
+      |> String.replace("\n", "")
 
     type = if type_kind in [:type, :typep, :opaque], do: :class, else: :event
 
@@ -192,7 +193,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
          {defname, _, [{:when, _, [{_, location, _} = fn_head, _]} | _]}
        )
        when defname in @defs do
-    name = Macro.to_string(fn_head)
+    name = Macro.to_string(fn_head) |> String.replace("\n", "")
 
     %Info{
       type: :function,
@@ -205,7 +206,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   # Function, macro, delegate
   defp extract_symbol(_current_module, {defname, _, [{_, location, _} = fn_head | _]})
        when defname in @defs do
-    name = Macro.to_string(fn_head)
+    name = Macro.to_string(fn_head) |> String.replace("\n", "")
 
     %Info{
       type: :function,

--- a/apps/language_server/lib/language_server/providers/folding_range/token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/token.ex
@@ -40,6 +40,9 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Token do
           {:bin_heredoc, {b1, b2, b3}, _, _} ->
             {:bin_heredoc, {b1 - 1, b2 - 1, b3}, nil}
 
+          {:list_heredoc, {b1, b2, b3}, _, _} ->
+            {:list_heredoc, {b1 - 1, b2 - 1, b3}, nil}
+
           # raise here?
           error ->
             Logger.warn("Unmatched token: #{inspect(error)}")

--- a/apps/language_server/lib/language_server/providers/folding_range/token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/token.ex
@@ -6,6 +6,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Token do
   """
 
   alias ElixirSense.Core.Normalized.Tokenizer
+  require Logger
 
   @type t :: {atom(), {non_neg_integer(), non_neg_integer(), any()}, any()}
 
@@ -36,8 +37,12 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Token do
           {:sigil, {b1, b2, b3}, _, _, _, delimiter} ->
             {:sigil, {b1 - 1, b2 - 1, b3}, delimiter}
 
+          {:bin_heredoc, {b1, b2, b3}, _, _} ->
+            {:bin_heredoc, {b1 - 1, b2 - 1, b3}, nil}
+
           # raise here?
-          _ ->
+          error ->
+            Logger.warn("Unmatched token: #{inspect(error)}")
             :error
         end
 

--- a/apps/language_server/test/providers/code_lens/type_spec/contract_translator_test.exs
+++ b/apps/language_server/test/providers/code_lens/type_spec/contract_translator_test.exs
@@ -145,8 +145,14 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TypeSpec.ContractTranslator
 
   test "map with fields" do
     contract = '(any()) -> \#{integer()=>any(), 1:=atom(), abc:=4}'
+    
+    expected = if Version.match?(System.version(), "< 1.13.0-rc.0") do
+      "foo(any) :: %{optional(integer) => any, 1 => atom, :abc => 4}"
+    else
+      "foo(any) :: %{optional(integer) => any, 1 => atom, abc: 4}"
+    end
 
-    assert "foo(any) :: %{optional(integer) => any, 1 => atom, :abc => 4}" ==
+    assert expected ==
              ContractTranslator.translate_contract(:foo, contract, false, Atom)
   end
 

--- a/apps/language_server/test/providers/execute_command/expand_macro_test.exs
+++ b/apps/language_server/test/providers/execute_command/expand_macro_test.exs
@@ -64,6 +64,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacroTest do
                }
              })
 
+    if Version.match?(System.version(), "< 1.13.0-rc.0") do
     assert res == %{
              "expand" => """
              require(ElixirLS.Test.MacroA)
@@ -96,5 +97,39 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ExpandMacroTest do
              )
              """
            }
+          else
+            assert res == %{
+              "expand" => """
+              require ElixirLS.Test.MacroA
+              ElixirLS.Test.MacroA.__using__([])
+              """,
+              "expandAll" => """
+              require ElixirLS.Test.MacroA
+ 
+              (
+                import ElixirLS.Test.MacroA
+ 
+                def macro_a_func do
+                  :ok
+                end
+              )
+              """,
+              "expandOnce" => """
+              require ElixirLS.Test.MacroA
+              ElixirLS.Test.MacroA.__using__([])
+              """,
+              "expandPartial" => """
+              require ElixirLS.Test.MacroA
+ 
+              (
+                import ElixirLS.Test.MacroA
+ 
+                def macro_a_func do
+                  :ok
+                end
+              )
+              """
+            }
+          end
   end
 end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -970,10 +970,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                    Inspects and writes the given `item` to the device.
 
                    ```
-                   @spec inspect(item, keyword) :: item
-                   when item: var
-                   ```
-                   """
+                   @spec inspect\
+                   """ <> _
                  },
                  "label" => "inspect(item, opts \\\\ [])",
                  "parameters" => [%{"label" => "item"}, %{"label" => "opts \\\\ []"}]
@@ -999,7 +997,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                  ]
                }
              ]
-           }) == resp
+           }) = resp
   end
 
   @tag :fixture

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # By default, the umbrella project as well as each child
 # application will require this configuration file, ensuring

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "docsh": {:hex, :docsh, "0.7.2", "f893d5317a0e14269dd7fe79cf95fb6b9ba23513da0480ec6e77c73221cae4f2", [:rebar3], [{:providers, "1.8.1", [hex: :providers, repo: "hexpm", optional: false]}], "hexpm", "4e7db461bb07540d2bc3d366b8513f0197712d0495bb85744f367d3815076134"},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "4a857f2c262b9f8ac2d72e31f4806cecc740192a", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "3aff3709d78f79c641fc0df47b0976aa7217b45e", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "getopt": {:hex, :getopt, "1.0.1", "c73a9fa687b217f2ff79f68a3b637711bb1936e712b521d8ce466b29cbf7808a", [:rebar3], [], "hexpm", "53e1ab83b9ceb65c9672d3e7a35b8092e9bdc9b3ee80721471a161c10c59959c"},


### PR DESCRIPTION
TODO:
- [x] bump elixir_sense
- [x] crash in debugger test (see https://github.com/elixir-lang/elixir/issues/11371) (extracted to https://github.com/elixir-lsp/elixir-ls/issues/627)
- [x] failing test test/providers/execute_command/expand_macro_test.exs:49
- [x] failing test test/providers/folding_range_test.exs:464
- [x] failing test test/server_test.exs:947
- [x] failing test test/source_file_test.exs:700 (see https://github.com/elixir-lang/elixir/issues/11363)
- [x] failing test test/providers/code_lens/type_spec/contract_translator_test.exs:146
- [x] breaking change in Mix.Shell behaviour (see https://github.com/elixir-lang/elixir/issues/11372)
- [x] Mix.Config.persist/1 hard deprecated. Replace with Application.put_all_env(config, persistent: true)
- [x] Macro.to_string/2 is deprecated (see https://github.com/elixir-lang/elixir/issues/11373) (not a problem for now)
- [x] Mix.Config hard deprecated (https://hexdocs.pm/elixir/master/Config.html#module-migrating-from-use-mix-config)
- [x] newline characters in document outline
- [x] docsh crashing on OTP24 (not a problem)

Edit:
Elixir 1.13-rc.1 is out with fixes for regressions found so far. I fixed all outstanding issues in elixir-ls. I think we can merge it now and get some more testing from the community.