### PR TITLE
Improved DocumentSymbols resilience

### DIFF
--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -60,6 +60,12 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
     ast |> Enum.map(&extract_modules(&1)) |> List.flatten()
   end
 
+  # handle a bare defimpl, defprotocol or defmodule
+  defp extract_modules({defname, _, nil} = ast)
+       when defname in [:defmodule, :defprotocol, :defimpl] do
+    []
+  end
+
   defp extract_modules({defname, _, _child_ast} = ast)
        when defname in [:defmodule, :defprotocol, :defimpl] do
     [extract_symbol("", ast)]
@@ -72,6 +78,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
   defp extract_modules(_ast), do: []
 
   # Modules, protocols
+
   defp extract_symbol(_module_name, {defname, location, arguments})
        when defname in [:defmodule, :defprotocol] do
     {module_name, module_name_location, module_body} =

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -2474,4 +2474,24 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               }
             ]} = DocumentSymbols.symbols(uri, text, true)
   end
+
+  describe "invalid documents" do
+    test "handles a module being defined" do
+      uri = "file:///project.test.ex"
+      text = "defmodule "
+      assert {:ok, []} = DocumentSymbols.symbols(uri, text, true)
+    end
+
+    test "handles a protocol being defined" do
+      uri = "file:///project.test.ex"
+      text = "defprotocol "
+      assert {:ok, []} = DocumentSymbols.symbols(uri, text, true)
+    end
+
+    test "handles a protocol being impolemented" do
+      uri = "file:///project.test.ex"
+      text = "defimpl "
+      assert {:ok, []} = DocumentSymbols.symbols(uri, text, true)
+    end
+  end
 end


### PR DESCRIPTION
When editing a new file, it's common to type `defmodule<spc>`, but the server would crash on this and emit lots of warnings. This change makes it so the document symbols provider returns no symbols if that happens.