### PR TITLE
Fix `Exception.message` FunctionClauseError

### DIFF
--- a/apps/language_server/lib/language_server/experimental/provider/handlers/formatting.ex
+++ b/apps/language_server/lib/language_server/experimental/provider/handlers/formatting.ex
@@ -15,8 +15,15 @@ defmodule ElixirLS.LanguageServer.Experimental.Provider.Handlers.Formatting do
       {:error, reason} ->
         Logger.error("Formatter failed #{inspect(reason)}")
 
-        {:reply,
-         Responses.Formatting.error(request.id, :request_failed, Exception.message(reason))}
+        {:reply, Responses.Formatting.error(request.id, :request_failed, message(reason))}
     end
+  end
+
+  defp message(reason) when is_exception(reason) do
+    Exception.message(reason)
+  end
+
+  defp message(reason) do
+    "#{inspect(reason)}"
   end
 end

--- a/apps/language_server/lib/language_server/experimental/provider/handlers/formatting.ex
+++ b/apps/language_server/lib/language_server/experimental/provider/handlers/formatting.ex
@@ -24,6 +24,6 @@ defmodule ElixirLS.LanguageServer.Experimental.Provider.Handlers.Formatting do
   end
 
   defp message(reason) do
-    "#{inspect(reason)}"
+    inspect(reason)
   end
 end


### PR DESCRIPTION
I'm trying to copy some providers to the experiment project.

When I create a new file in the `lib/language_server/experimental/provider/handlers` folder and do the formatting, the formatted will give me a `:mismatch` error, seems like the lsp doesn't have the file: `lib/language_server/experimental/provider/handlers/goto_definition.ex`

But I can't reproduce in dev by inputting the same `source_file` and `project_path_or_uri` args to this function:

```elixir
# ElixirLS.LanguageServer.Experimental.CodeMod.Format
  defp do_format(%SourceFile{} = document, project_path_or_uri)
```

So this pr [0c38754](https://github.com/elixir-lsp/elixir-ls/pull/811/commits/0c387540328231efff8846ab3e975813e00f5073) just fixes the `FunctionClauseError` to make the error more readable.

**before**:

<img width="960" alt="image" src="https://user-images.githubusercontent.com/12830256/219589219-2d1f10ee-892f-4502-a0cd-4b72fe89ca97.png">


<img width="1072" alt="image" src="https://user-images.githubusercontent.com/12830256/219587238-87caacdc-981f-482a-8598-d17d1c149043.png">


**after**:

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/12830256/219587270-1ec77227-52bd-441f-9e63-eae37ba1d6ed.png">


