### PR TITLE
Improved resilience of `formatter_for`

### DIFF
--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -348,8 +348,9 @@ defmodule ElixirLS.LanguageServer.SourceFile do
       end
     rescue
       e ->
+        message = Exception.message(e)
         IO.warn(
-          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{e.message}"
+          "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{message}"
         )
 
         :error

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -32,7 +32,8 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:dialyxir, "~> 1.0", runtime: false},
       {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
       {:stream_data, "~> 0.5", only: :test},
-      {:path_glob_vendored, github: "elixir-lsp/path_glob", branch: "vendored"}
+      {:path_glob_vendored, github: "elixir-lsp/path_glob", branch: "vendored"},
+      {:patch, "~> 0.12.0", only: :test}
     ]
   end
 

--- a/apps/language_server/test/source_file/invalid_project_test.exs
+++ b/apps/language_server/test/source_file/invalid_project_test.exs
@@ -1,0 +1,32 @@
+defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
+
+  use ExUnit.Case, async: false
+
+  use Patch
+  alias ElixirLS.LanguageServer.SourceFile
+  import ExUnit.CaptureIO
+
+  describe "formatter_for " do
+
+    test "should handle syntax errors" do
+      patch(Mix.Tasks.Format, :formatter_for_file, fn _ -> raise %SyntaxError{file: ".formatter.exs", line: 1}  end)
+
+      output = capture_io(:stderr, fn ->
+        assert :error = SourceFile.formatter_for("file:///root.ex")
+      end)
+
+      assert String.contains?(output, "Unable to get formatter options")
+    end
+
+    test "should handle compile errors" do
+      patch(Mix.Tasks.Format, :formatter_for_file, fn _ -> raise %SyntaxError{file: ".formatter.exs", line: 1}  end)
+
+      output = capture_io(:stderr, fn ->
+        assert :error = SourceFile.formatter_for("file:///root.ex")
+      end)
+
+      assert String.contains?(output, "Unable to get formatter options")
+    end
+
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "ee95ca80cd67b3a499a14f469536140935eb4483", [branch: "vendored"]},
   "mix_task_archive_deps": {:git, "https://github.com/elixir-lsp/mix_task_archive_deps.git", "30fa76221def649286835685fec5d151be83c354", []},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "patch": {:hex, :patch, "0.12.0", "2da8967d382bade20344a3e89d618bfba563b12d4ac93955468e830777f816b0", [:mix], [], "hexpm", "ffd0e9a7f2ad5054f37af84067ee88b1ad337308a1cb227e181e3967127b0235"},
   "path_glob_vendored": {:git, "https://github.com/elixir-lsp/path_glob.git", "965350dc41def7be4a70a23904195c733a2ecc84", [branch: "vendored"]},
   "providers": {:hex, :providers, "1.8.1", "70b4197869514344a8a60e2b2a4ef41ca03def43cfb1712ecf076a0f3c62f083", [:rebar3], [{:getopt, "1.0.1", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm", "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},


### PR DESCRIPTION
It's possible that the call to `Mix.Tasks.Format.formatter_for_file` can cause a compile or syntax errors. Because these types of errors don't have a `message` key, the attempt to log them will fail, and the server will crash.

This PR uses `Exception.message` to build the message text, which should work on any exceptions.