### PR TITLE
Fix dialyzer invalid contract in line.ex

### DIFF
--- a/apps/language_server/lib/language_server/providers/folding_range/line.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/line.ex
@@ -8,7 +8,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Line do
   @type cell :: {non_neg_integer(), non_neg_integer() | nil}
   @type t :: {String.t(), cell(), String.t()}
 
-  @spec format_string(String.t()) :: [cell()]
+  @spec format_string(String.t()) :: [t()]
   def format_string(text) do
     text
     |> SourceFile.lines()


### PR DESCRIPTION
From dialyzer warning:

```
lib/language_server/providers/folding_range/line.ex:11:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
ElixirLS.LanguageServer.Providers.FoldingRange.Line.format_string/1

Success typing:
@spec format_string(
  binary()
  | %ElixirLS.LanguageServer.SourceFile{
      :text =>
        binary()
        | %ElixirLS.LanguageServer.SourceFile{
            :text =>
              binary()
              | %ElixirLS.LanguageServer.SourceFile{:text => binary() | map(), _ => _},
            _ => _
          },
      _ => _
    }
) :: [{binary(), {non_neg_integer(), nil | non_neg_integer()}, binary()}]
```

The root cause is `embellish_lines_with_metadata/1` return a list
of `t()` but `format_string/1` said it returns a list of `cell()`
which is incorrect.