### PR TITLE
Disable elixir-sense's logging in production

### DIFF
--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -22,6 +22,7 @@ defmodule ElixirLS.LanguageServer.CLI do
 
     Launch.start_mix()
 
+    Application.put_env(:elixir_sense, :logging_enabled, Mix.env() != :prod)
     Build.set_compiler_options()
 
     start_language_server()


### PR DESCRIPTION
Right now, this change is a no-op, but if and when this change https://github.com/elixir-lsp/elixir_sense/pull/165 lands, this will quiet elixir_sense's logging in the prod environment, which will prevent logspam in lsp buffers when elixir_sense encounters invalid code.