### PR TITLE
Tracer was not being called via start_supervised

### DIFF
--- a/apps/language_server/test/providers/execute_command/mix_clean_test.exs
+++ b/apps/language_server/test/providers/execute_command/mix_clean_test.exs
@@ -4,7 +4,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.MixCleanTest do
   use Protocol
 
   setup do
-    {:ok, _} = Tracer.start_link([])
+    {:ok, _} = start_supervised(Tracer)
     server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
 
     {:ok, %{server: server}}

--- a/apps/language_server/test/providers/workspace_symbols_test.exs
+++ b/apps/language_server/test/providers/workspace_symbols_test.exs
@@ -5,8 +5,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbolsTest do
   setup do
     alias ElixirLS.Utils.PacketCapture
     packet_capture = start_supervised!({PacketCapture, self()})
-
-    {:ok, pid} = WorkspaceSymbols.start_link(name: nil)
+    {:ok, pid} = start_supervised({WorkspaceSymbols, name: nil})
     Process.group_leader(pid, packet_capture)
 
     state = :sys.get_state(pid)

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -235,13 +235,13 @@ defmodule ElixirLS.LanguageServer.ServerTest do
   end
 
   setup context do
-    unless context[:skip_server] do
+    if context[:skip_server] do
+      :ok
+    else
       server = ElixirLS.LanguageServer.Test.ServerTestHelpers.start_server()
-      {:ok, tracer} = Tracer.start_link([])
+      {:ok, tracer} = start_supervised(Tracer)
 
       {:ok, %{server: server, tracer: tracer}}
-    else
-      :ok
     end
   end
 

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -6,7 +6,7 @@ defmodule ElixirLS.LanguageServer.TracerTest do
   setup context do
     File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/calls.dets"))
     File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/modules.dets"))
-    {:ok, _pid} = Tracer.start_link([])
+    {:ok, _pid} = start_supervised(Tracer)
 
     {:ok, context}
   end


### PR DESCRIPTION
This caused it not to cleanly exit before the next test, but only sometimes.
Flaky tests are no fun.