### PR TITLE
Made .formatter.exs inputs relocatable

### DIFF
--- a/apps/language_server/.formatter.exs
+++ b/apps/language_server/.formatter.exs
@@ -1,8 +1,15 @@
 current_directory = Path.dirname(__ENV__.file)
 
 impossible_to_format = [
-  Path.join(current_directory, "test/fixtures/token_missing_error/lib/has_error.ex"),
-  Path.join(current_directory, "test/fixtures/project_with_tests/test/error_test.exs")
+  Path.join([current_directory, "test", "fixtures", "token_missing_error", "lib", "has_error.ex"]),
+  Path.join([
+    current_directory,
+    "test",
+    "fixtures",
+    "project_with_tests",
+    "test",
+    "error_test.exs"
+  ])
 ]
 
 deps =

--- a/apps/language_server/.formatter.exs
+++ b/apps/language_server/.formatter.exs
@@ -3,6 +3,8 @@ impossible_to_format = [
   "test/fixtures/project_with_tests/test/error_test.exs"
 ]
 
+current_directory = Path.dirname(__ENV__.file)
+
 deps =
   if Mix.env() == :test do
     [:patch]
@@ -29,8 +31,8 @@ proto_dsl = [
   inputs:
     Enum.flat_map(
       [
-        "*.exs",
-        "{lib,test,config}/**/*.{ex,exs}"
+        Path.join(current_directory, "*.exs"),
+        Path.join(current_directory, "{lib,test}/**/*.{ex,exs}")
       ],
       &Path.wildcard(&1, match_dot: true)
     ) -- impossible_to_format

--- a/apps/language_server/.formatter.exs
+++ b/apps/language_server/.formatter.exs
@@ -1,9 +1,9 @@
-impossible_to_format = [
-  "test/fixtures/token_missing_error/lib/has_error.ex",
-  "test/fixtures/project_with_tests/test/error_test.exs"
-]
-
 current_directory = Path.dirname(__ENV__.file)
+
+impossible_to_format = [
+  Path.join(current_directory, "test/fixtures/token_missing_error/lib/has_error.ex"),
+  Path.join(current_directory, "test/fixtures/project_with_tests/test/error_test.exs")
+]
 
 deps =
   if Mix.env() == :test do

--- a/apps/language_server/lib/language_server/experimental/code_mod/format.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/format.ex
@@ -115,7 +115,13 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Format do
 
     inputs_apply? =
       Enum.any?(inputs, fn input_glob ->
-        glob = Path.join(formatter_dir, input_glob)
+        glob =
+          if Path.type(input_glob) == :relative do
+            Path.join(formatter_dir, input_glob)
+          else
+            input_glob
+          end
+
         PathGlobVendored.match?(document.path, glob, match_dot: true)
       end)
 


### PR DESCRIPTION
The .formatter.exs defined paths via a call to `Path.wildcard`, but this would only work if it was executed from the current directory. If it was run from the topmost directory, none of the paths would be found, and the inputs would only contain the `.exs` files in the current directory.

I also removed config from the glob, as this is in an umbrella project, and umbrella apps have a centralized config which isn't in this directory.