### PR TITLE
Fix formatter race condition

### DIFF
--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -9,6 +9,7 @@ defmodule ElixirLS.LanguageServer do
     children = [
       {ElixirLS.LanguageServer.Server, ElixirLS.LanguageServer.Server},
       {ElixirLS.LanguageServer.JsonRpc, name: ElixirLS.LanguageServer.JsonRpc},
+      {ElixirLS.LanguageServer.Project, ElixirLS.LanguageServer.Project},
       {ElixirLS.LanguageServer.Providers.WorkspaceSymbols, []}
     ]
 

--- a/apps/language_server/lib/language_server/project.ex
+++ b/apps/language_server/lib/language_server/project.ex
@@ -1,0 +1,111 @@
+defmodule ElixirLS.LanguageServer.Project do
+  use GenServer
+
+  alias ElixirLS.LanguageServer.{Build, JsonRpc}
+
+  @timeout :infinity
+
+  # Client APIs
+
+  def start_link(name \\ nil) do
+    GenServer.start_link(__MODULE__, :ok, name: name || __MODULE__)
+  end
+
+  def reload(server \\ __MODULE__) do
+    GenServer.call(server, :reload, @timeout)
+  end
+
+  def formatter_opts_for_file(server \\ __MODULE__, path) do
+    GenServer.call(server, {:formatter_opts, path}, @timeout)
+  end
+
+  # Callbacks
+
+  @impl GenServer
+  def init(:ok) do
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def handle_call(:reload, _from, state) do
+    {:reply, reload_project(), state}
+  end
+
+  @impl GenServer
+  def handle_call({:formatter_opts, path}, _from, state) do
+    {:reply, formatter_opts(path), state}
+  end
+
+  # Internals
+
+  defp reload_project do
+    mixfile = Path.absname(System.get_env("MIX_EXS") || "mix.exs")
+
+    if File.exists?(mixfile) do
+      # FIXME: Private API
+      case Mix.ProjectStack.peek() do
+        %{file: ^mixfile, name: module} ->
+          # FIXME: Private API
+          Mix.Project.pop()
+          Build.purge_module(module)
+
+        _ ->
+          :ok
+      end
+
+      Mix.Task.clear()
+
+      # Override build directory to avoid interfering with other dev tools
+      # FIXME: Private API
+      Mix.ProjectStack.post_config(build_path: ".elixir_ls/build")
+
+      # We can get diagnostics if Mixfile fails to load
+      {status, diagnostics} =
+        case Kernel.ParallelCompiler.compile([mixfile]) do
+          {:ok, _, warnings} ->
+            {:ok, Enum.map(warnings, &Build.mixfile_diagnostic(&1, :warning))}
+
+          {:error, errors, warnings} ->
+            {
+              :error,
+              Enum.map(warnings, &Build.mixfile_diagnostic(&1, :warning)) ++
+                Enum.map(errors, &Build.mixfile_diagnostic(&1, :error))
+            }
+        end
+
+      if status == :ok do
+        # The project may override our logger config, so we reset it after loading their config
+        logger_config = Application.get_all_env(:logger)
+        Mix.Task.run("loadconfig")
+        Application.put_all_env([logger: logger_config], persistent: true)
+      end
+
+      {status, diagnostics}
+    else
+      msg =
+        "No mixfile found in project. " <>
+          "To use a subdirectory, set `elixirLS.projectDir` in your settings"
+
+      JsonRpc.log_message(:info, msg <> ". Looked for mixfile at #{inspect(mixfile)}")
+
+      :no_mixfile
+    end
+  end
+
+  defp formatter_opts(path) do
+    try do
+      opts =
+        path
+        |> Mix.Tasks.Format.formatter_opts_for_file()
+
+      {:ok, opts}
+    rescue
+      e ->
+        IO.warn(
+          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{e.message}"
+        )
+
+        :error
+    end
+  end
+end

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -1,6 +1,8 @@
 defmodule ElixirLS.LanguageServer.SourceFile do
   import ElixirLS.LanguageServer.Protocol
 
+  alias ElixirLS.LanguageServer.Project
+
   defstruct [:text, :version, dirty?: false]
 
   @endings ["\r\n", "\r", "\n"]
@@ -336,22 +338,8 @@ defmodule ElixirLS.LanguageServer.SourceFile do
 
   @spec formatter_opts(String.t()) :: {:ok, keyword()} | :error
   def formatter_opts(uri = "file:" <> _) do
-    path = path_from_uri(uri)
-
-    try do
-      opts =
-        path
-        |> Mix.Tasks.Format.formatter_opts_for_file()
-
-      {:ok, opts}
-    rescue
-      e ->
-        IO.warn(
-          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{e.message}"
-        )
-
-        :error
-    end
+    path_from_uri(uri)
+    |> Project.formatter_opts_for_file()
   end
 
   def formatter_opts(_), do: :error


### PR DESCRIPTION
Formatting request is usually sent immediately after didSave notification,
this could cause formatter doesn't work while building is running.

On my end, this is the error log:

```
LSP Warning: warning: Unable to get formatter options for /home/tw/code/elixir-test/chatter/mix.exs: Mix.Error Unknown dependency :ecto given to :import_deps in the formatter configuration. The dependency is not listed in your mix.exs for environment :test
  (language_server 0.9.0) lib/language_server/source_file.ex:349: ElixirLS.LanguageServer.SourceFile.formatter_opts/1
  (language_server 0.9.0) lib/language_server/providers/formatting.ex:8: ElixirLS.LanguageServer.Providers.Formatting.format/3
  (language_server 0.9.0) lib/language_server/server.ex:783: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2
```

In order to fix this race condition, let's wait building done before formatting.

Fix #402 

Signed-off-by: Tw <tw19881113@gmail.com>