### PR TITLE
Handle incoming nil data

### DIFF
--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -248,6 +248,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     IO.iodata_to_binary(Enum.reverse(acc))
   end
 
+  defp characters_to_binary!(nil, _from, _to), do: ""
   defp characters_to_binary!(binary, from, to) do
     case :unicode.characters_to_binary(binary, from, to) do
       result when is_binary(result) -> result


### PR DESCRIPTION
I very regularly get error messages coding Elixir: 

```
Company: An error occurred in auto-begin
Company: backend (:separate company-capf company-yasnippet) error "an exception was raised:
    ** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not valid character data (an iodata term)

        (stdlib 4.0.1) unicode.erl:900: :unicode.characters_to_binary(nil, :utf8, :utf16)
        (language_server 0.11.0) lib/language_server/source_file.ex:252: ElixirLS.LanguageServer.SourceFile.characters_to_binary!/3
        (language_server 0.11.0) lib/language_server/source_file.ex:379: ElixirLS.LanguageServer.SourceFile.lsp_character_to_elixir/2
        (language_server 0.11.0) lib/language_server/providers/completion.ex:96: ElixirLS.LanguageServer.Providers.Completion.completion/4
        (language_server 0.11.0) lib/language_server/server.ex:788: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2" with args (candidates )
```

I have no clue where the `nil` originates from, but catching it and converting it to an empty string seems to work fine.

(I use Elixir-LS from Doom Emacs with the standard LSP setup)