### PR TITLE
Return LSP 3.17 labelDetails on completion items

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -399,6 +399,16 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         other -> other
       end
 
+    priority =
+      case subtype do
+        :exception ->
+          # show exceptions after functions
+          18
+
+        _ ->
+          14
+      end
+
     %__MODULE__{
       label: name,
       kind: kind,
@@ -407,7 +417,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       insert_text: insert_text,
       filter_text: name,
       label_details: label_details,
-      priority: 14,
+      priority: priority,
       tags: metadata_to_tags(metadata)
     }
   end

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -340,15 +340,20 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
 
     alias_edit = indentation <> "alias " <> alias_value <> "\n"
 
+    label_details =
+      Map.update!(
+        completion_without_additional_text_edit.label_details,
+        "description",
+        &("alias " <> &1)
+      )
+
     struct(completion_without_additional_text_edit,
       additional_text_edit: %TextEdit{
         range: range(line_to_insert_alias, 0, line_to_insert_alias, 0),
         newText: alias_edit
       },
       documentation: alias_value <> "\n" <> summary,
-      label_details:
-        completion_without_additional_text_edit.label_details
-        |> Map.update!("description", &("alias " <> &1)),
+      label_details: label_details,
       priority: 24
     )
   end

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -21,6 +21,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
     :filter_text,
     # Lower priority is shown higher in the result list
     :priority,
+    :label_details,
     :tags,
     :command,
     {:preselect, false},
@@ -304,6 +305,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
          %{
            type: :module,
            name: name,
+           full_name: full_name,
            summary: summary,
            subtype: subtype,
            metadata: metadata,
@@ -317,14 +319,19 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
        ) do
     completion_without_additional_text_edit =
       from_completion_item(
-        %{type: :module, name: name, summary: summary, subtype: subtype, metadata: metadata},
+        %{
+          type: :module,
+          name: name,
+          full_name: full_name,
+          summary: summary,
+          subtype: subtype,
+          metadata: metadata
+        },
         %{def_before: nil},
         options
       )
 
-    alias_value =
-      Atom.to_string(required_alias)
-      |> String.replace_prefix("Elixir.", "")
+    alias_value = inspect(required_alias)
 
     indentation =
       if column_to_insert_alias >= 1,
@@ -338,12 +345,23 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         range: range(line_to_insert_alias, 0, line_to_insert_alias, 0),
         newText: alias_edit
       },
-      documentation: alias_value <> "\n" <> summary
+      documentation: alias_value <> "\n" <> summary,
+      label_details:
+        completion_without_additional_text_edit.label_details
+        |> Map.update!("description", &("alias " <> &1)),
+      priority: 24
     )
   end
 
   defp from_completion_item(
-         %{type: :module, name: name, summary: summary, subtype: subtype, metadata: metadata},
+         %{
+           type: :module,
+           name: name,
+           full_name: full_name,
+           summary: summary,
+           subtype: subtype,
+           metadata: metadata
+         },
          %{def_before: nil},
          _options
        ) do
@@ -363,12 +381,12 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
         _ -> :module
       end
 
-    label =
-      if subtype do
-        "#{name} (#{subtype})"
-      else
-        name
-      end
+    label_details = %{
+      "description" => full_name
+    }
+
+    label_details =
+      if detail != "module", do: Map.put(label_details, "detail", detail), else: label_details
 
     insert_text =
       case name do
@@ -377,12 +395,13 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       end
 
     %__MODULE__{
-      label: label,
+      label: name,
       kind: kind,
       detail: detail,
       documentation: summary,
       insert_text: insert_text,
       filter_text: name,
+      label_details: label_details,
       priority: 14,
       tags: metadata_to_tags(metadata)
     }
@@ -546,8 +565,15 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
          _context,
          _options
        ) do
-    %{name: name, arity: arity, origin: _origin, doc: doc, signature: signature, spec: spec} =
-      suggestion
+    %{
+      name: name,
+      arity: arity,
+      args_list: args_list,
+      origin: origin,
+      doc: doc,
+      signature: signature,
+      spec: spec
+    } = suggestion
 
     formatted_spec =
       if spec != "" do
@@ -564,8 +590,12 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       end
 
     %__MODULE__{
-      label: signature,
+      label: name,
       detail: "typespec #{signature}",
+      label_details: %{
+        "detail" => "(#{Enum.join(args_list, ", ")})",
+        "description" => if(origin, do: "#{origin}.#{name}/#{arity}", else: "#{name}/#{arity}")
+      },
       documentation: "#{doc}#{formatted_spec}",
       insert_text: snippet,
       priority: 10,
@@ -952,7 +982,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
           {name, name}
 
         true ->
-          label = "#{name}/#{arity}"
+          label = name
 
           insert_text =
             function_snippet(
@@ -997,6 +1027,10 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       label: label,
       kind: :function,
       detail: detail,
+      label_details: %{
+        "detail" => "(#{Enum.join(args_list, ", ")})",
+        "description" => "#{origin}.#{name}/#{arity}"
+      },
       documentation: summary <> footer,
       insert_text: insert_text,
       priority: 17,
@@ -1044,6 +1078,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
       "kind" => completion_kind(item.kind),
       "detail" => item.detail,
       "documentation" => %{"value" => item.documentation || "", kind: "markdown"},
+      "labelDetails" => item.label_details,
       "filterText" => item.filter_text,
       "sortText" => String.pad_leading(to_string(idx), 8, "0"),
       "insertText" => item.insert_text,

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -338,9 +338,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
       lines(urf8_text)
       |> Enum.at(max(elixir_line - 1, 0))
 
-    utf16_character =
-      (line || "")
-      |> elixir_character_to_lsp(elixir_character)
+    utf16_character = elixir_character_to_lsp(line || "", elixir_character)
 
     {elixir_line - 1, utf16_character}
   end

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -334,9 +334,12 @@ defmodule ElixirLS.LanguageServer.SourceFile do
       do: {max(elixir_line - 1, 0), 0}
 
   def elixir_position_to_lsp(urf8_text, {elixir_line, elixir_character}) do
-    utf16_character =
+    line =
       lines(urf8_text)
       |> Enum.at(max(elixir_line - 1, 0))
+
+    utf16_character =
+      (line || "")
       |> elixir_character_to_lsp(elixir_character)
 
     {elixir_line - 1, utf16_character}

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -739,7 +739,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                  "detail" => "behaviour",
                  "documentation" => _,
                  "kind" => 8,
-                 "label" => "GenServer (behaviour)"
+                 "label" => "GenServer"
                }
                | _
              ]

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir_vendored": {:git, "https://github.com/elixir-lsp/dialyxir.git", "b610d1a87885576e0e2aa4cfb5e176072bcd9457", [branch: "vendored"]},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "af9cb576d6fbb41a0c1e6196f20fd6e996299a1e", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "7b99c2835851c78c0986a0f8799dc751ddb22be5", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "244c2d9ed5805ef4855a491d8616b8842fef7ca4", []},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "e23c65b98411a3066ca73534b4aed1d23bcf0356", [branch: "vendored"]},


### PR DESCRIPTION
annotate completions that require alias insertions deprioretize alias insertion
fix crash when completing one line source file

Examples from vscode
<img width="1042" alt="Screenshot 2022-12-13 at 07 01 19" src="https://user-images.githubusercontent.com/1078186/207239024-fb2b6fdd-aa8e-481b-a31a-b499fc808221.png">
<img width="970" alt="Screenshot 2022-12-13 at 07 01 43" src="https://user-images.githubusercontent.com/1078186/207239027-bb5a6893-776e-4797-8265-a5c4395f0aa8.png">
<img width="992" alt="Screenshot 2022-12-13 at 07 02 16" src="https://user-images.githubusercontent.com/1078186/207239033-9c85ac67-d8eb-4851-ae64-da07e592c83b.png">


Addresses https://github.com/elixir-lsp/elixir-ls/issues/774