### PR TITLE
Fix long line formatting of the experimental project

### DIFF
--- a/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
@@ -70,7 +70,21 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Diff do
 
   defp apply_diff(:ins, {line, code_unit} = position, change, {current_line, prev_lines}) do
     current_line = [edit(change, line, code_unit, line, code_unit) | current_line]
-    advance(change, position, {current_line, prev_lines})
+    advance(:ins, change, position, {current_line, prev_lines})
+  end
+
+  defp advance(:ins, <<>>, position, edits) do
+    {position, edits}
+  end
+
+  for ending <- ["\r\n", "\r", "\n"] do
+    defp advance(:ins, <<unquote(ending), rest::binary>>, position, edits) do
+      advance(rest, position, edits)
+    end
+  end
+
+  defp advance(:ins, <<_c::utf8, rest::binary>>, position, edits) do
+    advance(rest, position, edits)
   end
 
   defp advance(<<>>, position, edits) do

--- a/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
@@ -70,20 +70,20 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Diff do
 
   defp apply_diff(:ins, {line, code_unit} = position, change, {current_line, prev_lines}) do
     current_line = [edit(change, line, code_unit, line, code_unit) | current_line]
-    advance(:ins, change, position, {current_line, prev_lines})
+    advance_ins(change, position, {current_line, prev_lines})
   end
 
-  defp advance(:ins, <<>>, position, edits) do
+  defp advance_ins(<<>>, position, edits) do
     {position, edits}
   end
 
   for ending <- ["\r\n", "\r", "\n"] do
-    defp advance(:ins, <<unquote(ending), rest::binary>>, position, edits) do
+    defp advance_ins(<<unquote(ending), rest::binary>>, position, edits) do
       advance(rest, position, edits)
     end
   end
 
-  defp advance(:ins, <<_c::utf8, rest::binary>>, position, edits) do
+  defp advance_ins(<<_c::utf8, rest::binary>>, position, edits) do
     advance(rest, position, edits)
   end
 

--- a/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
@@ -79,12 +79,12 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Diff do
 
   for ending <- ["\r\n", "\r", "\n"] do
     defp advance_ins(<<unquote(ending), rest::binary>>, position, edits) do
-      advance(rest, position, edits)
+      advance_ins(rest, position, edits)
     end
   end
 
   defp advance_ins(<<_c::utf8, rest::binary>>, position, edits) do
-    advance(rest, position, edits)
+    advance_ins(rest, position, edits)
   end
 
   defp advance(<<>>, position, edits) do

--- a/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
@@ -70,15 +70,8 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Diff do
 
   defp apply_diff(:ins, {line, code_unit} = position, change, {current_line, prev_lines}) do
     current_line = [edit(change, line, code_unit, line, code_unit) | current_line]
-    advance_ins(change, position, {current_line, prev_lines})
-  end
-
-  defp advance_ins(<<>>, position, edits) do
-    {position, edits}
-  end
-
-  defp advance_ins(<<_c::utf8, rest::binary>>, position, edits) do
-    advance_ins(rest, position, edits)
+    # When inserting, the insert itself does not exist in source, so there is no need to advance
+    {position, {current_line, prev_lines}}
   end
 
   defp advance(<<>>, position, edits) do

--- a/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/diff.ex
@@ -77,12 +77,6 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Diff do
     {position, edits}
   end
 
-  for ending <- ["\r\n", "\r", "\n"] do
-    defp advance_ins(<<unquote(ending), rest::binary>>, position, edits) do
-      advance_ins(rest, position, edits)
-    end
-  end
-
   defp advance_ins(<<_c::utf8, rest::binary>>, position, edits) do
     advance_ins(rest, position, edits)
   end

--- a/apps/language_server/test/experimental/code_mod/format_test.exs
+++ b/apps/language_server/test/experimental/code_mod/format_test.exs
@@ -71,6 +71,76 @@ defmodule ElixirLS.Experimental.FormatTest do
       ]t == result
     end
 
+    test "it can handles long lines" do
+      unformatted = ~q[
+        defmodule Unformatted do
+          def foo1(s) do
+            s = very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonooooong(s) |> IO.inputs()
+            s
+          end
+
+          def very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonooooong(s) do
+            s
+          end
+        end
+      ]t
+
+      formatted = ~q[
+        defmodule Unformatted do
+          def foo1(s) do
+            s =
+              very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonooooong(s) |> IO.inputs()
+
+            s
+          end
+
+          def very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonooooong(s) do
+            s
+          end
+        end
+      ]t
+
+      assert {:ok, formatted} == modify(unformatted)
+    end
+
+    test "it can handles the case of long line split into multiple lines" do
+      unformatted = ~q[
+        defmodule Unformatted do
+          def foo(foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo14, foo15, foo16) do
+            foo = foo14 <> foo15 <> foo16
+            {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo}
+          end
+        end
+      ]t
+      formatted = ~q[
+        defmodule Unformatted do
+          def foo(
+                foo1,
+                foo2,
+                foo3,
+                foo4,
+                foo5,
+                foo6,
+                foo7,
+                foo8,
+                foo9,
+                foo10,
+                foo11,
+                foo12,
+                foo13,
+                foo14,
+                foo15,
+                foo16
+              ) do
+            foo = foo14 <> foo15 <> foo16
+            {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo}
+          end
+        end
+      ]t
+
+      assert {:ok, formatted} == modify(unformatted)
+    end
+
     test "it handles extra lines" do
       assert {:ok, result} = ~q[
         defmodule  Unformatted do

--- a/apps/language_server/test/experimental/code_mod/format_test.exs
+++ b/apps/language_server/test/experimental/code_mod/format_test.exs
@@ -71,7 +71,29 @@ defmodule ElixirLS.Experimental.FormatTest do
       ]t == result
     end
 
-    test "it can split a long line to two lines" do
+    test "it can format a long line function definition into multiple lines" do
+      unformatted = ~q[
+        defmodule Unformatted do
+          def very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong(s) do
+            s
+          end
+        end
+      ]t
+
+      formatted = ~q[
+        defmodule Unformatted do
+          def very_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong(
+                s
+              ) do
+            s
+          end
+        end
+      ]t
+
+      assert {:ok, formatted} == modify(unformatted)
+    end
+
+    test "it can format a long line function call into two lines" do
       unformatted = ~q[
         defmodule Unformatted do
           def foo1(s) do
@@ -103,37 +125,32 @@ defmodule ElixirLS.Experimental.FormatTest do
       assert {:ok, formatted} == modify(unformatted)
     end
 
-    test "it can split a long line into multiple lines" do
+    test "it can format a long line function definition(with multiple args) into multiple lines" do
       unformatted = ~q[
         defmodule Unformatted do
-          def foo(foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo14, foo15, foo16) do
-            foo = foo14 <> foo15 <> foo16
-            {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo}
+          def foo(arg1, arg2, arg3, _arg4, _arg5, _arg6, _arg7, _arg8, _arg9, _arg10, _arg11, _arg12, _arg13) do
+            arg1 <> arg2 <> arg3
           end
         end
       ]t
       formatted = ~q[
         defmodule Unformatted do
           def foo(
-                foo1,
-                foo2,
-                foo3,
-                foo4,
-                foo5,
-                foo6,
-                foo7,
-                foo8,
-                foo9,
-                foo10,
-                foo11,
-                foo12,
-                foo13,
-                foo14,
-                foo15,
-                foo16
+                arg1,
+                arg2,
+                arg3,
+                _arg4,
+                _arg5,
+                _arg6,
+                _arg7,
+                _arg8,
+                _arg9,
+                _arg10,
+                _arg11,
+                _arg12,
+                _arg13
               ) do
-            foo = foo14 <> foo15 <> foo16
-            {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo}
+            arg1 <> arg2 <> arg3
           end
         end
       ]t

--- a/apps/language_server/test/experimental/code_mod/format_test.exs
+++ b/apps/language_server/test/experimental/code_mod/format_test.exs
@@ -71,7 +71,7 @@ defmodule ElixirLS.Experimental.FormatTest do
       ]t == result
     end
 
-    test "it can handles long lines" do
+    test "it can split a long line to two lines" do
       unformatted = ~q[
         defmodule Unformatted do
           def foo1(s) do
@@ -103,7 +103,7 @@ defmodule ElixirLS.Experimental.FormatTest do
       assert {:ok, formatted} == modify(unformatted)
     end
 
-    test "it can handles the case of long line split into multiple lines" do
+    test "it can split a long line into multiple lines" do
       unformatted = ~q[
         defmodule Unformatted do
           def foo(foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9, foo10, foo11, foo12, foo13, foo14, foo15, foo16) do


### PR DESCRIPTION
It should not advance when :ins