### PR TITLE
A tilde is not expanded inside double quotes

### DIFF
--- a/apps/elixir_ls_utils/priv/launch.sh
+++ b/apps/elixir_ls_utils/priv/launch.sh
@@ -41,7 +41,7 @@ fi
 # give them the chance here. ELS_MODE will be set for
 # the really complex stuff. Use an XDG compliant path.
 
-els_setup="${XDG_CONFIG_HOME:-~/.config}/elixir_ls/setup.sh"
+els_setup="${XDG_CONFIG_HOME:-$HOME/.config}/elixir_ls/setup.sh"
 if test -f "${els_setup}"
 then
   .  "${els_setup}"


### PR DESCRIPTION
Use $HOME instead.

Otherwise, the clause

```
. "${els_setup}"
```

is never invoked for those people (like me) who does not set $XDG_CONFIG_HOME.