### PR TITLE
Logger backend for language server and fixes for debugger

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger.ex
+++ b/apps/elixir_ls_debugger/lib/debugger.ex
@@ -4,12 +4,13 @@ defmodule ElixirLS.Debugger do
   """
 
   use Application
+  alias ElixirLS.Debugger.Output
 
   @impl Application
   def start(_type, _args) do
     # We don't start this as a worker because if the debugger crashes, we want
     # this process to remain alive to print errors
-    {:ok, _pid} = ElixirLS.Debugger.Output.start(ElixirLS.Debugger.Output)
+    {:ok, _pid} = Output.start(Output)
 
     children = [
       {ElixirLS.Debugger.Server, name: ElixirLS.Debugger.Server}
@@ -22,7 +23,7 @@ defmodule ElixirLS.Debugger do
   @impl Application
   def stop(_state) do
     if ElixirLS.Utils.WireProtocol.io_intercepted?() do
-      IO.puts(:standard_error, "ElixirLS debugger has crashed")
+      Output.debugger_important("ElixirLS debugger has crashed")
 
       :init.stop(1)
     end

--- a/apps/elixir_ls_debugger/lib/debugger/breakpoint_condition.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/breakpoint_condition.ex
@@ -4,6 +4,7 @@ defmodule ElixirLS.Debugger.BreakpointCondition do
   """
 
   use GenServer
+  alias ElixirLS.Debugger.Output
   @range 0..99
 
   def start_link(args) do
@@ -162,7 +163,7 @@ defmodule ElixirLS.Debugger.BreakpointCondition do
         # Debug Adapter Protocol:
         # If this attribute exists and is non-empty, the backend must not 'break' (stop)
         # but log the message instead. Expressions within {} are interpolated.
-        IO.puts(interpolate(log_message, elixir_binding))
+        Output.debugger_console(interpolate(log_message, elixir_binding))
         false
       else
         result
@@ -178,7 +179,10 @@ defmodule ElixirLS.Debugger.BreakpointCondition do
       if term, do: true, else: false
     catch
       kind, error ->
-        IO.warn("Error in conditional breakpoint: " <> Exception.format_banner(kind, error))
+        Output.debugger_important(
+          "Error in conditional breakpoint: " <> Exception.format_banner(kind, error)
+        )
+
         false
     end
   end
@@ -189,7 +193,10 @@ defmodule ElixirLS.Debugger.BreakpointCondition do
       to_string(term)
     catch
       kind, error ->
-        IO.warn("Error in log message interpolation: " <> Exception.format_banner(kind, error))
+        Output.debugger_important(
+          "Error in log message interpolation: " <> Exception.format_banner(kind, error)
+        )
+
         ""
     end
   end
@@ -220,7 +227,7 @@ defmodule ElixirLS.Debugger.BreakpointCondition do
         interpolate(expression_rest, [eval_result | acc], elixir_binding)
 
       :error ->
-        IO.warn("Log message has unpaired or nested `{}`")
+        Output.debugger_important("Log message has unpaired or nested `{}`")
         acc
     end
   end

--- a/apps/elixir_ls_debugger/lib/debugger/cli.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/cli.ex
@@ -7,8 +7,17 @@ defmodule ElixirLS.Debugger.CLI do
     Launch.start_mix()
     {:ok, _} = Application.ensure_all_started(:elixir_ls_debugger, :permanent)
 
-    IO.puts("Started ElixirLS debugger v#{Launch.debugger_version()}")
-    Launch.print_versions()
+    IO.puts("Started ElixirLS Debugger v#{Launch.debugger_version()}")
+    versions = Launch.get_versions()
+
+    IO.puts(
+      "ElixirLS Debugger built with elixir #{versions.compile_elixir_version} on OTP #{versions.compile_otp_version}"
+    )
+
+    IO.puts(
+      "Running on elixir #{versions.current_elixir_version} on OTP #{versions.current_otp_version}"
+    )
+
     Launch.limit_num_schedulers()
     warn_if_unsupported_version()
     WireProtocol.stream_packets(&Server.receive_packet/1)

--- a/apps/elixir_ls_debugger/lib/debugger/cli.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/cli.ex
@@ -3,18 +3,18 @@ defmodule ElixirLS.Debugger.CLI do
   alias ElixirLS.Debugger.{Output, Server}
 
   def main do
-    WireProtocol.intercept_output(&Output.print/1, &Output.print_err/1)
+    WireProtocol.intercept_output(&Output.debuggee_out/1, &Output.debuggee_err/1)
     Launch.start_mix()
     {:ok, _} = Application.ensure_all_started(:elixir_ls_debugger, :permanent)
 
-    IO.puts("Started ElixirLS Debugger v#{Launch.debugger_version()}")
+    Output.debugger_console("Started ElixirLS Debugger v#{Launch.debugger_version()}")
     versions = Launch.get_versions()
 
-    IO.puts(
+    Output.debugger_console(
       "ElixirLS Debugger built with elixir #{versions.compile_elixir_version} on OTP #{versions.compile_otp_version}"
     )
 
-    IO.puts(
+    Output.debugger_console(
       "Running on elixir #{versions.current_elixir_version} on OTP #{versions.current_otp_version}"
     )
 
@@ -25,11 +25,11 @@ defmodule ElixirLS.Debugger.CLI do
 
   defp warn_if_unsupported_version do
     with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_elixir_version() do
-      Output.print_err("WARNING: " <> message)
+      Output.debugger_important("WARNING: " <> message)
     end
 
     with {:error, message} <- ElixirLS.Utils.MinimumVersion.check_otp_version() do
-      Output.print_err("WARNING: " <> message)
+      Output.debugger_important("WARNING: " <> message)
     end
   end
 end

--- a/apps/elixir_ls_debugger/lib/debugger/output.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/output.ex
@@ -29,11 +29,19 @@ defmodule ElixirLS.Debugger.Output do
     GenServer.call(server, {:send_event, event, body})
   end
 
-  def print(server \\ __MODULE__, str) when is_binary(str) do
+  def debugger_console(server \\ __MODULE__, str) when is_binary(str) do
+    send_event(server, "output", %{"category" => "console", "output" => str})
+  end
+
+  def debugger_important(server \\ __MODULE__, str) when is_binary(str) do
+    send_event(server, "output", %{"category" => "important", "output" => str})
+  end
+
+  def debuggee_out(server \\ __MODULE__, str) when is_binary(str) do
     send_event(server, "output", %{"category" => "stdout", "output" => str})
   end
 
-  def print_err(server \\ __MODULE__, str) when is_binary(str) do
+  def debuggee_err(server \\ __MODULE__, str) when is_binary(str) do
     send_event(server, "output", %{"category" => "stderr", "output" => str})
   end
 

--- a/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/stacktrace.ex
@@ -2,6 +2,7 @@ defmodule ElixirLS.Debugger.Stacktrace do
   @moduledoc """
   Retrieves the stack trace for a process that's paused at a breakpoint
   """
+  alias ElixirLS.Debugger.Output
 
   defmodule Frame do
     defstruct [:level, :file, :module, :function, :args, :line, :bindings, :messages]
@@ -56,7 +57,10 @@ defmodule ElixirLS.Debugger.Stacktrace do
         [first_frame | other_frames]
 
       error ->
-        IO.warn("Failed to obtain meta for pid #{inspect(pid)}: #{inspect(error)}")
+        Output.debugger_important(
+          "Failed to obtain meta for pid #{inspect(pid)}: #{inspect(error)}"
+        )
+
         []
     end
   end

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -402,7 +402,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                      }),
                      500
 
-      {log, stderr} =
+      {log, _stderr} =
         capture_log_and_io(:standard_error, fn ->
           assert_receive event(_, "thread", %{
                            "reason" => "exited",
@@ -412,7 +412,6 @@ defmodule ElixirLS.Debugger.ServerTest do
         end)
 
       assert log =~ "Fixture MixProject expected error"
-      assert stderr =~ "Fixture MixProject expected error"
     end)
   end
 
@@ -461,7 +460,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                      }),
                      5000
 
-      {log, io} =
+      {log, _io} =
         capture_log_and_io(:stderr, fn ->
           assert_receive event(_, "thread", %{
                            "reason" => "exited",
@@ -471,7 +470,6 @@ defmodule ElixirLS.Debugger.ServerTest do
         end)
 
       assert log =~ "Fixture MixProject raise for exit_self/0"
-      assert io =~ "Fixture MixProject raise for exit_self/0"
 
       assert_receive event(_, "exited", %{
                        "exitCode" => 1
@@ -560,20 +558,20 @@ defmodule ElixirLS.Debugger.ServerTest do
                  |> Enum.filter(&(&1["name"] |> String.starts_with?("MixProject.Some")))
                  |> Enum.map(& &1["id"])
 
-        {_, stderr} =
-          capture_log_and_io(:standard_error, fn ->
-            Server.receive_packet(server, request(7, "pause", %{"threadId" => thread_id}))
-            assert_receive(response(_, 7, "pause", %{}), 500)
+        Server.receive_packet(server, request(7, "pause", %{"threadId" => thread_id}))
+        assert_receive(response(_, 7, "pause", %{}), 500)
 
-            assert_receive event(_, "stopped", %{
-                             "allThreadsStopped" => false,
-                             "reason" => "pause",
-                             "threadId" => ^thread_id
-                           }),
-                           500
-          end)
+        assert_receive event(_, "stopped", %{
+                         "allThreadsStopped" => false,
+                         "reason" => "pause",
+                         "threadId" => ^thread_id
+                       }),
+                       500
 
-        assert stderr =~ "Failed to obtain meta for pid"
+        assert_receive event(_, "output", %{
+                         "category" => "important",
+                         "output" => "Failed to obtain meta for pid" <> _
+                       })
       end)
     end
 

--- a/apps/elixir_ls_utils/lib/launch.ex
+++ b/apps/elixir_ls_utils/lib/launch.ex
@@ -13,14 +13,13 @@ defmodule ElixirLS.Utils.Launch do
     :ok
   end
 
-  def print_versions do
-    IO.inspect(System.build_info()[:build], label: "Elixir version")
-    IO.inspect(System.otp_release(), label: "Erlang version")
-
-    IO.puts(
-      "ElixirLS compiled with Elixir #{@compiled_elixir_version}" <>
-        " and erlang #{@compiled_otp_version}"
-    )
+  def get_versions do
+    %{
+      current_elixir_version: inspect(System.build_info()[:build]),
+      current_otp_version: inspect(System.otp_release()),
+      compile_elixir_version: inspect(@compiled_elixir_version),
+      compile_otp_version: inspect(@compiled_otp_version)
+    }
   end
 
   def language_server_version do

--- a/apps/elixir_ls_utils/lib/packet_stream.ex
+++ b/apps/elixir_ls_utils/lib/packet_stream.ex
@@ -31,7 +31,7 @@ defmodule ElixirLS.Utils.PacketStream do
           :ok
 
         {:error, reason} ->
-          IO.warn("Unable to read from device: #{inspect(reason)}")
+          raise "Unable to read from device: #{inspect(reason)}"
       end
     )
   end

--- a/apps/elixir_ls_utils/test/support/packet_capture.ex
+++ b/apps/elixir_ls_utils/test/support/packet_capture.ex
@@ -26,7 +26,6 @@ defmodule ElixirLS.Utils.PacketCapture do
     handle_output(to_string(chars), from, reply_as, parent)
   end
 
-  @impl GenServer
   def handle_info(
         {:io_request, from, reply_as, {:put_chars, _encoding, module, fun, args}},
         parent

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -10,7 +10,13 @@ defmodule ElixirLS.LanguageServer.CLI do
     # :logger application is already started
     # replace console logger with LSP
     Application.put_env(:logger, :backends, [Logger.Backends.JsonRpc])
-    Application.put_env(:logger, Logger.Backends.JsonRpc, [level: :debug, format: "$message", metadata: []])
+
+    Application.put_env(:logger, Logger.Backends.JsonRpc,
+      level: :debug,
+      format: "$message",
+      metadata: []
+    )
+
     {:ok, _} = Logger.add_backend(Logger.Backends.JsonRpc)
     :ok = Logger.remove_backend(:console, flush: true)
 

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -26,14 +26,7 @@ defmodule ElixirLS.LanguageServer.CLI do
 
     start_language_server()
 
-    Logger.debug("Started ElixirLS v#{Launch.language_server_version()}")
     Logger.info("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.notice("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.warn("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.error("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.critical("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.alert("Started ElixirLS v#{Launch.language_server_version()}")
-    Logger.emergency("Started ElixirLS v#{Launch.language_server_version()}")
 
     Launch.print_versions()
     Launch.limit_num_schedulers()

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -47,25 +47,39 @@ defmodule ElixirLS.LanguageServer.CLI do
     WireProtocol.stream_packets(&JsonRpc.receive_packet/1)
   end
 
-  defp start_language_server do
+  defp incomplete_installation_message(hash \\ "") do
     guide =
       "https://github.com/elixir-lsp/elixir-ls/blob/master/guides/incomplete-installation.md"
 
+    "Unable to start ElixirLS due to an incomplete erlang installation. " <>
+      "See #{guide}#{hash} for guidance."
+  end
+
+  defp start_language_server do
     case Application.ensure_all_started(:language_server, :temporary) do
       {:ok, _} ->
         :ok
 
       {:error, {:edoc, {'no such file or directory', 'edoc.app'}}} ->
-        raise "Unable to start ElixirLS due to an incomplete erlang installation. " <>
-                "See #{guide}#edoc-missing for guidance."
+        message = incomplete_installation_message("#edoc-missing")
+
+        JsonRpc.show_message(:error, message)
+        Process.sleep(5000)
+        raise message
 
       {:error, {:dialyzer, {'no such file or directory', 'dialyzer.app'}}} ->
-        raise "Unable to start ElixirLS due to an incomplete erlang installation. " <>
-                "See #{guide}#dialyzer-missing for guidance."
+        message = incomplete_installation_message("#dialyzer-missing")
+
+        JsonRpc.show_message(:error, message)
+        Process.sleep(5000)
+        raise message
 
       {:error, _} ->
-        raise "Unable to start ElixirLS due to an incomplete erlang installation. " <>
-                "See #{guide} for guidance."
+        message = incomplete_installation_message()
+
+        JsonRpc.show_message(:error, message)
+        Process.sleep(5000)
+        raise message
     end
   end
 end

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -2,16 +2,33 @@ defmodule ElixirLS.LanguageServer.CLI do
   alias ElixirLS.Utils.{WireProtocol, Launch}
   alias ElixirLS.LanguageServer.JsonRpc
   alias ElixirLS.LanguageServer.Build
+  require Logger
 
   def main do
     WireProtocol.intercept_output(&JsonRpc.print/1, &JsonRpc.print_err/1)
+
+    # :logger application is already started
+    # replace console logger with LSP
+    Application.put_env(:logger, :backends, [Logger.Backends.JsonRpc])
+    Application.put_env(:logger, Logger.Backends.JsonRpc, [level: :debug, format: "$message", metadata: []])
+    {:ok, _} = Logger.add_backend(Logger.Backends.JsonRpc)
+    :ok = Logger.remove_backend(:console, flush: true)
+
     Launch.start_mix()
 
     Build.set_compiler_options()
 
     start_language_server()
 
-    IO.puts("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.debug("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.info("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.notice("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.warn("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.error("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.critical("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.alert("Started ElixirLS v#{Launch.language_server_version()}")
+    Logger.emergency("Started ElixirLS v#{Launch.language_server_version()}")
+
     Launch.print_versions()
     Launch.limit_num_schedulers()
 

--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -28,7 +28,16 @@ defmodule ElixirLS.LanguageServer.CLI do
 
     Logger.info("Started ElixirLS v#{Launch.language_server_version()}")
 
-    Launch.print_versions()
+    versions = Launch.get_versions()
+
+    Logger.info(
+      "ElixirLS built with elixir #{versions.compile_elixir_version} on OTP #{versions.compile_otp_version}"
+    )
+
+    Logger.info(
+      "Running on elixir #{versions.current_elixir_version} on OTP #{versions.current_otp_version}"
+    )
+
     Launch.limit_num_schedulers()
 
     Mix.shell(ElixirLS.LanguageServer.MixShell)

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -3,6 +3,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   alias ElixirLS.LanguageServer.Dialyzer.{Manifest, Analyzer, Utils, SuccessTypings}
   import Utils
   use GenServer
+  require Logger
 
   defstruct [
     :parent,
@@ -147,7 +148,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     state =
       ElixirLS.LanguageServer.Build.with_build_lock(fn ->
         if Mix.Project.get() do
-          JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Checking for stale beam files")
+          Logger.info("[ElixirLS Dialyzer] Checking for stale beam files")
           new_timestamp = adjusted_timestamp()
 
           {removed_files, file_changes} =
@@ -261,8 +262,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         {changed, changed_contents}
       end)
 
-    JsonRpc.log_message(
-      :info,
+    Logger.info(
       "[ElixirLS Dialyzer] Found #{length(changed)} changed files in #{div(us, 1000)} milliseconds"
     )
 
@@ -338,7 +338,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
               :ok
 
             {:error, reason} ->
-              IO.warn("Unable to remove temporary file #{path}: #{inspect(reason)}")
+              Logger.warn("Unable to remove temporary file #{path}: #{inspect(reason)}")
           end
         end
 
@@ -375,8 +375,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         warnings = Map.drop(warnings, modules_to_analyze)
 
         # Analyze!
-        JsonRpc.log_message(
-          :info,
+        Logger.info(
           "[ElixirLS Dialyzer] Analyzing #{Enum.count(modules_to_analyze)} modules: " <>
             "#{inspect(modules_to_analyze)}"
         )
@@ -396,10 +395,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         {active_plt, mod_deps, md5, warnings}
       end)
 
-    JsonRpc.log_message(
-      :info,
-      "[ElixirLS Dialyzer] Analysis finished in #{div(us, 1000)} milliseconds"
-    )
+    Logger.info("[ElixirLS Dialyzer] Analysis finished in #{div(us, 1000)} milliseconds")
 
     analysis_finished(parent, :ok, active_plt, mod_deps, md5, warnings, timestamp, build_ref)
   end
@@ -507,7 +503,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   defp normalize_postion(position) do
-    IO.warn("dialyzer returned warning with invalid position #{inspect(position)}")
+    Logger.warn("dialyzer returned warning with invalid position #{inspect(position)}")
     0
   end
 
@@ -534,8 +530,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   defp warning_message(raw_warning, warning_format) do
-    JsonRpc.log_message(
-      :info,
+    Logger.info(
       "[ElixirLS Dialyzer] Unrecognized dialyzerFormat setting: #{inspect(warning_format)}" <>
         ", falling back to \"dialyzer\""
     )

--- a/apps/language_server/lib/language_server/dialyzer/analyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer/analyzer.ex
@@ -1,5 +1,6 @@
 defmodule ElixirLS.LanguageServer.Dialyzer.Analyzer do
   require Record
+  require Logger
 
   # warn_race_condition is unsupported because it greatly increases analysis time
   # OTP 25 dropped support for warn_race_condition
@@ -178,7 +179,9 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Analyzer do
   end
 
   defp print_failure(reason, log_cache) do
-    IO.puts("Analysis failed: " <> Exception.format_exit(reason))
-    for msg <- log_cache, do: IO.puts(msg)
+    message =
+      "Analysis failed: " <> Exception.format_exit(reason) <> "\n" <> Enum.join(log_cache, "\n")
+
+    Logger.error(message)
   end
 end

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -2,6 +2,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   alias ElixirLS.LanguageServer.{Dialyzer, Dialyzer.Utils, JsonRpc}
   import Record
   import Dialyzer.Utils
+  require Logger
 
   @manifest_vsn :v2
 
@@ -50,7 +51,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
 
           # Because the manifest file can be several megabytes, we do a write-then-rename
           # to reduce the likelihood of corrupting the manifest
-          JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Writing manifest...")
+          Logger.info("[ElixirLS Dialyzer] Writing manifest...")
           File.mkdir_p!(Path.dirname(manifest_path))
           tmp_manifest_path = manifest_path <> ".new"
           File.write!(tmp_manifest_path, :erlang.term_to_binary(manifest_data, compressed: 1))
@@ -58,10 +59,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
           File.touch!(manifest_path, timestamp)
         end)
 
-      JsonRpc.log_message(
-        :info,
-        "[ElixirLS Dialyzer] Done writing manifest in #{div(us, 1000)} milliseconds."
-      )
+      Logger.info("[ElixirLS Dialyzer] Done writing manifest in #{div(us, 1000)} milliseconds.")
     end)
   end
 

--- a/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
+++ b/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
@@ -20,30 +20,20 @@ defmodule Logger.Backends.JsonRpc do
       Setting `:metadata` to `:all` prints all metadata. See
       the "Metadata" section for more information.
 
-    * `:device` - the device to log error messages to. Defaults to
-      `:user` but can be changed to something else such as `:standard_error`.
-
   """
 
   @behaviour :gen_event
 
-  defstruct device: nil,
-            format: nil,
+  defstruct format: nil,
             level: nil,
             metadata: nil,
-            output: nil,
-            ref: nil
+            output: nil
 
   @impl true
   def init(:json_rpc) do
     config = Application.get_env(:logger, :json_rpc)
-    device = Keyword.get(config, :device, :user)
 
-    if Process.whereis(device) do
-      {:ok, init(config, %__MODULE__{})}
-    else
-      {:error, :ignore}
-    end
+    {:ok, init(config, %__MODULE__{})}
   end
 
   def init({__MODULE__, opts}) when is_list(opts) do
@@ -58,7 +48,7 @@ defmodule Logger.Backends.JsonRpc do
 
   @impl true
   def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
-    %{level: log_level, ref: ref} = state
+    %{level: log_level} = state
 
     {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
 
@@ -66,13 +56,13 @@ defmodule Logger.Backends.JsonRpc do
       not meet_level?(level, log_level) ->
         {:ok, state}
 
-      is_nil(ref) ->
+      true ->
         {:ok, log_event(level, msg, ts, md, state)}
     end
   end
 
   def handle_event(:flush, state) do
-    {:ok, flush(state)}
+    {:ok, state}
   end
 
   def handle_event(_, state) do
@@ -80,14 +70,6 @@ defmodule Logger.Backends.JsonRpc do
   end
 
   @impl true
-  def handle_info({:io_reply, ref, msg}, %{ref: ref} = state) do
-    {:ok, handle_io_reply(msg, state)}
-  end
-
-  def handle_info({:DOWN, ref, _, pid, reason}, %{ref: ref}) do
-    raise "device #{inspect(pid)} exited: " <> Exception.format_exit(reason)
-  end
-
   def handle_info(_, state) do
     {:ok, state}
   end
@@ -118,7 +100,6 @@ defmodule Logger.Backends.JsonRpc do
 
   defp init(config, state) do
     level = Keyword.get(config, :level)
-    device = Keyword.get(config, :device, :user)
     format = Logger.Formatter.compile(Keyword.get(config, :format))
     metadata = Keyword.get(config, :metadata, []) |> configure_metadata()
 
@@ -126,8 +107,7 @@ defmodule Logger.Backends.JsonRpc do
       state
       | format: format,
         metadata: metadata,
-        level: level,
-        device: device
+        level: level
     }
   end
 
@@ -140,41 +120,9 @@ defmodule Logger.Backends.JsonRpc do
     end)
   end
 
-  defp log_event(level, msg, ts, md, %{device: device} = state) do
+  defp log_event(level, msg, ts, md, state) do
     output = format_event(level, msg, ts, md, state)
-    %{state | ref: async_io(device, output), output: output}
-  end
-
-  defp async_io(name, output) when is_atom(name) do
-    case Process.whereis(name) do
-      device when is_pid(device) ->
-        async_io(device, output)
-
-      nil ->
-        raise "no device registered with the name #{inspect(name)}"
-    end
-  end
-
-  defp async_io(device, output) when is_pid(device) do
-    ref = Process.monitor(device)
-    send(device, {:io_request, self(), ref, {:put_chars, :unicode, output}})
-    ref
-  end
-
-  defp await_io(%{ref: nil} = state), do: state
-
-  defp await_io(%{ref: ref} = state) do
-    receive do
-      {:io_reply, ^ref, :ok} ->
-        handle_io_reply(:ok, state)
-
-      {:io_reply, ^ref, error} ->
-        handle_io_reply(error, state)
-        |> await_io()
-
-      {:DOWN, ^ref, _, pid, reason} ->
-        raise "device #{inspect(pid)} exited: " <> Exception.format_exit(reason)
-    end
+    %{state | output: output}
   end
 
   defp format_event(level, msg, ts, md, state) do
@@ -195,33 +143,5 @@ defmodule Logger.Backends.JsonRpc do
         :error -> acc
       end
     end)
-  end
-
-  defp retry_log(error, %{device: device, ref: ref, output: dirty} = state) do
-    Process.demonitor(ref, [:flush])
-
-    try do
-      :unicode.characters_to_binary(dirty)
-    rescue
-      ArgumentError ->
-        clean = ["failure while trying to log malformed data: ", inspect(dirty), ?\n]
-        %{state | ref: async_io(device, clean), output: clean}
-    else
-      {_, good, bad} ->
-        clean = [good | Logger.Formatter.prune(bad)]
-        %{state | ref: async_io(device, clean), output: clean}
-
-      _ ->
-        # A well behaved IO device should not error on good data
-        raise "failure while logging json_rpc messages: " <> inspect(error)
-    end
-  end
-
-  defp flush(%{ref: nil} = state), do: state
-
-  defp flush(state) do
-    state
-    |> await_io()
-    |> flush()
   end
 end

--- a/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
+++ b/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
@@ -1,0 +1,340 @@
+defmodule Logger.Backends.Console do
+  @moduledoc ~S"""
+  A logger backend that logs messages by printing them to the console.
+
+  ## Options
+
+    * `:level` - the level to be logged by this backend.
+      Note that messages are filtered by the general
+      `:level` configuration for the `:logger` application first.
+
+    * `:format` - the format message used to print logs.
+      Defaults to: `"\n$time $metadata[$level] $message\n"`.
+      It may also be a `{module, function}` tuple that is invoked
+      with the log level, the message, the current timestamp and
+      the metadata and must return `t:IO.chardata/0`. See
+      `Logger.Formatter`.
+
+    * `:metadata` - the metadata to be printed by `$metadata`.
+      Defaults to an empty list (no metadata).
+      Setting `:metadata` to `:all` prints all metadata. See
+      the "Metadata" section for more information.
+
+    * `:colors` - a keyword list of coloring options.
+
+    * `:device` - the device to log error messages to. Defaults to
+      `:user` but can be changed to something else such as `:standard_error`.
+
+    * `:max_buffer` - maximum events to buffer while waiting
+      for a confirmation from the IO device (default: 32).
+      Once the buffer is full, the backend will block until
+      a confirmation is received.
+
+  The supported keys in the `:colors` keyword list are:
+
+    * `:enabled` - boolean value that allows for switching the
+      coloring on and off. Defaults to: `IO.ANSI.enabled?/0`
+
+    * `:debug` - color for debug messages. Defaults to: `:cyan`
+
+    * `:info` - color for info and notice messages. Defaults to: `:normal`
+
+    * `:warning` - color for warning messages. Defaults to: `:yellow`
+
+    * `:error` - color for error and higher messages. Defaults to: `:red`
+
+  See the `IO.ANSI` module for a list of colors and attributes.
+
+  Here is an example of how to configure the `:console` backend in a
+  `config/config.exs` file:
+
+      config :logger, :console,
+        format: "\n$time $metadata[$level] $message\n",
+        metadata: [:user_id]
+
+  """
+
+  @behaviour :gen_event
+
+  defstruct buffer: [],
+            buffer_size: 0,
+            colors: nil,
+            device: nil,
+            format: nil,
+            level: nil,
+            max_buffer: nil,
+            metadata: nil,
+            output: nil,
+            ref: nil
+
+  @impl true
+  def init(:console) do
+    config = Application.get_env(:logger, :console)
+    device = Keyword.get(config, :device, :user)
+
+    if Process.whereis(device) do
+      {:ok, init(config, %__MODULE__{})}
+    else
+      {:error, :ignore}
+    end
+  end
+
+  def init({__MODULE__, opts}) when is_list(opts) do
+    config = configure_merge(Application.get_env(:logger, :console), opts)
+    {:ok, init(config, %__MODULE__{})}
+  end
+
+  @impl true
+  def handle_call({:configure, options}, state) do
+    {:ok, :ok, configure(options, state)}
+  end
+
+  @impl true
+  def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
+    %{level: log_level, ref: ref, buffer_size: buffer_size, max_buffer: max_buffer} = state
+
+    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
+
+    cond do
+      not meet_level?(level, log_level) ->
+        {:ok, state}
+
+      is_nil(ref) ->
+        {:ok, log_event(level, msg, ts, md, state)}
+
+      buffer_size < max_buffer ->
+        {:ok, buffer_event(level, msg, ts, md, state)}
+
+      buffer_size === max_buffer ->
+        state = buffer_event(level, msg, ts, md, state)
+        {:ok, await_io(state)}
+    end
+  end
+
+  def handle_event(:flush, state) do
+    {:ok, flush(state)}
+  end
+
+  def handle_event(_, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info({:io_reply, ref, msg}, %{ref: ref} = state) do
+    {:ok, handle_io_reply(msg, state)}
+  end
+
+  def handle_info({:DOWN, ref, _, pid, reason}, %{ref: ref}) do
+    raise "device #{inspect(pid)} exited: " <> Exception.format_exit(reason)
+  end
+
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def code_change(_old_vsn, state, _extra) do
+    {:ok, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  ## Helpers
+
+  defp meet_level?(_lvl, nil), do: true
+
+  defp meet_level?(lvl, min) do
+    Logger.compare_levels(lvl, min) != :lt
+  end
+
+  defp configure(options, state) do
+    config = configure_merge(Application.get_env(:logger, :console), options)
+    Application.put_env(:logger, :console, config)
+    init(config, state)
+  end
+
+  defp init(config, state) do
+    level = Keyword.get(config, :level)
+    device = Keyword.get(config, :device, :user)
+    format = Logger.Formatter.compile(Keyword.get(config, :format))
+    colors = configure_colors(config)
+    metadata = Keyword.get(config, :metadata, []) |> configure_metadata()
+    max_buffer = Keyword.get(config, :max_buffer, 32)
+
+    %{
+      state
+      | format: format,
+        metadata: metadata,
+        level: level,
+        colors: colors,
+        device: device,
+        max_buffer: max_buffer
+    }
+  end
+
+  defp configure_metadata(:all), do: :all
+  defp configure_metadata(metadata), do: Enum.reverse(metadata)
+
+  defp configure_merge(env, options) do
+    Keyword.merge(env, options, fn
+      :colors, v1, v2 -> Keyword.merge(v1, v2)
+      _, _v1, v2 -> v2
+    end)
+  end
+
+  defp configure_colors(config) do
+    colors = Keyword.get(config, :colors, [])
+
+    warning =
+      Keyword.get_lazy(colors, :warning, fn ->
+        # TODO: Deprecate :warn option on Elixir v1.19
+        if warn = Keyword.get(colors, :warn) do
+          warn
+        else
+          :yellow
+        end
+      end)
+
+    %{
+      emergency: Keyword.get(colors, :error, :red),
+      alert: Keyword.get(colors, :error, :red),
+      critical: Keyword.get(colors, :error, :red),
+      error: Keyword.get(colors, :error, :red),
+      warning: warning,
+      notice: Keyword.get(colors, :info, :normal),
+      info: Keyword.get(colors, :info, :normal),
+      debug: Keyword.get(colors, :debug, :cyan),
+      enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
+    }
+  end
+
+  defp log_event(level, msg, ts, md, %{device: device} = state) do
+    output = format_event(level, msg, ts, md, state)
+    %{state | ref: async_io(device, output), output: output}
+  end
+
+  defp buffer_event(level, msg, ts, md, state) do
+    %{buffer: buffer, buffer_size: buffer_size} = state
+    buffer = [buffer | format_event(level, msg, ts, md, state)]
+    %{state | buffer: buffer, buffer_size: buffer_size + 1}
+  end
+
+  defp async_io(name, output) when is_atom(name) do
+    case Process.whereis(name) do
+      device when is_pid(device) ->
+        async_io(device, output)
+
+      nil ->
+        raise "no device registered with the name #{inspect(name)}"
+    end
+  end
+
+  defp async_io(device, output) when is_pid(device) do
+    ref = Process.monitor(device)
+    send(device, {:io_request, self(), ref, {:put_chars, :unicode, output}})
+    ref
+  end
+
+  defp await_io(%{ref: nil} = state), do: state
+
+  defp await_io(%{ref: ref} = state) do
+    receive do
+      {:io_reply, ^ref, :ok} ->
+        handle_io_reply(:ok, state)
+
+      {:io_reply, ^ref, error} ->
+        handle_io_reply(error, state)
+        |> await_io()
+
+      {:DOWN, ^ref, _, pid, reason} ->
+        raise "device #{inspect(pid)} exited: " <> Exception.format_exit(reason)
+    end
+  end
+
+  defp format_event(level, msg, ts, md, state) do
+    %{format: format, metadata: keys, colors: colors} = state
+
+    format
+    |> Logger.Formatter.format(level, msg, ts, take_metadata(md, keys))
+    |> color_event(level, colors, md)
+  end
+
+  defp take_metadata(metadata, :all) do
+    metadata
+  end
+
+  defp take_metadata(metadata, keys) do
+    Enum.reduce(keys, [], fn key, acc ->
+      case Keyword.fetch(metadata, key) do
+        {:ok, val} -> [{key, val} | acc]
+        :error -> acc
+      end
+    end)
+  end
+
+  defp color_event(data, _level, %{enabled: false}, _md), do: data
+
+  defp color_event(data, level, %{enabled: true} = colors, md) do
+    color = md[:ansi_color] || Map.fetch!(colors, level)
+    [IO.ANSI.format_fragment(color, true), data | IO.ANSI.reset()]
+  end
+
+  defp log_buffer(%{buffer_size: 0, buffer: []} = state), do: state
+
+  defp log_buffer(state) do
+    %{device: device, buffer: buffer} = state
+    %{state | ref: async_io(device, buffer), buffer: [], buffer_size: 0, output: buffer}
+  end
+
+  defp handle_io_reply(:ok, %{ref: ref} = state) do
+    Process.demonitor(ref, [:flush])
+    log_buffer(%{state | ref: nil, output: nil})
+  end
+
+  defp handle_io_reply({:error, {:put_chars, :unicode, _} = error}, state) do
+    retry_log(error, state)
+  end
+
+  defp handle_io_reply({:error, :put_chars}, %{output: output} = state) do
+    retry_log({:put_chars, :unicode, output}, state)
+  end
+
+  defp handle_io_reply({:error, {:no_translation, _encoding_from, _encoding_to} = error}, state) do
+    retry_log(error, state)
+  end
+
+  defp handle_io_reply({:error, error}, _) do
+    raise "failure while logging console messages: " <> inspect(error)
+  end
+
+  defp retry_log(error, %{device: device, ref: ref, output: dirty} = state) do
+    Process.demonitor(ref, [:flush])
+
+    try do
+      :unicode.characters_to_binary(dirty)
+    rescue
+      ArgumentError ->
+        clean = ["failure while trying to log malformed data: ", inspect(dirty), ?\n]
+        %{state | ref: async_io(device, clean), output: clean}
+    else
+      {_, good, bad} ->
+        clean = [good | Logger.Formatter.prune(bad)]
+        %{state | ref: async_io(device, clean), output: clean}
+
+      _ ->
+        # A well behaved IO device should not error on good data
+        raise "failure while logging consoles messages: " <> inspect(error)
+    end
+  end
+
+  defp flush(%{ref: nil} = state), do: state
+
+  defp flush(state) do
+    state
+    |> await_io()
+    |> flush()
+  end
+end

--- a/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
+++ b/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
@@ -1,6 +1,6 @@
 defmodule Logger.Backends.JsonRpc do
   @moduledoc ~S"""
-  A logger backend that logs messages by printing them to the console.
+  A logger backend that logs messages by sending them via ‘window/logMessage’.
 
   ## Options
 
@@ -45,13 +45,6 @@ defmodule Logger.Backends.JsonRpc do
 
   See the `IO.ANSI` module for a list of colors and attributes.
 
-  Here is an example of how to configure the `:console` backend in a
-  `config/config.exs` file:
-
-      config :logger, :console,
-        format: "\n$time $metadata[$level] $message\n",
-        metadata: [:user_id]
-
   """
 
   @behaviour :gen_event
@@ -68,8 +61,8 @@ defmodule Logger.Backends.JsonRpc do
             ref: nil
 
   @impl true
-  def init(:console) do
-    config = Application.get_env(:logger, :console)
+  def init(:json_rpc) do
+    config = Application.get_env(:logger, :json_rpc)
     device = Keyword.get(config, :device, :user)
 
     if Process.whereis(device) do
@@ -80,7 +73,7 @@ defmodule Logger.Backends.JsonRpc do
   end
 
   def init({__MODULE__, opts}) when is_list(opts) do
-    config = configure_merge(Application.get_env(:logger, :console), opts)
+    config = configure_merge(Application.get_env(:logger, :json_rpc), opts)
     {:ok, init(config, %__MODULE__{})}
   end
 
@@ -151,8 +144,8 @@ defmodule Logger.Backends.JsonRpc do
   end
 
   defp configure(options, state) do
-    config = configure_merge(Application.get_env(:logger, :console), options)
-    Application.put_env(:logger, :console, config)
+    config = configure_merge(Application.get_env(:logger, :json_rpc), options)
+    Application.put_env(:logger, :json_rpc, config)
     init(config, state)
   end
 
@@ -307,7 +300,7 @@ defmodule Logger.Backends.JsonRpc do
   end
 
   defp handle_io_reply({:error, error}, _) do
-    raise "failure while logging console messages: " <> inspect(error)
+    raise "failure while logging json_rpc messages: " <> inspect(error)
   end
 
   defp retry_log(error, %{device: device, ref: ref, output: dirty} = state) do
@@ -326,7 +319,7 @@ defmodule Logger.Backends.JsonRpc do
 
       _ ->
         # A well behaved IO device should not error on good data
-        raise "failure while logging consoles messages: " <> inspect(error)
+        raise "failure while logging json_rpc messages: " <> inspect(error)
     end
   end
 

--- a/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
+++ b/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
@@ -45,6 +45,11 @@ defmodule Logger.Backends.JsonRpc do
     {:ok, :ok, configure(options, state)}
   end
 
+  def handle_call({:set_group_leader, pid}, state) do
+    Process.group_leader(self(), pid)
+    {:ok, :ok, state}
+  end
+
   @impl true
   def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
     %{level: log_level} = state

--- a/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
+++ b/apps/language_server/lib/language_server/json_rpc_logger_backend.ex
@@ -1,4 +1,4 @@
-defmodule Logger.Backends.Console do
+defmodule Logger.Backends.JsonRpc do
   @moduledoc ~S"""
   A logger backend that logs messages by printing them to the console.
 

--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -9,7 +9,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
   alias ElixirLS.LanguageServer.ErlangSourceFile
   alias ElixirLS.LanguageServer.SourceFile
   alias ElixirLS.LanguageServer.Providers.SymbolUtils
-  alias ElixirLS.LanguageServer.JsonRpc
+  require Logger
 
   @arity_suffix_regex ~r/\/\d+$/
 
@@ -122,7 +122,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
           callbacks_indexed: false
         }
       ) do
-    JsonRpc.log_message(:info, "[ElixirLS WorkspaceSymbols] Indexing...")
+    Logger.info("[ElixirLS WorkspaceSymbols] Indexing...")
 
     module_paths =
       :code.all_loaded()
@@ -133,7 +133,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
             do: {module, path}
       end)
 
-    JsonRpc.log_message(:info, "[ElixirLS WorkspaceSymbols] Module discovery complete")
+    Logger.info("[ElixirLS WorkspaceSymbols] Module discovery complete")
 
     index(module_paths)
 
@@ -149,7 +149,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
           modified_uris: modified_uris = [_ | _]
         } = state
       ) do
-    JsonRpc.log_message(:info, "[ElixirLS WorkspaceSymbols] Updating index...")
+    Logger.info("[ElixirLS WorkspaceSymbols] Updating index...")
 
     module_paths =
       :code.all_loaded()
@@ -160,10 +160,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
             do: {module, path}
       end)
 
-    JsonRpc.log_message(
-      :info,
-      "[ElixirLS WorkspaceSymbols] #{length(module_paths)} modules need reindexing"
-    )
+    Logger.info("[ElixirLS WorkspaceSymbols] #{length(module_paths)} modules need reindexing")
 
     index(module_paths)
 
@@ -428,10 +425,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
 
         send(self, {:indexing_complete, key, results})
 
-        JsonRpc.log_message(
-          :info,
-          "[ElixirLS WorkspaceSymbols] #{length(results)} #{key} added to index"
-        )
+        Logger.info("[ElixirLS WorkspaceSymbols] #{length(results)} #{key} added to index")
       end)
 
     :ok

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1170,8 +1170,11 @@ defmodule ElixirLS.LanguageServer.Server do
     else
       JsonRpc.show_message(
         :warning,
-        "You must restart ElixirLS after changing environment variables"
+        "Environment variables have changed. ElixirLS needs to restart"
       )
+
+      Process.sleep(5000)
+      System.halt(1)
     end
 
     state
@@ -1183,7 +1186,10 @@ defmodule ElixirLS.LanguageServer.Server do
     if is_nil(prev_env) or env == prev_env do
       Mix.env(String.to_atom(env))
     else
-      JsonRpc.show_message(:warning, "You must restart ElixirLS after changing Mix env")
+      JsonRpc.show_message(:warning, "Mix env change detected. ElixirLS will restart.")
+
+      Process.sleep(5000)
+      System.halt(1)
     end
 
     state
@@ -1203,7 +1209,10 @@ defmodule ElixirLS.LanguageServer.Server do
     if is_nil(prev_target) or target == prev_target do
       Mix.target(String.to_atom(target))
     else
-      JsonRpc.show_message(:warning, "You must restart ElixirLS after changing Mix target")
+      JsonRpc.show_message(:warning, "Mix target change detected. ElixirLS will restart")
+
+      Process.sleep(5000)
+      System.halt(1)
     end
 
     state
@@ -1235,10 +1244,11 @@ defmodule ElixirLS.LanguageServer.Server do
       prev_project_dir != project_dir ->
         JsonRpc.show_message(
           :warning,
-          "You must restart ElixirLS after changing the project directory"
+          "Project directory change detected. ElixirLS will restart"
         )
 
-        state
+        Process.sleep(5000)
+        System.halt(1)
 
       true ->
         state

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1094,7 +1094,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
     case Dialyzer.check_support() do
       :ok -> :ok
-      {:error, msg} -> JsonRpc.show_message(:info, msg)
+      {:error, msg} -> JsonRpc.show_message(:warning, msg)
     end
 
     :ok

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -1,5 +1,6 @@
 defmodule ElixirLS.LanguageServer.SourceFile do
   import ElixirLS.LanguageServer.Protocol
+  require Logger
 
   defstruct [:text, :version, dirty?: false]
 
@@ -248,7 +249,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
       e ->
         message = Exception.message(e)
 
-        IO.warn(
+        Logger.warn(
           "Unable to get formatter options for #{path}: #{inspect(e.__struct__)} #{message}"
         )
 

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -36,11 +36,6 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
 
   test "empty query", %{server: server} do
     assert {:ok, []} == WorkspaceSymbols.symbols("", server)
-
-    assert_receive %{
-      "method" => "window/logMessage",
-      "params" => %{"message" => "[ElixirLS WorkspaceSymbols] Updating index..."}
-    }
   end
 
   test "returns modules", %{server: server} do

--- a/apps/language_server/test/source_file/invalid_project_test.exs
+++ b/apps/language_server/test/source_file/invalid_project_test.exs
@@ -3,7 +3,7 @@ defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
 
   use Patch
   alias ElixirLS.LanguageServer.SourceFile
-  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
 
   describe "formatter_for " do
     test "should handle syntax errors" do
@@ -12,7 +12,7 @@ defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
       end)
 
       output =
-        capture_io(:stderr, fn ->
+        capture_log(fn ->
           assert :error = SourceFile.formatter_for("file:///root.ex")
         end)
 
@@ -25,7 +25,7 @@ defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
       end)
 
       output =
-        capture_io(:stderr, fn ->
+        capture_log(fn ->
           assert :error = SourceFile.formatter_for("file:///root.ex")
         end)
 

--- a/apps/language_server/test/support/server_test_helpers.ex
+++ b/apps/language_server/test/support/server_test_helpers.ex
@@ -9,6 +9,31 @@ defmodule ElixirLS.LanguageServer.Test.ServerTestHelpers do
   def start_server do
     packet_capture = start_supervised!({PacketCapture, self()})
 
+    # :logger application is already started
+    # replace console logger with LSP
+    Application.put_env(:logger, :backends, [Logger.Backends.JsonRpc])
+
+    Application.put_env(:logger, Logger.Backends.JsonRpc,
+      level: :debug,
+      format: "$message",
+      metadata: []
+    )
+
+    {:ok, _logger_backend} = Logger.add_backend(Logger.Backends.JsonRpc)
+    :ok = Logger.remove_backend(:console, flush: true)
+
+    # Logger.add_backend returns Logger.Watcher pid
+    # the handler is supervised by :gen_event and the pid cannot be received via public api
+    # instead we call it to set group leader in the callback
+    :gen_event.call(Logger, Logger.Backends.JsonRpc, {:set_group_leader, packet_capture})
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Application.put_env(:logger, :backends, [:console])
+
+      {:ok, _} = Logger.add_backend(:console)
+      :ok = Logger.remove_backend(Logger.Backends.JsonRpc, flush: false)
+    end)
+
     server = start_supervised!({Server, nil})
     Process.group_leader(server, packet_capture)
 


### PR DESCRIPTION
This PR adds logger backend using LSP that translates elixir logger levels to LSP. Thanks to that proper logging metadata is displayed in client. Before that all messages was logged as debug. See spec details here
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage
Furthermore, I did some cleanup and unification of how we log and show notifications. (relevant spec here
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage). I especially made sure that we try to show a message before crashing (https://github.com/elixir-lsp/elixir-ls/issues/741).

I also looked into how we log in debugger and it turned out it was wrong. DAP reserves `stdout` and `stderr` for debuggee and debugger should use only `console` and `important`. Up until now we were emitting everything as `stdout|err`. (see https://microsoft.github.io/debug-adapter-protocol/specification#Events_Output).
