### PR TITLE
Fix test code lens when umbrella app names have the same prefix.

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -869,7 +869,7 @@ defmodule ElixirLS.LanguageServer.Server do
     file_path = SourceFile.Path.from_uri(uri)
 
     Mix.Project.apps_paths()
-    |> Enum.find(fn {_app, app_path} -> String.contains?(file_path, app_path) end)
+    |> Enum.find(fn {_app, app_path} -> under_app?(file_path, project_dir, app_path) end)
     |> case do
       nil ->
         {:ok, []}
@@ -927,6 +927,13 @@ defmodule ElixirLS.LanguageServer.Server do
     Mix.Utils.extract_files(test_paths, test_pattern)
     |> Enum.map(&Path.absname/1)
     |> Enum.any?(&(&1 == file_path))
+  end
+
+  defp under_app?(file_path, project_dir, app_path) do
+    file_path_list = file_path |> Path.relative_to(project_dir) |> Path.split()
+    app_path_list = app_path |> Path.split()
+
+    List.starts_with?(file_path_list, app_path_list)
   end
 
   # Build

--- a/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app/mix.exs
@@ -1,0 +1,14 @@
+defmodule App.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app,
+      version: "0.1.0"
+    ]
+  end
+
+  def application do
+    []
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app/test/fixture_custom_test.exs
+++ b/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app/test/fixture_custom_test.exs
@@ -1,0 +1,7 @@
+defmodule App.UmbrellaTestCodeLensTest do
+  use ExUnit.Case
+
+  test "fixture test" do
+    assert true
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app1/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app1/mix.exs
@@ -1,0 +1,14 @@
+defmodule App1.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app1,
+      version: "0.1.0"
+    ]
+  end
+
+  def application do
+    []
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app1/test/fixture_custom_test.exs
+++ b/apps/language_server/test/fixtures/umbrella_test_code_lens/apps/app1/test/fixture_custom_test.exs
@@ -1,0 +1,7 @@
+defmodule App1.UmbrellaTestCodeLensTest do
+  use ExUnit.Case
+
+  test "fixture test" do
+    assert true
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella_test_code_lens/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella_test_code_lens/mix.exs
@@ -1,0 +1,7 @@
+defmodule UmbrellaTestCodeLens.Mixfile do
+  use Mix.Project
+
+  def project do
+    [apps_path: "apps"]
+  end
+end


### PR DESCRIPTION
This PR will fix _test code lens_ not working with some umbrella project test files.

For example, if we have umbrella apps paths `apps/app` and `apps/app1`, The previous method using `String.contains?/1` will treat `apps/app1/test/some_test.exs` as belonging to `app` instead of `app1` which is a wrong result.

The new approach uses the `Path` module, which is more accurate.