### PR TITLE
Fix position format

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -279,7 +279,7 @@ defmodule ElixirLS.LanguageServer.Build do
   end
 
   defp range(position, nil) when is_integer(position) do
-    line = position - 1
+    line = if position - 1 < 0, do: 0, else: position - 1
 
     # we don't care about utf16 positions here as we send 0
     %{
@@ -289,7 +289,7 @@ defmodule ElixirLS.LanguageServer.Build do
   end
 
   defp range(position, source_file) when is_integer(position) do
-    line = position - 1
+    line = if position - 1 < 0, do: 0, else: position - 1
     text = Enum.at(SourceFile.lines(source_file), line) || ""
 
     start_idx = String.length(text) - String.length(String.trim_leading(text)) + 1


### PR DESCRIPTION
This was discovered by using helix, code editor. For reference the issue is here: https://github.com/helix-editor/helix/issues/2029.

In the [Position](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) documentation it says:

> Position in a text document expressed as zero-based line and zero-based character offset. A position is between two characters like an ‘insert’ cursor in an editor. Special values like for example -1 to denote the end of a line are not supported.

So this is binding it to be `0` if the `position - 1` returns less.

I'm not sure this is the only place that the change needs to be done, so I'm open to some guidance so we can make this work as it should.

Thanks!