### PR TITLE
Track running processes in debugger

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger.ex
+++ b/apps/elixir_ls_debugger/lib/debugger.ex
@@ -25,7 +25,7 @@ defmodule ElixirLS.Debugger do
     if ElixirLS.Utils.WireProtocol.io_intercepted?() do
       Output.debugger_important("ElixirLS debugger has crashed")
 
-      :init.stop(1)
+      System.stop(1)
     end
 
     :ok

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -2,12 +2,14 @@ defmodule ElixirLS.Debugger.Server do
   @moduledoc """
   Implements the VS Code Debug Protocol
 
-  Refer to the protocol's [documentation](https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/debug/common/debugProtocol.d.ts)
+  Refer to the protocol's [documentation](https://microsoft.github.io/debug-adapter-protocol)
   for details.
 
   The protocol specifies that we must assign unique IDs to "threads" (or processes), to stack
   frames, and to any variables that can be expanded. We keep a counter with the next ID to use and
-  increment it any time we assign an ID.
+  increment it any time we assign an ID. Note that besides thread ids all other are defined in
+  the suspended state and can be reused.
+  See [Lifetime of Objects References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
   """
 
   defmodule ServerError do

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -831,7 +831,7 @@ defmodule ElixirLS.Debugger.Server do
         []
 
       {_pid, %PausedProcess{} = paused_process} ->
-        paused_process.frame_ids_to_frames |> Map.values()
+        Map.values(paused_process.frame_ids_to_frames)
     end)
     |> Enum.filter(&match?(%Frame{bindings: bindings} when is_map(bindings), &1))
     |> Enum.flat_map(fn %Frame{bindings: bindings} ->

--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -896,18 +896,18 @@ defmodule ElixirLS.Debugger.Server do
   end
 
   defp ensure_var_id(state = %__MODULE__{}, pid, var) when is_pid(pid) or pid == :evaluator do
-    unless Map.has_key?(state.paused_processes, pid) do
-      raise ArgumentError, message: "paused process #{inspect(pid)} not found"
-    end
+    paused_process = Map.fetch!(state.paused_processes, pid)
 
-    if Map.has_key?(state.paused_processes[pid].vars_to_var_ids, var) do
-      {state, state.paused_processes[pid].vars_to_var_ids[var]}
-    else
-      id = state.next_id
-      state = put_in(state.paused_processes[pid].var_ids_to_vars[id], var)
-      state = put_in(state.paused_processes[pid].vars_to_var_ids[var], id)
-      state = put_in(state.next_id, id + 1)
-      {state, id}
+    case paused_process.vars_to_var_ids[var] do
+      nil ->
+        id = state.next_id
+        state = put_in(state.paused_processes[pid].var_ids_to_vars[id], var)
+        state = put_in(state.paused_processes[pid].vars_to_var_ids[var], id)
+        state = put_in(state.next_id, id + 1)
+        {state, id}
+
+      var_id ->
+        {state, var_id}
     end
   end
 
@@ -919,18 +919,18 @@ defmodule ElixirLS.Debugger.Server do
   end
 
   defp ensure_frame_id(state = %__MODULE__{}, pid, %Frame{} = frame) when is_pid(pid) do
-    unless Map.has_key?(state.paused_processes, pid) do
-      raise ArgumentError, message: "paused process #{inspect(pid)} not found"
-    end
+    paused_process = Map.fetch!(state.paused_processes, pid)
 
-    if Map.has_key?(state.paused_processes[pid].frames_to_frame_ids, frame) do
-      {state, state.paused_processes[pid].frames_to_frame_ids[frame]}
-    else
-      id = state.next_id
-      state = put_in(state.paused_processes[pid].frame_ids_to_frames[id], frame)
-      state = put_in(state.paused_processes[pid].frames_to_frame_ids[frame], id)
-      state = put_in(state.next_id, id + 1)
-      {state, id}
+    case paused_process.frames_to_frame_ids[frame] do
+      nil ->
+        id = state.next_id
+        state = put_in(state.paused_processes[pid].frame_ids_to_frames[id], frame)
+        state = put_in(state.paused_processes[pid].frames_to_frame_ids[frame], id)
+        state = put_in(state.next_id, id + 1)
+        {state, id}
+
+      frame_id ->
+        {state, frame_id}
     end
   end
 

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -1503,9 +1503,9 @@ defmodule ElixirLS.Debugger.ServerTest do
       send(server, :update_threads)
       state = :sys.get_state(server)
 
-      thread_id = state.threads_inverse[pid]
+      thread_id = state.pids_to_thread_ids[pid]
       assert thread_id
-      assert state.threads[thread_id] == pid
+      assert state.thread_ids_to_pids[thread_id] == pid
 
       Server.receive_packet(server, request(6, "threads", %{}))
       assert_receive(response(_, 6, "threads", %{"threads" => threads}), 1_000)
@@ -1522,8 +1522,8 @@ defmodule ElixirLS.Debugger.ServerTest do
       send(server, :update_threads)
       state = :sys.get_state(server)
 
-      refute Map.has_key?(state.threads_inverse, pid)
-      refute Map.has_key?(state.threads, thread_id)
+      refute Map.has_key?(state.pids_to_thread_ids, pid)
+      refute Map.has_key?(state.thread_ids_to_pids, thread_id)
 
       Server.receive_packet(server, request(6, "threads", %{}))
       assert_receive(response(_, 6, "threads", %{"threads" => threads}), 1_000)

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -1466,6 +1466,72 @@ defmodule ElixirLS.Debugger.ServerTest do
     end
   end
 
+  @tag :fixture
+  test "server tracks running processes", %{server: server} do
+    in_fixture(__DIR__, "mix_project", fn ->
+      Server.receive_packet(server, initialize_req(1, %{}))
+
+      assert_receive(response(_, 1, "initialize", %{"supportsConfigurationDoneRequest" => true}))
+
+      Server.receive_packet(
+        server,
+        launch_req(2, %{
+          "request" => "launch",
+          "type" => "mix_task",
+          "task" => "run",
+          "taskArgs" => ["-e", "MixProject.Some.sleep()"],
+          "projectDir" => File.cwd!()
+        })
+      )
+
+      assert_receive(response(_, 2, "launch", %{}), 5000)
+      assert_receive(event(_, "initialized", %{}))
+
+      Server.receive_packet(server, request(5, "configurationDone", %{}))
+      assert_receive(response(_, 5, "configurationDone", %{}))
+      Process.sleep(1000)
+
+      {:ok, pid} =
+        Task.start(fn ->
+          receive do
+            :done -> :ok
+          end
+        end)
+
+      Process.monitor(pid)
+
+      send(server, :update_threads)
+      state = :sys.get_state(server)
+
+      thread_id = state.threads_inverse[pid]
+      assert thread_id
+      assert state.threads[thread_id] == pid
+
+      Server.receive_packet(server, request(6, "threads", %{}))
+      assert_receive(response(_, 6, "threads", %{"threads" => threads}), 1_000)
+
+      assert Enum.find(threads, &(&1["id"] == thread_id))["name"] ==
+               ":proc_lib.init_p/5 #{:erlang.pid_to_list(pid)}"
+
+      send(pid, :done)
+
+      receive do
+        {:DOWN, _, _, ^pid, _} -> :ok
+      end
+
+      send(server, :update_threads)
+      state = :sys.get_state(server)
+
+      refute Map.has_key?(state.threads_inverse, pid)
+      refute Map.has_key?(state.threads, thread_id)
+
+      Server.receive_packet(server, request(6, "threads", %{}))
+      assert_receive(response(_, 6, "threads", %{"threads" => threads}), 1_000)
+
+      refute Enum.find(threads, &(&1["id"] == thread_id))
+    end)
+  end
+
   describe "Watch section" do
     defp gen_watch_expression_packet(expr) do
       %{

--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -35,7 +35,7 @@ defmodule ElixirLS.LanguageServer do
         "ElixirLS has crashed. See Output panel."
       )
 
-      :init.stop(1)
+      System.stop(1)
     end
 
     :ok


### PR DESCRIPTION
Prior to this commit new processes were added on threads request but the exited ones were never removed. This commit adds periodical updates and now the server sends events when processes starts and terminate so debugger client UI can update