### PR TITLE
Default fetchDeps to false

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -933,7 +933,7 @@ defmodule ElixirLS.LanguageServer.Server do
         state
 
       not state.build_running? ->
-        fetch_deps? = Map.get(state.settings || %{}, "fetchDeps", true)
+        fetch_deps? = Map.get(state.settings || %{}, "fetchDeps", false)
 
         {_pid, build_ref} =
           Build.build(self(), project_dir,


### PR DESCRIPTION
There were already race conditions (if the user runs `mix deps.get` at the same time) and Elixir 1.13 semantic recompilation makes it worse.

Fixes #626