### PR TITLE
Fix dialyzer invalid contract in special_token.ex

### DIFF
--- a/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
@@ -45,7 +45,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
         %{startLine: 2, endLine: 3, kind?: :region},
       ]}
   """
-  @spec provide_ranges([FoldingRange.input()]) :: {:ok, [FoldingRange.t()]}
+  @spec provide_ranges(FoldingRange.input()) :: {:ok, [FoldingRange.t()]}
   def provide_ranges(%{tokens: tokens}) do
     ranges =
       tokens


### PR DESCRIPTION
From dialyzer warning:

```
lib/language_server/providers/folding_range/special_token.ex:48:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken.provide_ranges/1

Success typing:
@spec provide_ranges(%{:tokens => [{atom(), {_, _, _}, _}], _ => _}) ::
  {:ok,
   [
     %{
       :endLine => non_neg_integer(),
       :startLine => non_neg_integer(),
       :endCharacter? => non_neg_integer(),
       :kind? => :comment | :imports | :region,
       :startCharacter? => non_neg_integer()
     }
   ]}
```

It's happens because the typespec function declare that it accepts the
list of folding range, but in the real usage, it accepts just one
folding range.