### PR TITLE
Return references to elixir modules

### DIFF
--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -45,6 +45,10 @@ defmodule ElixirLS.LanguageServer.Providers.References do
           "uri" => build_uri(ref, current_file_uri)
         }
 
+      {:error, :nofile} ->
+        Logger.debug("Skipping reference from `nofile`")
+        nil
+
       {:error, reason} ->
         # workaround for elixir tracer returning invalid paths
         # https://github.com/elixir-lang/elixir/issues/12393
@@ -67,6 +71,7 @@ defmodule ElixirLS.LanguageServer.Providers.References do
   def get_text(elixir_sense_ref, current_file_text) do
     case elixir_sense_ref.uri do
       nil -> {:ok, current_file_text}
+      "nofile" -> {:error, :nofile}
       path when is_binary(path) -> File.read(path)
     end
   end

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -205,10 +205,16 @@ defmodule ElixirLS.LanguageServer.Tracer do
     register_call(meta, module, nil, nil, env)
   end
 
-  def trace(trace, env) do
-    # if env.file |> String.ends_with?("references_alias.ex") do
-    #   IO.inspect(trace, label: "skipped")
-    # end
+  def trace({:alias, meta, module, _as, _opts}, %Macro.Env{} = env) do
+    register_call(meta, module, nil, nil, env)
+  end
+
+  def trace({kind, meta, module, _opts}, %Macro.Env{} = env) when kind in [:import, :require] do
+    register_call(meta, module, nil, nil, env)
+  end
+
+  def trace(_trace, _env) do
+    # IO.inspect(trace, label: "skipped")
     :ok
   end
 

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -4,7 +4,7 @@ defmodule ElixirLS.LanguageServer.Tracer do
   use GenServer
   require Logger
 
-  @version 2
+  @version 3
 
   @tables ~w(modules calls)a
 

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -201,8 +201,14 @@ defmodule ElixirLS.LanguageServer.Tracer do
     register_call(meta, env.module, name, arity, env)
   end
 
-  def trace(_trace, _env) do
-    # IO.inspect(trace, label: "skipped")
+  def trace({:alias_reference, meta, module}, %Macro.Env{} = env) do
+    register_call(meta, module, nil, nil, env)
+  end
+
+  def trace(trace, env) do
+    # if env.file |> String.ends_with?("references_alias.ex") do
+    #   IO.inspect(trace, label: "skipped")
+    # end
     :ok
   end
 
@@ -260,6 +266,7 @@ defmodule ElixirLS.LanguageServer.Tracer do
 
     line = meta[:line]
     column = meta[:column]
+    # TODO meta can have last or maybe other?
 
     :ets.insert(table_name(:calls), {{callee, env.file, line, column}, :ok})
   end

--- a/apps/language_server/test/providers/references_test.exs
+++ b/apps/language_server/test/providers/references_test.exs
@@ -229,13 +229,12 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
                              ^
     """)
 
-    list = References.references(text, uri, line, char, true)
-    |> Enum.filter(& String.ends_with?(&1["uri"], "references_alias.ex"))
+    list =
+      References.references(text, uri, line, char, true)
+      |> Enum.filter(&String.ends_with?(&1["uri"], "references_alias.ex"))
 
-    assert length(list) == 4
-    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 6))
-    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 10))
-    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 14))
-    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 18))
+    references_lines = Enum.map(list, & &1["range"]["start"]["line"])
+
+    assert references_lines == [1, 2, 3, 4, 7, 11, 15, 19, 20]
   end
 end

--- a/apps/language_server/test/providers/references_test.exs
+++ b/apps/language_server/test/providers/references_test.exs
@@ -33,6 +33,7 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
     Code.compile_file(FixtureHelpers.get_path("uses_macro_a.ex"))
     Code.compile_file(FixtureHelpers.get_path("macro_a.ex"))
     Code.compile_file(FixtureHelpers.get_path("references_erlang.ex"))
+    Code.compile_file(FixtureHelpers.get_path("references_alias.ex"))
     {:ok, context}
   end
 
@@ -214,5 +215,27 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
     assert length(list) == 2
     assert Enum.any?(list, &(&1["uri"] |> String.ends_with?("references_erlang.ex")))
     assert Enum.any?(list, &(&1["uri"] |> String.ends_with?("references_referenced.ex")))
+  end
+
+  test "finds alias references" do
+    file_path = FixtureHelpers.get_path("references_referenced.ex")
+    text = File.read!(file_path)
+    uri = SourceFile.Path.to_uri(file_path)
+
+    {line, char} = {0, 25}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+    defmodule ElixirLS.Test.ReferencesReferenced do
+                             ^
+    """)
+
+    list = References.references(text, uri, line, char, true)
+    |> Enum.filter(& String.ends_with?(&1["uri"], "references_alias.ex"))
+
+    assert length(list) == 4
+    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 6))
+    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 10))
+    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 14))
+    assert Enum.any?(list, &(&1["range"]["start"]["line"] == 18))
   end
 end

--- a/apps/language_server/test/support/fixtures/references_alias.ex
+++ b/apps/language_server/test/support/fixtures/references_alias.ex
@@ -1,0 +1,21 @@
+defmodule ElixirLS.Test.ReferencesAlias do
+  require ElixirLS.Test.ReferencesReferenced, as: ReferencesReferenced
+  alias ElixirLS.Test.ReferencesReferenced, as: Some
+  alias Some, as: Other
+
+  def uses_alias_1 do
+    ReferencesReferenced
+  end
+
+  def uses_alias_2 do
+    Some
+  end
+
+  def uses_alias_3 do
+    ElixirLS.Test.ReferencesReferenced
+  end
+
+  def uses_alias_4 do
+    Other
+  end
+end

--- a/apps/language_server/test/support/fixtures/references_alias.ex
+++ b/apps/language_server/test/support/fixtures/references_alias.ex
@@ -2,6 +2,7 @@ defmodule ElixirLS.Test.ReferencesAlias do
   require ElixirLS.Test.ReferencesReferenced, as: ReferencesReferenced
   alias ElixirLS.Test.ReferencesReferenced, as: Some
   alias Some, as: Other
+  import Other
 
   def uses_alias_1 do
     ReferencesReferenced
@@ -16,6 +17,7 @@ defmodule ElixirLS.Test.ReferencesAlias do
   end
 
   def uses_alias_4 do
+    uses_attribute()
     Other
   end
 end

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -156,7 +156,7 @@ defmodule ElixirLS.LanguageServer.TracerTest do
       project_path = FixtureHelpers.get_path("")
       Tracer.write_manifest(project_path)
 
-      assert 2 == Tracer.read_manifest(project_path)
+      assert 3 == Tracer.read_manifest(project_path)
     end
   end
 end


### PR DESCRIPTION
Prior to this PR references provider was only able to return references to elixir modules made with function/macro calls. This PR covers more cases:
- struct usage (`%MyMod{}`)
- alias, require, import statements
- literals (`MyMod`)