### PR TITLE
Do not pass project dir to tracer if mix.exs is not found

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1157,7 +1157,11 @@ defmodule ElixirLS.LanguageServer.Server do
 
     maybe_rebuild(state)
     state = create_gitignore(state)
-    Tracer.set_project_dir(state.project_dir)
+
+    if state.mix_project? do
+      Tracer.set_project_dir(state.project_dir)
+    end
+
     trigger_build(%{state | settings: settings})
   end
 

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -87,6 +87,10 @@ defmodule ElixirLS.LanguageServer.Tracer do
   end
 
   @impl true
+  def handle_cast(:save, %{project_dir: nil} = state) do
+    {:noreply, state}
+  end
+
   def handle_cast(:save, %{project_dir: project_dir} = state) do
     for table <- @tables do
       table_name = table_name(table)

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -1501,6 +1501,16 @@ defmodule ElixirLS.LanguageServer.ServerTest do
         assert_receive notification("window/logMessage", %{
                          "message" => "Compile took" <> _
                        })
+
+        uri = SourceFile.Path.to_uri("a.ex")
+        Server.receive_packet(server, did_open(uri, "elixir", 1, ""))
+        Server.receive_packet(server, did_save(uri))
+
+        assert_receive notification("window/logMessage", %{
+                         "message" => "Compile took" <> _
+                       })
+
+        wait_until_compiled(server)
       end)
     end
 
@@ -1519,6 +1529,16 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                          "message" => "No mixfile found in project." <> _
                        }),
                        1000
+
+        wait_until_compiled(server)
+        uri = SourceFile.Path.to_uri("a.ex")
+        Server.receive_packet(server, did_open(uri, "elixir", 1, ""))
+        Server.receive_packet(server, did_save(uri))
+
+        assert_receive notification("textDocument/publishDiagnostics", %{
+                         "diagnostics" => [],
+                         "uri" => ^uri
+                       })
 
         wait_until_compiled(server)
       end)

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -33,6 +33,10 @@ defmodule ElixirLS.LanguageServer.TracerTest do
     assert File.exists?(FixtureHelpers.get_path(".elixir_ls/modules.dets"))
   end
 
+  test "skips save if project dir not set" do
+    Tracer.save()
+  end
+
   describe "call trace" do
     setup context do
       Tracer.set_project_dir(FixtureHelpers.get_path(""))


### PR DESCRIPTION
Fixes https://github.com/elixir-lsp/elixir-ls/issues/806