### PR TITLE
[WIP/Proposal] feat: add working first draft

### DIFF
--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -140,6 +140,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
       ""
     else
       s = root_mod_name |> source()
+
       cond do
         third_dep?(s, project_dir) -> third_dep_name(s, project_dir)
         builtin?(s) -> builtin_dep_name(s)

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -30,6 +30,13 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
         after
           :ok
         end
+        defmacro customdef(call, do: block) do
+          quote do
+            Kernel.def(unquote(call), do: unquote(block))
+          end
+        end
+
+        customdef name(arg1, arg2), do: :ok
       end
     ]
 
@@ -192,7 +199,22 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                       "end" => %{"character" => 12, "line" => 13},
                       "start" => %{"character" => 12, "line" => 13}
                     }
-                  }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "defmacro customdef(call) do  blockend",
+                    range: %{"end" => %{"character" => 17, "line" => 24},
+                    "start" => %{"character" => 17, "line" => 24}},
+                    selectionRange: %{"end" => %{"character" => 17, "line" => 24}, "start" => %{"character" => 17, "line" => 24}}
+                  },
+                    %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                      children: [],
+                      kind: 12,
+                      name: "customdef name(arg1, arg2)",
+                      range: %{"end" => %{"character" => 18, "line" => 30}, "start" => %{"character" => 18, "line" => 30}},
+                      selectionRange: %{"end" => %{"character" => 18, "line" => 30}, "start" => %{"character" => 18, "line" => 30}}
+                    }
                 ],
                 kind: 2,
                 name: "MyModule",

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -30,13 +30,27 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
         after
           :ok
         end
-        defmacro customdef(call, do: block) do
+        defmacro customdef_remote(call, do: block) do
           quote do
             Kernel.def(unquote(call), do: unquote(block))
           end
         end
-
-        customdef name(arg1, arg2), do: :ok
+        defmacro customdef_local(call, do: block) do
+          quote do
+            customdef_remote(unquote(call), do: unquote(block))
+          end
+        end
+        defmacro customdef_kernel(call, do: block) do
+          quote do
+            def(unquote(call), do: unquote(block))
+          end
+        end
+        customdef_remote remote_name(arg1, arg2), do: :ok
+        customdef_local local_name(arg1, arg2) when arg1 == arg2, do: :ok
+        customdef_kernel kernel_name(arg1, arg2)
+        case :customdef do
+          value when :customdef -> :ok
+        end
       end
     ]
 
@@ -203,18 +217,81 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                   %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
                     children: [],
                     kind: 12,
-                    name: "defmacro customdef(call) do  blockend",
-                    range: %{"end" => %{"character" => 17, "line" => 24},
-                    "start" => %{"character" => 17, "line" => 24}},
-                    selectionRange: %{"end" => %{"character" => 17, "line" => 24}, "start" => %{"character" => 17, "line" => 24}}
-                  },
-                    %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
-                      children: [],
-                      kind: 12,
-                      name: "customdef name(arg1, arg2)",
-                      range: %{"end" => %{"character" => 18, "line" => 30}, "start" => %{"character" => 18, "line" => 30}},
-                      selectionRange: %{"end" => %{"character" => 18, "line" => 30}, "start" => %{"character" => 18, "line" => 30}}
+                    name: "defmacro customdef_remote(call) do  blockend",
+                    range: %{
+                      "end" => %{"character" => 17, "line" => 24},
+                      "start" => %{"character" => 17, "line" => 24}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 17, "line" => 24},
+                      "start" => %{"character" => 17, "line" => 24}
                     }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "defmacro customdef_local(call) do  blockend",
+                    range: %{
+                      "end" => %{"character" => 17, "line" => 29},
+                      "start" => %{"character" => 17, "line" => 29}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 17, "line" => 29},
+                      "start" => %{"character" => 17, "line" => 29}
+                    }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "defmacro customdef_kernel(call) do  blockend",
+                    range: %{
+                      "end" => %{"character" => 17, "line" => 34},
+                      "start" => %{"character" => 17, "line" => 34}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 17, "line" => 34},
+                      "start" => %{"character" => 17, "line" => 34}
+                    }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "customdef_remote remote_name(arg1, arg2)",
+                    range: %{
+                      "end" => %{"character" => 25, "line" => 39},
+                      "start" => %{"character" => 25, "line" => 39}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 25, "line" => 39},
+                      "start" => %{"character" => 25, "line" => 39}
+                    }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "customdef_local local_name(arg1, arg2)",
+                    range: %{
+                      "end" => %{"character" => 24, "line" => 40},
+                      "start" => %{"character" => 24, "line" => 40}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 24, "line" => 40},
+                      "start" => %{"character" => 24, "line" => 40}
+                    }
+                  },
+                  %ElixirLS.LanguageServer.Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 12,
+                    name: "customdef_kernel kernel_name(arg1, arg2)",
+                    range: %{
+                      "end" => %{"character" => 25, "line" => 41},
+                      "start" => %{"character" => 25, "line" => 41}
+                    },
+                    selectionRange: %{
+                      "end" => %{"character" => 25, "line" => 41},
+                      "start" => %{"character" => 25, "line" => 41}
+                    }
+                  }
                 ],
                 kind: 2,
                 name: "MyModule",

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -48,8 +48,14 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
         customdef_remote remote_name(arg1, arg2), do: :ok
         customdef_local local_name(arg1, arg2) when arg1 == arg2, do: :ok
         customdef_kernel kernel_name(arg1, arg2)
-        case :customdef do
-          value when :customdef -> :ok
+        case :customdef_remote do
+          value when :customdef_remote -> :ok
+        end
+        case :customdef_local do
+          value when :customdef_local -> :ok
+        end
+        case :customdef_kernel do
+          value when :customdef_kernel -> :ok
         end
       end
     ]


### PR DESCRIPTION
This PR aims to add custom symbols as part of the symbol finder

This is a step to improve upon Nx development and usage, but done in a more generalized way.
The idea is to detect if a given node ends up defining a function (in the LSP sense) inside it through macro calls.

Given this proposal is accepted, I plan to provide a user configuration for a list of custom names (which solves imported macros as is usual with Nx's defns) and I also plan to add an option to load the "locals_without_parens" list from the formatter configuration (this should reduce even further the use cases in which a user would _have_ to provide their custom symbol)

I've added the `Symbols` struct mostly so I didn't have to carry tuples around, but I'm not too set on the implementation details yet.