### PR TITLE
Special case handling of Phoenix 'live' dir when suggesting module names

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -647,7 +647,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
               "channels",
               "plugs",
               "endpoints",
-              "sockets"
+              "sockets",
+              "live"
             ] do
     if String.ends_with?(project_web_dir, "_web") do
       # by convention Phoenix doesn't use these folders as part of the module names

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -1164,7 +1164,8 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
         {"MyProjectWeb.MyView", "views/my_view.ex"},
         {"MyProjectWeb.MyChannel", "channels/my_channel.ex"},
         {"MyProjectWeb.MyEndpoint", "endpoints/my_endpoint.ex"},
-        {"MyProjectWeb.MySocket", "sockets/my_socket.ex"}
+        {"MyProjectWeb.MySocket", "sockets/my_socket.ex"},
+        {"MyProjectWeb.MyviewLive.MyComponent", "live/myview_live/my_component.ex"}
       ]
       |> Enum.each(fn {expected_module_name, partial_path} ->
         path = "some/path/my_project/lib/my_project_web/#{partial_path}"


### PR DESCRIPTION
When generating a live view with `mix phx.gen.live` the view and all related files
are put under `my_project_web/live/*`

Similar to other Phoenix paths (e.g. `/controllers`) the `/live` directory is
not a part of the generated module names, and the suggested module names
when auto-completing should account for that convention.