### PR TITLE
Add support for mix format plugins (#660)

### DIFF
--- a/apps/language_server/lib/language_server/providers/execute_command/apply_spec.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/apply_spec.ex
@@ -56,8 +56,8 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec do
     formatted =
       try do
         target_line_length =
-          case SourceFile.formatter_opts(uri) do
-            {:ok, opts} -> Keyword.get(opts, :line_length, @default_target_line_length)
+          case SourceFile.formatter_for(uri) do
+            {:ok, {_, opts}} -> Keyword.get(opts, :line_length, @default_target_line_length)
             :error -> @default_target_line_length
           end
 
@@ -94,3 +94,4 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec do
     end
   end
 end
+

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -670,8 +670,8 @@ defmodule ElixirLS.LanguageServer.Server do
       !!get_in(state.client_capabilities, ["textDocument", "signatureHelp"])
 
     locals_without_parens =
-      case SourceFile.formatter_opts(uri) do
-        {:ok, opts} -> Keyword.get(opts, :locals_without_parens, [])
+      case SourceFile.formatter_for(uri) do
+        {:ok, {_, opts}} -> Keyword.get(opts, :locals_without_parens, [])
         :error -> []
       end
       |> MapSet.new()
@@ -1258,3 +1258,4 @@ defmodule ElixirLS.LanguageServer.Server do
     end)
   end
 end
+

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -334,16 +334,16 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     """
   end
 
-  @spec formatter_opts(String.t()) :: {:ok, keyword()} | :error
-  def formatter_opts(uri = "file:" <> _) do
+  @spec formatter_for(String.t()) :: {:ok, keyword()} | :error
+  def formatter_for(uri = "file:" <> _) do
     path = path_from_uri(uri)
 
     try do
-      opts =
-        path
-        |> Mix.Tasks.Format.formatter_opts_for_file()
-
-      {:ok, opts}
+      if function_exported?(Mix.Tasks.Format, :formatter_for_file, 1) do
+        {:ok, Mix.Tasks.Format.formatter_for_file(path)}
+      else
+        {:ok, {nil, Mix.Tasks.Format.formatter_opts_for_file(path)}}
+      end
     rescue
       e ->
         IO.warn(
@@ -354,7 +354,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     end
   end
 
-  def formatter_opts(_), do: :error
+  def formatter_for(_), do: :error
 
   defp format_code(code, opts) do
     try do
@@ -431,3 +431,4 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     {elixir_line - 1, utf16_character}
   end
 end
+


### PR DESCRIPTION
Use mix formatter for formatting source file instead of Code.format_string! so it can support plugins in formatters. 

Fix #660