### PR TITLE
trap exit :dialyzer_utils.get_core_from_beam

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -592,10 +592,10 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     Process.exit(pid, :kill)
   end
 
-  defp with_trapping_exits(fun) do 
-    Process.flag(:trap_exit, true) 
+  defp with_trapping_exits(fun) do
+    Process.flag(:trap_exit, true)
     fun.()
   after
-    Process.flag(:trap_exit, false) 
+    Process.flag(:trap_exit, false)
   end
 end


### PR DESCRIPTION
prevent silent exit of dialyzer process when it's unable to process some of the beams

Example crash: https://github.com/elixir-lang/elixir/issues/12394