### PR TITLE
Add regression test for autocompletion of 'fn' within parentheses

### DIFF
--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -128,6 +128,24 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
     end
   end
 
+  test "returns fn autocompletion when inside parentheses" do
+    text = """
+    defmodule MyModule do
+
+      def dummy_function() do
+        Task.async(fn)
+        #            ^
+      end
+    end
+    """
+
+    {line, char} = {3, 17}
+    TestUtils.assert_has_cursor_char(text, line, char)
+    {:ok, %{"items" => [first_suggestion | _tail]}} = Completion.completion(text, line, char, @supports)
+
+    assert first_suggestion["label"] === "fn"
+  end
+
   test "unless with snippets not supported does not return a completion" do
     text = """
     defmodule MyModule do


### PR DESCRIPTION
The 'autocomplete within parens' behavior wasn't working for me in vs-code, so I hopped into the repo to write a failing test, but the test passed right away (🤔) and I'm now seeing the behavior _sometimes_ work (and sometimes not) in vs-code
  - my conclusion is that the issue is likely in the vs-code extension—or in vs-code outright—but I figured I'd submit a PR with the regression test if it's desired. Feel free to close if not!
