### PR TITLE
Added missing generated modules

### DIFF
--- a/apps/language_server/lib/generated/language_server/experimental/protocol/types/document/formatting/options.ex
+++ b/apps/language_server/lib/generated/language_server/experimental/protocol/types/document/formatting/options.ex
@@ -1,0 +1,6 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule ElixirLS.LanguageServer.Experimental.Protocol.Types.Document.Formatting.Options do
+  alias ElixirLS.LanguageServer.Experimental.Protocol.Proto
+  use Proto
+  deftype work_done_progress: optional(boolean())
+end

--- a/apps/language_server/lib/generated/language_server/experimental/protocol/types/document/formatting/params.ex
+++ b/apps/language_server/lib/generated/language_server/experimental/protocol/types/document/formatting/params.ex
@@ -1,0 +1,10 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule ElixirLS.LanguageServer.Experimental.Protocol.Types.Document.Formatting.Params do
+  alias ElixirLS.LanguageServer.Experimental.Protocol.Proto
+  alias ElixirLS.LanguageServer.Experimental.Protocol.Types
+  use Proto
+
+  deftype options: Types.Formatting.Options,
+          text_document: Types.TextDocument.Identifier,
+          work_done_token: optional(Types.Progress.Token)
+end

--- a/apps/language_server/lib/generated/language_server/experimental/protocol/types/formatting/options.ex
+++ b/apps/language_server/lib/generated/language_server/experimental/protocol/types/formatting/options.ex
@@ -1,0 +1,11 @@
+# This file's contents are auto-generated. Do not edit.
+defmodule ElixirLS.LanguageServer.Experimental.Protocol.Types.Formatting.Options do
+  alias ElixirLS.LanguageServer.Experimental.Protocol.Proto
+  use Proto
+
+  deftype insert_final_newline: optional(boolean()),
+          insert_spaces: boolean(),
+          tab_size: integer(),
+          trim_final_newlines: optional(boolean()),
+          trim_trailing_whitespace: optional(boolean())
+end

--- a/apps/language_server/lib/language_server/experimental/protocol/requests.ex
+++ b/apps/language_server/lib/language_server/experimental/protocol/requests.ex
@@ -32,7 +32,7 @@ defmodule ElixirLS.LanguageServer.Experimental.Protocol.Requests do
 
     defrequest "textDocument/formatting", :exclusive,
       text_document: Types.TextDocument.Identifier,
-      options: Types.FormattingOptions
+      options: Types.Formatting.Options
   end
 
   defmodule CodeAction do


### PR DESCRIPTION
I missed the formatting options on the last PR which generated experimental protocol modules. This fixes that error

@scottming FYI