### PR TITLE
Update to elixir-lsp fork of mix_task_archive_deps

### DIFF
--- a/apps/elixir_ls_utils/mix.exs
+++ b/apps/elixir_ls_utils/mix.exs
@@ -28,7 +28,7 @@ defmodule ElixirLS.Utils.Mixfile do
   defp deps do
     [
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
-      {:mix_task_archive_deps, github: "JakeBecker/mix_task_archive_deps"}
+      {:mix_task_archive_deps, github: "elixir-lsp/mix_task_archive_deps"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "getopt": {:hex, :getopt, "1.0.1", "c73a9fa687b217f2ff79f68a3b637711bb1936e712b521d8ce466b29cbf7808a", [:rebar3], [], "hexpm", "53e1ab83b9ceb65c9672d3e7a35b8092e9bdc9b3ee80721471a161c10c59959c"},
   "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "ee95ca80cd67b3a499a14f469536140935eb4483", [branch: "vendored"]},
-  "mix_task_archive_deps": {:git, "https://github.com/JakeBecker/mix_task_archive_deps.git", "50301a4314e3cc1104f77a8208d5b66ee382970b", []},
+  "mix_task_archive_deps": {:git, "https://github.com/elixir-lsp/mix_task_archive_deps.git", "30fa76221def649286835685fec5d151be83c354", []},
   "providers": {:hex, :providers, "1.8.1", "70b4197869514344a8a60e2b2a4ef41ca03def43cfb1712ecf076a0f3c62f083", [:rebar3], [{:getopt, "1.0.1", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm", "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }


### PR DESCRIPTION
This allows us to use https://github.com/elixir-lsp/mix_task_archive_deps/pull/1 as well as giving us some additional commits added by https://github.com/rabbitmq/mix_task_archive_deps (although the main win is to be using a maintained version of mix_task_archive_deps in general).

This switch is necessitated by #609 as mentioned at https://github.com/elixir-lsp/elixir-ls/pull/609#issuecomment-954487450