### PR TITLE
Return type of breakpoint that was hit as required by DAP

### DIFF
--- a/apps/elixir_ls_debugger/lib/debugger/server.ex
+++ b/apps/elixir_ls_debugger/lib/debugger/server.ex
@@ -1342,7 +1342,7 @@ defmodule ElixirLS.Debugger.Server do
   defp get_stop_reason(_state, :breakpoint_reached, []), do: "breakpoint"
 
   defp get_stop_reason(state = %__MODULE__{}, :breakpoint_reached, [first_frame = %Frame{} | _]) do
-    file_breakpoints = state.breakpoints[first_frame.file] || []
+    file_breakpoints = Map.get(state.breakpoints, first_frame.file, [])
 
     function_breakpoints =
       Map.new(state.function_breakpoints)[

--- a/apps/elixir_ls_debugger/test/debugger_test.exs
+++ b/apps/elixir_ls_debugger/test/debugger_test.exs
@@ -1407,13 +1407,13 @@ defmodule ElixirLS.Debugger.ServerTest do
 
         assert :hello in :int.interpreted()
         assert [{{:hello, 5}, _}] = :int.all_breaks(:hello)
-        assert [{{:hello, :hello_world, 0}, [5]}] = :sys.get_state(server).function_breakpoints
+        assert %{{:hello, :hello_world, 0} => [5]} = :sys.get_state(server).function_breakpoints
 
         Server.receive_packet(
           server,
           set_function_breakpoints_req(3, [
             %{"name" => ":hello.hello_world/0"},
-            %{"name" => "MixProject.quadruple/1"}
+            %{"name" => "Some.with_multi_clauses/1"}
           ])
         )
 
@@ -1424,11 +1424,11 @@ defmodule ElixirLS.Debugger.ServerTest do
           3000
         )
 
-        assert MixProject in :int.interpreted()
+        assert Some in :int.interpreted()
         assert [{{:hello, 5}, _}] = :int.all_breaks(:hello)
-        assert [{{MixProject, 3}, _}] = :int.all_breaks(MixProject)
+        assert [{{Some, 74}, _}, {{Some, 78}, _}] = :int.all_breaks(Some)
 
-        assert [{{MixProject, :quadruple, 1}, [3]}, {{:hello, :hello_world, 0}, [5]}] =
+        assert %{{Some, :with_multi_clauses, 1} => [74, 78], {:hello, :hello_world, 0} => [5]} =
                  :sys.get_state(server).function_breakpoints
 
         Server.receive_packet(
@@ -1443,7 +1443,7 @@ defmodule ElixirLS.Debugger.ServerTest do
 
         assert [] = :int.all_breaks(:hello)
         assert [{{MixProject, 3}, _}] = :int.all_breaks(MixProject)
-        assert [{{MixProject, :quadruple, 1}, [3]}] = :sys.get_state(server).function_breakpoints
+        assert %{{MixProject, :quadruple, 1} => [3]} = :sys.get_state(server).function_breakpoints
       end)
     end
 
@@ -1489,7 +1489,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                  {{:hello, 5}, [:active, :enable, :null, {BreakpointCondition, :check_0}]}
                ] = :int.all_breaks(:hello)
 
-        assert [{{:hello, :hello_world, 0}, [5]}] = :sys.get_state(server).function_breakpoints
+        assert %{{:hello, :hello_world, 0} => [5]} = :sys.get_state(server).function_breakpoints
 
         assert BreakpointCondition.has_condition?(:hello, [5])
 
@@ -1515,7 +1515,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                  {{:hello, 5}, [:active, :enable, :null, {BreakpointCondition, :check_0}]}
                ] = :int.all_breaks(:hello)
 
-        assert [{{:hello, :hello_world, 0}, [5]}] = :sys.get_state(server).function_breakpoints
+        assert %{{:hello, :hello_world, 0} => [5]} = :sys.get_state(server).function_breakpoints
 
         assert BreakpointCondition.has_condition?(:hello, [5])
 
@@ -1534,7 +1534,7 @@ defmodule ElixirLS.Debugger.ServerTest do
         )
 
         assert [] = :int.all_breaks(:hello)
-        assert [] = :sys.get_state(server).function_breakpoints
+        assert %{} == :sys.get_state(server).function_breakpoints
 
         refute BreakpointCondition.has_condition?(:hello, [5])
       end)
@@ -1582,7 +1582,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                  {{:hello, 5}, [:active, :enable, :null, {BreakpointCondition, :check_0}]}
                ] = :int.all_breaks(:hello)
 
-        assert [{{:hello, :hello_world, 0}, [5]}] = :sys.get_state(server).function_breakpoints
+        assert %{{:hello, :hello_world, 0} => [5]} = :sys.get_state(server).function_breakpoints
 
         assert BreakpointCondition.has_condition?(:hello, [5])
 
@@ -1608,7 +1608,7 @@ defmodule ElixirLS.Debugger.ServerTest do
                  {{:hello, 5}, [:active, :enable, :null, {BreakpointCondition, :check_0}]}
                ] = :int.all_breaks(:hello)
 
-        assert [{{:hello, :hello_world, 0}, [5]}] = :sys.get_state(server).function_breakpoints
+        assert %{{:hello, :hello_world, 0} => [5]} = :sys.get_state(server).function_breakpoints
 
         assert BreakpointCondition.has_condition?(:hello, [5])
 
@@ -1627,7 +1627,7 @@ defmodule ElixirLS.Debugger.ServerTest do
         )
 
         assert [] = :int.all_breaks(:hello)
-        assert [] = :sys.get_state(server).function_breakpoints
+        assert %{} == :sys.get_state(server).function_breakpoints
 
         refute BreakpointCondition.has_condition?(:hello, [5])
       end)

--- a/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
+++ b/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
@@ -44,3 +44,29 @@ defmodule MixProject.Some do
     Process.sleep(:infinity)
   end
 end
+
+defmodule Some do
+  def fun_1(x) do
+    a = fun_3(x + 1)
+    b = fun_2(a)
+    b * 2
+  end
+
+  def fun_2(x) do
+    a = fun_3(x + 2)
+    b = a + x
+    b * 2
+  end
+
+  def fun_3(x) do
+    x + 9
+  end
+
+  def multiple(x) do
+    Task.start(fn ->
+      fun_2(3)
+    end)
+
+    x + 2
+  end
+end

--- a/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
+++ b/apps/elixir_ls_debugger/test/fixtures/mix_project/lib/mix_project.ex
@@ -69,4 +69,12 @@ defmodule Some do
 
     x + 2
   end
+
+  def with_multi_clauses(a) when is_atom(a) do
+    Atom.to_string(a)
+  end
+
+  def with_multi_clauses(a) when is_integer(a) do
+    a + 2
+  end
 end


### PR DESCRIPTION
https://microsoft.github.io/debug-adapter-protocol/specification#Events_Stopped
consistently set breakpoints in tests with absolute path as VSCode does add tests covering allThreadsContinued
add tests covering stepIn, stepOut, next