### PR TITLE
Suggest an appropriate module name with the 'defmodule' snippet

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -636,6 +636,30 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
     |> Enum.join(".")
   end
 
+  defp do_suggest_module_name(
+         [probable_phoenix_dir | [project_web_dir | _] = rest],
+         module_name_acc,
+         opts
+       )
+       when probable_phoenix_dir in [
+              "controllers",
+              "views",
+              "channels",
+              "plugs",
+              "endpoints",
+              "sockets"
+            ] do
+    if String.ends_with?(project_web_dir, "_web") do
+      # by convention Phoenix doesn't use these folders as part of the module names
+      # for modules located inside them, so we'll try to do the same
+      do_suggest_module_name(rest, module_name_acc, opts)
+    else
+      # when not directly under the *_web folder however then we should make the folder
+      # part of the module's name
+      do_suggest_module_name(rest, [probable_phoenix_dir | module_name_acc], opts)
+    end
+  end
+
   defp do_suggest_module_name([dir_name | rest], module_name_acc, opts) do
     do_suggest_module_name(rest, [dir_name | module_name_acc], opts)
   end

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -565,9 +565,9 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         completion
       end
 
-    uri = Keyword.get(options, :uri)
+    file_path = Keyword.get(options, :file_path)
 
-    if snippet = snippet_for({origin, name}, Map.put(context, :uri, uri)) do
+    if snippet = snippet_for({origin, name}, Map.put(context, :file_path, file_path)) do
       %{completion | insert_text: snippet, kind: :snippet, label: name}
     else
       completion
@@ -578,10 +578,10 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
     nil
   end
 
-  defp snippet_for({"Kernel", "defmodule"}, %{uri: uri}) when is_binary(uri) do
-    # In a mix project the uri can be something like "/some/code/path/project/lib/project/sub_path/myfile.ex"
+  defp snippet_for({"Kernel", "defmodule"}, %{file_path: file_path}) when is_binary(file_path) do
+    # In a mix project the file_path can be something like "/some/code/path/project/lib/project/sub_path/my_file.ex"
     # so we'll try to guess the appropriate module name from the path
-    "defmodule #{suggest_module_name(uri)}$1 do\n\t$0\nend"
+    "defmodule #{suggest_module_name(file_path)}$1 do\n\t$0\nend"
   end
 
   defp snippet_for(key, %{pipe_before?: true}) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -685,7 +685,8 @@ defmodule ElixirLS.LanguageServer.Server do
         tags_supported: tags_supported,
         signature_help_supported: signature_help_supported,
         locals_without_parens: locals_without_parens,
-        signature_after_complete: signature_after_complete
+        signature_after_complete: signature_after_complete,
+        uri: uri
       )
     end
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -686,7 +686,7 @@ defmodule ElixirLS.LanguageServer.Server do
         signature_help_supported: signature_help_supported,
         locals_without_parens: locals_without_parens,
         signature_after_complete: signature_after_complete,
-        uri: uri
+        file_path: SourceFile.path_from_uri(uri)
       )
     end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -1158,5 +1158,32 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                  "some/path/my_umbrella_project/apps/my_sub_app/lib/my_sub_app/foo/bar/baz.ex"
                )
     end
+
+    test "returns appropriate suggestions for modules nested under known phoenix dirs" do
+      [
+        {"MyProjectWeb.MyController", "controllers/my_controller.ex"},
+        {"MyProjectWeb.MyPlug", "plugs/my_plug.ex"},
+        {"MyProjectWeb.MyView", "views/my_view.ex"},
+        {"MyProjectWeb.MyChannel", "channels/my_channel.ex"},
+        {"MyProjectWeb.MyEndpoint", "endpoints/my_endpoint.ex"},
+        {"MyProjectWeb.MySocket", "sockets/my_socket.ex"}
+      ]
+      |> Enum.each(fn {expected_module_name, partial_path} ->
+        path = "some/path/my_project/lib/my_project_web/#{partial_path}"
+        assert expected_module_name == suggest_module_name(path)
+      end)
+    end
+
+    test "uses known Phoenix dirs as part of a module's name if these are not located directly beneath the *_web folder" do
+      assert "MyProject.Controllers.MyController" ==
+               suggest_module_name(
+                 "some/path/my_project/lib/my_project/controllers/my_controller.ex"
+               )
+
+      assert "MyProjectWeb.SomeNestedDir.Controllers.MyController" ==
+               suggest_module_name(
+                 "some/path/my_project/lib/my_project_web/some_nested_dir/controllers/my_controller.ex"
+               )
+    end
   end
 end

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -1151,5 +1151,12 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                  "some/path/my_project/test/my_project/foo/bar/baz/my_file_test.exs"
                )
     end
+
+    test "returns an appropriate suggestion if file is part of an umbrella project" do
+      assert "MySubApp.Foo.Bar.Baz" ==
+               suggest_module_name(
+                 "some/path/my_umbrella_project/apps/my_sub_app/lib/my_sub_app/foo/bar/baz.ex"
+               )
+    end
   end
 end

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -926,8 +926,8 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                  char,
                  @supports
                  |> Keyword.put(
-                   :uri,
-                   "file://some/path/my_project/lib/my_project/sub_folder/my_file.ex"
+                   :file_path,
+                   "/some/path/my_project/lib/my_project/sub_folder/my_file.ex"
                  )
                )
 
@@ -954,8 +954,8 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                  char,
                  @supports
                  |> Keyword.put(
-                   :uri,
-                   "file://some/path/my_project/lib/my_project/sub_folder/my_file.heex"
+                   :file_path,
+                   "/some/path/my_project/lib/my_project/sub_folder/my_file.heex"
                  )
                )
 
@@ -1030,7 +1030,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       text = """
       defmodule MyModule do
         def hello do
-          Date.today() |> 
+          Date.today() |>
           #               ^
         end
       end
@@ -1041,6 +1041,8 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       TestUtils.assert_has_cursor_char(text, line, char)
 
       assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
+
+      IO.inspect(Enum.filter(items, fn i -> i["label"] == "make_ref/0" end))
 
       refute Enum.any?(items, fn i -> i["label"] == "make_ref/0" end)
     end
@@ -1113,7 +1115,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
   describe "suggest_module_name/1" do
     import Completion, only: [suggest_module_name: 1]
 
-    test "returns nil if current file uri is empty" do
+    test "returns nil if current file_path is empty" do
       assert nil == suggest_module_name("")
     end
 
@@ -1125,7 +1127,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       assert nil == suggest_module_name("some/path/not_lib/dir/file.ex")
     end
 
-    test "returns nil if current file is an *_test.exs file but not test folder exists in path" do
+    test "returns nil if current file is an *_test.exs file but no test folder exists in path" do
       assert nil == suggest_module_name("some/path/not_test/dir/file_test.exs")
     end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -1030,7 +1030,7 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       text = """
       defmodule MyModule do
         def hello do
-          Date.today() |>
+          Date.today() |> 
           #               ^
         end
       end
@@ -1041,8 +1041,6 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
       TestUtils.assert_has_cursor_char(text, line, char)
 
       assert {:ok, %{"items" => items}} = Completion.completion(text, line, char, @supports)
-
-      IO.inspect(Enum.filter(items, fn i -> i["label"] == "make_ref/0" end))
 
       refute Enum.any?(items, fn i -> i["label"] == "make_ref/0" end)
     end


### PR DESCRIPTION
Hi all, this is a feature that I always wanted to have and now took some time to implement.

Basically when creating a new file and writing a `defmod...` prompt for auto-completion I wanted a likely module_name to be suggested along with completing the `defmodule do .. end` snippet.

This is what my attempt looks like

https://user-images.githubusercontent.com/622973/160127379-746dfd4a-05cc-4d3e-ad5e-a4c11ebe5152.mov

There are some limitations I'm aware of (and probably tens of others that I'm not aware of!)
- Nested module names: the users will be getting a suggestion based on the full file path instead of taking into account the parent module and basically doing nothing (let the users name their module)
- Phoenix conventions are not observed. e.g with controller names the suggested module name will be `MyProjectWeb.Controllers.PageController` instead of `MyProjectWeb.PageController`

Still, do let me know if this PR is on the right track and if so also let me know if these limitations (and possibly others) should be fixed before attempting to ship something like this to the users.

Thanks for taking the time to review!
