### PR TITLE
Re-enabled code action support through the experimental server

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -17,6 +17,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
   use GenServer
   require Logger
+  alias ElixirLS.LanguageServer.Experimental
   alias ElixirLS.LanguageServer.Server.Decider
   alias ElixirLS.LanguageServer.{SourceFile, Build, Protocol, JsonRpc, Dialyzer, Diagnostics}
 
@@ -859,7 +860,8 @@ defmodule ElixirLS.LanguageServer.Server do
       "workspace" => %{
         "workspaceFolders" => %{"supported" => false, "changeNotifications" => false}
       },
-      "foldingRangeProvider" => true
+      "foldingRangeProvider" => true,
+      "codeActionProvider" => Experimental.LanguageServer.enabled?()
     }
   end
 


### PR DESCRIPTION
This was removed when we backed out the change that allowed code actions. Re-enabling them, but only if experimental support is on. 