### PR TITLE
Handle blank mix target value properly

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1162,7 +1162,7 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   defp set_mix_target(state = %__MODULE__{}, target) do
-    target = target || "host"
+    target = valid_target(target)
 
     prev_target = state.settings["mixTarget"]
 
@@ -1173,6 +1173,18 @@ defmodule ElixirLS.LanguageServer.Server do
     end
 
     state
+  end
+
+  defp valid_target(nil), do: valid_target("")
+
+  defp valid_target(target) when is_binary(target) do
+    target = String.trim(target)
+
+    if target == "" do
+      "host"
+    else
+      target
+    end
   end
 
   defp set_project_dir(

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1157,13 +1157,13 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp maybe_set_mix_target(state = %__MODULE__{}, nil), do: state
 
+  defp maybe_set_mix_target(state = %__MODULE__{}, ""), do: state
+
   defp maybe_set_mix_target(state = %__MODULE__{}, target) do
     set_mix_target(state, target)
   end
 
   defp set_mix_target(state = %__MODULE__{}, target) do
-    target = valid_target(target)
-
     prev_target = state.settings["mixTarget"]
 
     if is_nil(prev_target) or target == prev_target do
@@ -1173,18 +1173,6 @@ defmodule ElixirLS.LanguageServer.Server do
     end
 
     state
-  end
-
-  defp valid_target(nil), do: valid_target("")
-
-  defp valid_target(target) when is_binary(target) do
-    target = String.trim(target)
-
-    if target == "" do
-      "host"
-    else
-      target
-    end
   end
 
   defp set_project_dir(


### PR DESCRIPTION
This addresses an empty string can get passed into `Mix.target/1`, which sets the Mix target value to `:""`. Mix target is supposed to default to `:host` but `Mix.target/1` force-updates it with any wrong value. We should make sure the target value is valid before converting it to atom.

The accidental `:""` is bad, because for example, Nerves projects assume `Mix.target/0` defaults to `:host`.

### Notes

- discussed with @fhunleth at  https://github.com/nerves-project/nerves/issues/694
-  I attempted to improve  `Mix.target/1` in Elixir language first,  but Jose says it is not Elixir's responsibility.  https://github.com/elixir-lang/elixir/pull/11603