### PR TITLE
Remove load_all_applications

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -49,7 +49,6 @@ defmodule ElixirLS.LanguageServer.Server do
     build_diagnostics: [],
     dialyzer_diagnostics: [],
     needs_build?: false,
-    load_all_mix_applications?: false,
     build_running?: false,
     analysis_ready?: false,
     received_shutdown?: false,
@@ -923,19 +922,14 @@ defmodule ElixirLS.LanguageServer.Server do
       not state.build_running? ->
         fetch_deps? = Map.get(state.settings || %{}, "fetchDeps", false)
 
-        {_pid, build_ref} =
-          Build.build(self(), project_dir,
-            fetch_deps?: fetch_deps?,
-            load_all_mix_applications?: state.load_all_mix_applications?
-          )
+        {_pid, build_ref} = Build.build(self(), project_dir, fetch_deps?: fetch_deps?)
 
         %__MODULE__{
           state
           | build_ref: build_ref,
             needs_build?: false,
             build_running?: true,
-            analysis_ready?: false,
-            load_all_mix_applications?: false
+            analysis_ready?: false
         }
 
       true ->
@@ -1217,7 +1211,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
       is_nil(prev_project_dir) ->
         File.cd!(project_dir)
-        Map.merge(state, %{project_dir: File.cwd!(), load_all_mix_applications?: true})
+        %{state | project_dir: File.cwd!()}
 
       prev_project_dir != project_dir ->
         JsonRpc.show_message(

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -7,8 +7,6 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
   @project_dir "/project"
 
   setup context do
-    ElixirLS.LanguageServer.Build.load_all_mix_applications()
-
     unless context[:skip_server] do
       server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -20,8 +20,6 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
   }
 
   setup context do
-    ElixirLS.LanguageServer.Build.load_all_mix_applications()
-
     unless context[:skip_server] do
       server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
 


### PR DESCRIPTION
since elixir 1.11 mix compile loads applications by default
it can be turned off with `--no-app-loading`
https://hexdocs.pm/mix/1.11.0/Mix.Tasks.Compile.html#module-command-line-options