### PR TITLE
Fix unused warning during compile

### DIFF
--- a/apps/language_server/lib/language_server/providers/code_action.ex
+++ b/apps/language_server/lib/language_server/providers/code_action.ex
@@ -10,7 +10,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeAction do
     {:ok, actions}
   end
 
-  defp actions(uri, %{"message" => message, "range" => range} = diagnostic) do
+  defp actions(uri, %{"message" => message} = diagnostic) do
     [
       {~r/variable "(.*)" is unused/, &prefix_with_underscore/2},
       {~r/variable "(.*)" is unused/, &remove_variable/2}
@@ -19,7 +19,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeAction do
     |> Enum.map(fn {_r, fun} -> fun.(uri, diagnostic) end)
   end
 
-  defp prefix_with_underscore(uri, %{"message" => message, "range" => range} = diagnostic) do
+  defp prefix_with_underscore(uri, %{"range" => range}) do
     %{
       "title" => "Add '_' to unused variable",
       "kind" => "quickfix",
@@ -42,7 +42,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeAction do
     }
   end
 
-  defp remove_variable(uri, %{"range" => range} = diagnostic) do
+  defp remove_variable(uri, %{"range" => range}) do
     %{
       "title" => "Remove unused variable",
       "kind" => "quickfix",

--- a/apps/language_server/lib/language_server/providers/hover.ex
+++ b/apps/language_server/lib/language_server/providers/hover.ex
@@ -162,7 +162,7 @@ defmodule ElixirLS.LanguageServer.Providers.Hover do
     ("Elixir." <> mod_name) |> String.to_atom() |> function_exported?(:__info__, 1)
   end
 
-  defp third_dep?(source, nil), do: false
+  defp third_dep?(_source, nil), do: false
 
   defp third_dep?(source, project_dir) do
     prefix = project_dir <> "/deps"

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -791,7 +791,7 @@ defmodule ElixirLS.LanguageServer.Server do
     end
   end
 
-  defp handle_request(code_action_req(id, uri, diagnostics) = req, state = %__MODULE__{}) do
+  defp handle_request(code_action_req(_id, uri, diagnostics), state = %__MODULE__{}) do
     {:async, fn -> CodeAction.code_actions(uri, diagnostics) end, state}
   end
 


### PR DESCRIPTION
Fixes issues below:

```
warning: variable "source" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/providers/hover.ex:165: ElixirLS.LanguageServer.Providers.Hover.third_dep?/2

warning: variable "range" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/providers/code_action.ex:13: ElixirLS.LanguageServer.Providers.CodeAction.actions/2

warning: variable "diagnostic" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/providers/code_action.ex:22: ElixirLS.LanguageServer.Providers.CodeAction.prefix_with_underscore/2

warning: variable "message" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/providers/code_action.ex:22: ElixirLS.LanguageServer.Providers.CodeAction.prefix_with_underscore/2

warning: variable "diagnostic" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/providers/code_action.ex:45: ElixirLS.LanguageServer.Providers.CodeAction.remove_variable/2

warning: variable "id" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/server.ex:794: ElixirLS.LanguageServer.Server.handle_request/2

warning: variable "req" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/language_server/server.ex:794: ElixirLS.LanguageServer.Server.handle_request/2
```