### PR TITLE
Fix dialyzer overlapping contract in comment_block.ex

### DIFF
--- a/apps/language_server/lib/language_server/providers/folding_range/comment_block.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/comment_block.ex
@@ -43,7 +43,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.CommentBlock do
     {:ok, ranges}
   end
 
-  @spec group_comments([Line.t()]) :: [{Line.cell(), String.t()}]
+  @spec group_comments([Line.t()]) :: [[{Line.cell(), String.t()}]]
   defp group_comments(lines) do
     lines
     |> Enum.reduce([[]], fn
@@ -62,7 +62,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.CommentBlock do
     |> Enum.filter(fn group -> length(group) > 1 end)
   end
 
-  @spec group_comments([{Line.cell(), String.t()}]) :: [FoldingRange.t()]
+  @spec convert_comment_group_to_range([[{Line.cell(), String.t()}]]) :: FoldingRange.t()
   defp convert_comment_group_to_range(group) do
     {{{end_line, _}, _}, {{start_line, _}, _}} =
       group |> FoldingRange.Helpers.first_and_last_of_list()


### PR DESCRIPTION
From dialyzer:

```
lib/language_server/providers/folding_range/comment_block.ex:46:overlapping_contract
Overloaded contract for ElixirLS.LanguageServer.Providers.FoldingRange.CommentBlock.group_comments/1 has
overlapping domains; such contracts are currently unsupported and
are simply ignored.
```

It's happens because of declare `group_comments` spec on
`convert_comment_group_to_range/1`. But after fix it to
correct name, dialyzer will complain invalid contract because
`convert_comment_group_to_range` receive `[[{Line.cell(), String.t()}]]`
and it's returns `FoldingRange.t()` not a list.