### PR TITLE
Enable smarter test searches

### DIFF
--- a/apps/language_server/lib/language_server/ex_unit_test_tracer.ex
+++ b/apps/language_server/lib/language_server/ex_unit_test_tracer.ex
@@ -76,11 +76,12 @@ defmodule ElixirLS.LanguageServer.ExUnitTestTracer do
         test_info
         |> Enum.group_by(fn %ExUnit.Test{tags: tags} -> {tags.describe, tags.describe_line} end)
         |> Enum.map(fn {{describe, describe_line}, tests} ->
-          %{test: tests, doctest: doctests} =
+          grouped_tests =
             tests |> Enum.group_by(fn %ExUnit.Test{tags: tags} -> tags.test_type end)
 
           tests =
-            tests
+            grouped_tests
+            |> Map.get(:test, [])
             |> Enum.map(fn %ExUnit.Test{tags: tags} = test ->
               # drop test prefix
               test_name =
@@ -104,7 +105,9 @@ defmodule ElixirLS.LanguageServer.ExUnitTestTracer do
             end)
 
           tests =
-            case doctests do
+            grouped_tests
+            |> Map.get(:doctest, [])
+            |> case do
               [doctest | _] ->
                 %{
                   name: "doctest #{inspect(doctest.tags.doctest)}",

--- a/apps/language_server/lib/language_server/providers/code_lens/test.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test.ex
@@ -54,7 +54,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
         "filePath" => file_path,
         "testName" => block.name,
         "projectDir" => project_dir,
-        "module" => Atom.to_string(block.module) |> String.replace("Elixir.", "")
+        "module" => get_module_name(block.module)
       }
       |> Map.merge(if block.describe != nil, do: %{"describe" => block.describe.name}, else: %{})
     end
@@ -72,7 +72,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
         "filePath" => file_path,
         "describe" => block.name,
         "projectDir" => project_dir,
-        "module" => Atom.to_string(block.module) |> String.replace("Elixir.", "")
+        "module" => get_module_name(block.module)
       })
     end)
   end
@@ -97,11 +97,13 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
         |> String.trim()
         |> case do
           "test " <> rest ->
-            String.split(rest, ~r/"/)
+            rest
+            |> String.split(~s("))
             |> Enum.at(1)
 
           "doctest" <> _ = line ->
-            String.split(line, ~r/,/)
+            line
+            |> String.split(~s(,))
             |> Enum.at(0)
         end
 
@@ -156,5 +158,11 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
     else
       {:ok, buffer_file_metadata}
     end
+  end
+
+  defp get_module_name(module) do
+    module
+    |> Module.split()
+    |> Enum.join(".")
   end
 end

--- a/apps/language_server/lib/language_server/providers/code_lens/test.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test.ex
@@ -78,7 +78,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test do
   end
 
   defp find_test_blocks(lines_to_env_list, calls_list, describe_blocks, source_lines) do
-    runnable_functions = [{:test, 3}, {:test, 2}, {:doctest, 2}, {:doctest, 1}]
+    runnable_functions = [test: 3, test: 2, doctest: 2, doctest: 1]
 
     for func <- runnable_functions,
         {line, _col} <- calls_to(calls_list, func) do

--- a/apps/language_server/lib/language_server/providers/code_lens/test/describe_block.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test/describe_block.ex
@@ -1,13 +1,14 @@
 defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test.DescribeBlock do
   alias ElixirSense.Core.State.Env
 
-  @struct_keys [:line, :name, :body_scope_id]
+  @struct_keys [:line, :name, :body_scope_id, :module]
 
   @enforce_keys @struct_keys
   defstruct @struct_keys
 
   def find_block_info(line, lines_to_env_list, lines_to_env_list_length, source_lines) do
     name = get_name(source_lines, line)
+    module = lines_to_env_list |> Enum.find(fn {env_line, _env} -> env_line == line end) |> elem(1) |> Map.get(:module)
 
     body_scope_id =
       get_body_scope_id(
@@ -16,7 +17,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test.DescribeBlock do
         lines_to_env_list_length
       )
 
-    %__MODULE__{line: line, body_scope_id: body_scope_id, name: name}
+    %__MODULE__{line: line, body_scope_id: body_scope_id, name: name, module: module}
   end
 
   defp get_name(source_lines, declaration_line) do

--- a/apps/language_server/lib/language_server/providers/code_lens/test/describe_block.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test/describe_block.ex
@@ -8,7 +8,12 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test.DescribeBlock do
 
   def find_block_info(line, lines_to_env_list, lines_to_env_list_length, source_lines) do
     name = get_name(source_lines, line)
-    module = lines_to_env_list |> Enum.find(fn {env_line, _env} -> env_line == line end) |> elem(1) |> Map.get(:module)
+
+    module =
+      lines_to_env_list
+      |> Enum.find(fn {env_line, _env} -> env_line == line end)
+      |> elem(1)
+      |> Map.get(:module)
 
     body_scope_id =
       get_body_scope_id(

--- a/apps/language_server/lib/language_server/providers/code_lens/test/test_block.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens/test/test_block.ex
@@ -1,5 +1,5 @@
 defmodule ElixirLS.LanguageServer.Providers.CodeLens.Test.TestBlock do
-  @struct_keys [:name, :describe, :line]
+  @struct_keys [:name, :describe, :line, :module]
 
   @enforce_keys @struct_keys
   defstruct @struct_keys

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -42,6 +42,77 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
              ]
   end
 
+  test "returns all separate code lenses in different modules" do
+    uri = "file:///project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      use ExUnit.Case
+
+      doctest MyModule
+
+      test "test1" do
+      end
+    end
+
+    defmodule MyModule2 do
+      use ExUnit.Case
+
+      doctest MyModule2
+
+      test "test1" do
+      end
+
+      describe "nested" do
+        doctest MyModule
+        test "test2" do
+        end
+      end
+    end
+    """
+
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
+
+    assert Enum.member?(lenses, build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => MyModule
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(9, :module, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => MyModule2
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule",
+      "testName" => "doctest MyModule"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule",
+      "testName" => "test1"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(14, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule2",
+      "testName" => "test1"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(12, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule2",
+      "testName" => "doctest MyModule2"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(18, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule2",
+      "testName" => "doctest MyModule",
+      "describe" => "nested"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(17, :describe, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule2",
+      "describe" => "nested"
+    }))
+  end
+
   test "returns all nested module code lenses" do
     uri = "file:///project/file.ex"
 
@@ -68,6 +139,79 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
              ]
   end
 
+  test "returns all code lenses in nested modules" do
+    uri = "file:///project/file.ex"
+
+    text = """
+    defmodule MyModule do
+      use ExUnit.Case
+
+      doctest MyModule
+
+      test "test1" do
+      end
+
+      defmodule MyModule2 do
+        use ExUnit.Case
+
+        doctest MyModule2
+
+        test "test1" do
+        end
+
+        describe "nested" do
+          doctest MyModule
+          test "test2" do
+          end
+        end
+      end
+    end
+
+
+    """
+
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
+
+    assert Enum.member?(lenses, build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => MyModule
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(8, :module, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => MyModule.MyModule2
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule",
+      "testName" => "doctest MyModule"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule",
+      "testName" => "test1"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(13, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule.MyModule2",
+      "testName" => "test1"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(11, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule.MyModule2",
+      "testName" => "doctest MyModule2"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(17, :test, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule.MyModule2",
+      "testName" => "doctest MyModule",
+      "describe" => "nested"
+    }))
+
+    assert Enum.member?(lenses, build_code_lens(16, :describe, maybe_convert_path_separators("/project/file.ex"), %{
+      "module" => "MyModule.MyModule2",
+      "describe" => "nested"
+    }))
+  end
+
   test "returns lenses for all describe blocks" do
     uri = "file:///project/file.ex"
 
@@ -88,14 +232,16 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     assert Enum.member?(
              lenses,
              build_code_lens(3, :describe, maybe_convert_path_separators("/project/file.ex"), %{
-               "describe" => "describe1"
+               "describe" => "describe1",
+               "module" => "MyModule"
              })
            )
 
     assert Enum.member?(
              lenses,
              build_code_lens(6, :describe, maybe_convert_path_separators("/project/file.ex"), %{
-               "describe" => "describe2"
+               "describe" => "describe2",
+               "module" => "MyModule"
              })
            )
   end
@@ -120,14 +266,54 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     assert Enum.member?(
              lenses,
              build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
-               "testName" => "test1"
+               "testName" => "test1",
+               "module" => "MyModule"
              })
            )
 
     assert Enum.member?(
              lenses,
              build_code_lens(6, :test, maybe_convert_path_separators("/project/file.ex"), %{
-               "testName" => "test2"
+               "testName" => "test2",
+               "module" => "MyModule"
+             })
+           )
+  end
+
+  test "returns lenses for all test blocks including doctests" do
+    uri = "file:///project/file.ex"
+
+    text = """
+    defmodule MyModuleTest do
+      use ExUnit.Case
+
+      doctest MyModule
+
+      test "test1" do
+      end
+
+      test "test2" do
+      end
+    end
+    """
+
+    {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
+
+    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{"testName" => "doctest MyModule", "module" => "MyModuleTest"}))
+
+    assert Enum.member?(
+             lenses,
+             build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "testName" => "test1",
+                "module" => "MyModuleTest"
+             })
+           )
+
+    assert Enum.member?(
+             lenses,
+             build_code_lens(8, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "testName" => "test2",
+               "module" => "MyModuleTest"
              })
            )
   end
@@ -152,7 +338,8 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
              lenses,
              build_code_lens(4, :test, maybe_convert_path_separators("/project/file.ex"), %{
                "testName" => "test1",
-               "describe" => "describe1"
+               "describe" => "describe1",
+               "module" => "MyModule"
              })
            )
   end
@@ -306,7 +493,8 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
                lenses,
                build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
                  "testName" => "extract the stacktrace from the message and format it",
-                 "describe" => "normalize/2"
+                 "describe" => "normalize/2",
+                 "module" => "ElixirLS.LanguageServer.DiagnosticsTest"
                })
              )
     end
@@ -330,7 +518,8 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
     assert Enum.member?(
              lenses,
              build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
-               "testName" => "test1"
+               "testName" => "test1",
+               "module" => "MyModule"
              })
            )
   end

--- a/apps/language_server/test/providers/code_lens/test_test.exs
+++ b/apps/language_server/test/providers/code_lens/test_test.exs
@@ -73,44 +73,68 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
 
     {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
-    assert Enum.member?(lenses, build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => MyModule
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => MyModule
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(9, :module, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => MyModule2
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(9, :module, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => MyModule2
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule",
-      "testName" => "doctest MyModule"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule",
+               "testName" => "doctest MyModule"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule",
-      "testName" => "test1"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule",
+               "testName" => "test1"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(14, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule2",
-      "testName" => "test1"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(14, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule2",
+               "testName" => "test1"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(12, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule2",
-      "testName" => "doctest MyModule2"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(12, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule2",
+               "testName" => "doctest MyModule2"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(18, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule2",
-      "testName" => "doctest MyModule",
-      "describe" => "nested"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(18, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule2",
+               "testName" => "doctest MyModule",
+               "describe" => "nested"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(17, :describe, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule2",
-      "describe" => "nested"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(17, :describe, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule2",
+               "describe" => "nested"
+             })
+           )
   end
 
   test "returns all nested module code lenses" do
@@ -172,44 +196,68 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
 
     {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
-    assert Enum.member?(lenses, build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => MyModule
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(0, :module, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => MyModule
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(8, :module, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => MyModule.MyModule2
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(8, :module, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => MyModule.MyModule2
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule",
-      "testName" => "doctest MyModule"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule",
+               "testName" => "doctest MyModule"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule",
-      "testName" => "test1"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule",
+               "testName" => "test1"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(13, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule.MyModule2",
-      "testName" => "test1"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(13, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule.MyModule2",
+               "testName" => "test1"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(11, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule.MyModule2",
-      "testName" => "doctest MyModule2"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(11, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule.MyModule2",
+               "testName" => "doctest MyModule2"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(17, :test, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule.MyModule2",
-      "testName" => "doctest MyModule",
-      "describe" => "nested"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(17, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule.MyModule2",
+               "testName" => "doctest MyModule",
+               "describe" => "nested"
+             })
+           )
 
-    assert Enum.member?(lenses, build_code_lens(16, :describe, maybe_convert_path_separators("/project/file.ex"), %{
-      "module" => "MyModule.MyModule2",
-      "describe" => "nested"
-    }))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(16, :describe, maybe_convert_path_separators("/project/file.ex"), %{
+               "module" => "MyModule.MyModule2",
+               "describe" => "nested"
+             })
+           )
   end
 
   test "returns lenses for all describe blocks" do
@@ -299,13 +347,19 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens.TestTest do
 
     {:ok, lenses} = CodeLens.Test.code_lens(uri, text, @project_dir)
 
-    assert Enum.member?(lenses, build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{"testName" => "doctest MyModule", "module" => "MyModuleTest"}))
+    assert Enum.member?(
+             lenses,
+             build_code_lens(3, :test, maybe_convert_path_separators("/project/file.ex"), %{
+               "testName" => "doctest MyModule",
+               "module" => "MyModuleTest"
+             })
+           )
 
     assert Enum.member?(
              lenses,
              build_code_lens(5, :test, maybe_convert_path_separators("/project/file.ex"), %{
                "testName" => "test1",
-                "module" => "MyModuleTest"
+               "module" => "MyModuleTest"
              })
            )
 

--- a/apps/language_server/test/providers/execute_command/get_ex_unit_tests_in_file_test.exs
+++ b/apps/language_server/test/providers/execute_command/get_ex_unit_tests_in_file_test.exs
@@ -23,7 +23,11 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.GetExUnitTestsInFileT
                         describe: nil,
                         line: nil,
                         tests: [
-                          %{line: 19, name: "this will be a test in future", type: :test},
+                          %{
+                            line: 19,
+                            name: "this will be a test in future",
+                            type: :test
+                          },
                           %{line: 6, name: "fixture test", type: :test}
                         ]
                       },


### PR DESCRIPTION
Although I believe the test lens code needs to be refactored, this now properly handles doctests.
In addition, there is extra metadata in the `TestItem` which enables a more integrated UI experience with the test lens. Note that this extra information is required for this: https://github.com/elixir-lsp/vscode-elixir-ls/pull/293