### PR TITLE
Fixed language server crashes in emacs

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -89,7 +89,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
     line_text =
       text
       |> SourceFile.lines()
-      |> Enum.at(line)
+      |> Enum.at(line, "")
 
     # convert to 1 based utf8 position
     line = line + 1

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -94,6 +94,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
           # TODO extract module name location from Code.Fragment.surround_context?
           # TODO better selection ranges for defimpl?
           {extract_module_name(module_expression), module_name_location, module_body}
+
+        _ ->
+          case defname do
+            :defmodule -> {"MISSING_MODULE_NAME", nil, do: nil}
+            :defprotocol -> {"MISSING_PROTOCOL_NAME", nil, do: nil}
+          end
       end
 
     mod_defns =

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -248,7 +248,11 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     IO.iodata_to_binary(Enum.reverse(acc))
   end
 
-  defp characters_to_binary!(binary, from, to) do
+  defp characters_to_binary!(nil, _from, _to) do
+    ""
+  end
+
+  defp characters_to_binary!(binary, from, to) when is_binary(binary) do
     case :unicode.characters_to_binary(binary, from, to) do
       result when is_binary(result) -> result
     end
@@ -348,8 +352,15 @@ defmodule ElixirLS.LanguageServer.SourceFile do
       end
     rescue
       e ->
+        message =
+          case e do
+            %{message: message} -> message
+            %{description: description} -> description
+            _ -> ""
+          end
+
         IO.warn(
-          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{e.message}"
+          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{message}"
         )
 
         :error

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -32,7 +32,8 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:dialyxir, "~> 1.0", runtime: false},
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
       {:stream_data, "~> 0.5", only: :test},
-      {:path_glob_vendored, github: "elixir-lsp/path_glob", branch: "vendored"}
+      {:path_glob_vendored, github: "elixir-lsp/path_glob", branch: "vendored"},
+      {:patch, "~> 0.12.0", only: :test}
     ]
   end
 

--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -1183,4 +1183,10 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
                )
     end
   end
+
+  describe "error handling" do
+    test "it should handle out of bounds line numbers" do
+      assert {:ok, _} = Completion.completion("", 3, 8, [])
+    end
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "ee95ca80cd67b3a499a14f469536140935eb4483", [branch: "vendored"]},
   "mix_task_archive_deps": {:git, "https://github.com/elixir-lsp/mix_task_archive_deps.git", "30fa76221def649286835685fec5d151be83c354", []},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob_vendored": {:git, "https://github.com/elixir-lsp/path_glob.git", "965350dc41def7be4a70a23904195c733a2ecc84", [branch: "vendored"]},
   "providers": {:hex, :providers, "1.8.1", "70b4197869514344a8a60e2b2a4ef41ca03def43cfb1712ecf076a0f3c62f083", [:rebar3], [{:getopt, "1.0.1", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm", "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},


### PR DESCRIPTION
While editing in emacs, I've been noticing a lot of language server crashes. It appears that some of them are due to the way emacs builds elixir files, which can cause the tooling of elixir-ls to emit syntax errors or have off-by-one line errors or not handle certain types of code.

I might be barking up the wrong tree here, but I think elixir-ls should be pretty agressive with handling errors and shouldn't crash, but if that's the expected behavior, then we'll need a different approach, and I'm all ears.

The changes here reduce the number of crashes dramatically so it's pleasant to use elixir-ls in emacs again.