### PR TITLE
Fix: markdown doc lines should wrap with \n\n

### DIFF
--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -67,7 +67,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
   end
 
   defp add_hexdocs_link(markdown, subject, project_dir) do
-    [hd | tail] = markdown |> String.split("\n\n")
+    [hd | tail] = markdown |> String.split("\n\n", parts: 2)
 
     link = hexdocs_link(hd, subject, project_dir)
 
@@ -76,7 +76,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
         markdown
 
       _ ->
-        hd <> "  [view on hexdocs](#{link})\n\n" <> Enum.join(tail, "")
+        ["#{hd}  [view on hexdocs](#{link})" | tail] |> Enum.join("\n\n")
     end
   end
 


### PR DESCRIPTION
This bug was introduced by #574

https://github.com/elixir-lsp/elixir-ls/pull/574/files#diff-45f5b34f620f56be3dd9d7aee38e7b7d144229ee89a225b43aa6b1a674000c5cR70

The `markdown` is split with `\n\n`, but only joined with `""`