### PR TITLE
Vendor PathGlob

### DIFF
--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -59,7 +59,7 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
 
     Enum.any?(inputs, fn input_glob ->
       glob = Path.join(formatter_dir, input_glob)
-      PathGlob.match?(file_path, glob, match_dot: true)
+      PathGlobVendored.match?(file_path, glob, match_dot: true)
     end)
   end
 

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -32,7 +32,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:dialyxir, "~> 1.0", runtime: false},
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
       {:stream_data, "~> 0.5", only: :test},
-      {:path_glob, "~> 0.1.0"}
+      {:path_glob_vendored, github: "elixir-ls/path_glob", branch: "vendored"}
     ]
   end
 

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -32,7 +32,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:dialyxir, "~> 1.0", runtime: false},
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
       {:stream_data, "~> 0.5", only: :test},
-      {:path_glob_vendored, github: "elixir-ls/path_glob", branch: "vendored"}
+      {:path_glob_vendored, github: "elixir-lsp/path_glob", branch: "vendored"}
     ]
   end
 


### PR DESCRIPTION
This is important in case someone uses PathGlob in their own project

Uses the vendored version at https://github.com/elixir-lsp/path_glob/tree/vendored