### PR TITLE
Make document symbols more resilient

### DIFF
--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -169,13 +169,17 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
 
   # Types
   defp extract_symbol(_current_module, {:@, location, [{type_kind, _, type_expression}]})
-       when type_kind in [:type, :typep, :opaque, :callback, :macrocallback] do
+       when type_kind in [:type, :typep, :opaque, :callback, :macrocallback] and
+              not is_nil(type_expression) do
     {type_name, type_head_location} =
       case type_expression do
         [{:"::", _, [{_, type_head_location, _} = type_head | _]}] ->
           {Macro.to_string(type_head), type_head_location}
 
         [{:when, _, [{:"::", _, [{_, type_head_location, _} = type_head, _]}, _]}] ->
+          {Macro.to_string(type_head), type_head_location}
+
+        [{_, type_head_location, _} = type_head | _] ->
           {Macro.to_string(type_head), type_head_location}
       end
 

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1172,6 +1172,8 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
       @opaque my_simple_opaque :: integer
       @type my_with_args(key, value) :: [{key, value}]
       @type my_with_args_when(key, value) :: [{key, value}] when value: integer
+      @type abc
+      @type
     end
     """
 
@@ -1216,6 +1218,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
                     children: [],
                     kind: 5,
                     name: "@type my_with_args_when(key, value)"
+                  },
+                  %Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 5,
+                    name: "@type abc"
+                  },
+                  %Protocol.DocumentSymbol{
+                    children: [],
+                    kind: 14,
+                    name: "@type"
                   }
                 ],
                 kind: 2,
@@ -1235,6 +1247,8 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
       @opaque my_simple_opaque :: integer
       @type my_with_args(key, value) :: [{key, value}]
       @type my_with_args_when(key, value) :: [{key, value}] when value: integer
+      @type abc
+      @type
     end
     """
 
@@ -1278,6 +1292,16 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               %Protocol.SymbolInformation{
                 kind: 5,
                 name: "@type my_with_args_when(key, value)",
+                containerName: "MyModule"
+              },
+              %Protocol.SymbolInformation{
+                kind: 5,
+                name: "@type abc",
+                containerName: "MyModule"
+              },
+              %Protocol.SymbolInformation{
+                kind: 14,
+                name: "@type",
                 containerName: "MyModule"
               }
             ]} = DocumentSymbols.symbols(uri, text, false)


### PR DESCRIPTION
Do not crash on incomplete typespecs