### PR TITLE
Build improvements

### DIFF
--- a/apps/elixir_ls_debugger/mix.exs
+++ b/apps/elixir_ls_debugger/mix.exs
@@ -13,6 +13,8 @@ defmodule ElixirLS.Debugger.Mixfile do
       build_embedded: false,
       start_permanent: true,
       build_per_environment: false,
+      # if we consolidate here debugged code will not work correctly
+      # and debugged protocol implementation will not be available
       consolidate_protocols: false,
       deps: deps(),
       xref: [exclude: [:int, :dbg_iserver]]

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -78,6 +78,18 @@ defmodule ElixirLS.LanguageServer.Build do
 
     if File.exists?(mixfile) do
       if module = Mix.Project.get() do
+        build_path = Mix.Project.config()[:build_path]
+
+        for {app, path} <- Mix.Project.deps_paths() || %{} do
+          child_module = Mix.Project.in_project(app, path, [build_path: build_path], fn mix_project ->
+            mix_project
+          end)
+
+          if child_module do
+            purge_module(child_module)
+          end
+        end
+
         # FIXME: Private API
         Mix.Project.pop()
         purge_module(module)

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -341,6 +341,10 @@ defmodule ElixirLS.LanguageServer.Build do
       options
       |> Keyword.merge(
         tracers: [Tracer],
+        # we are running the server with consolidated protocols
+        # this disables warnings `X has already been consolidated`
+        # when running `compile` task
+        ignore_already_consolidated: true,
         parser_options: parser_options
       )
 

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -136,8 +136,8 @@ defmodule ElixirLS.LanguageServer.Build do
   end
 
   defp run_mix_compile do
-    # TODO consider adding --no-compile
-    case Mix.Task.run("compile", ["--return-errors", "--ignore-module-conflict"]) do
+    # TODO --all-warnings not needed on 1.15
+    case Mix.Task.run("compile", ["--return-errors", "--ignore-module-conflict", "--all-warnings", "--no-protocol-consolidation"]) do
       {status, diagnostics} when status in [:ok, :error, :noop] and is_list(diagnostics) ->
         {status, diagnostics}
 

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -156,7 +156,8 @@ defmodule ElixirLS.LanguageServer.Build do
       status when status in [:ok, :noop] ->
         {status, []}
 
-      _ ->
+      other ->
+        Logger.debug("mix compile returned #{inspect(other)}")
         {:ok, []}
     end
   end

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -215,18 +215,8 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     prev_paths = Map.keys(md5) |> MapSet.new()
 
     # FIXME: Private API
-    consolidation_path = Mix.Project.consolidation_path()
-
-    consolidated_protocol_beams =
-      for path <- Path.join(consolidation_path, "*.beam") |> Path.wildcard(),
-          into: MapSet.new(),
-          do: Path.basename(path)
-
-    # FIXME: Private API
     all_paths =
       for path <- Mix.Utils.extract_files([Mix.Project.build_path()], [:beam]),
-          Path.basename(path) not in consolidated_protocol_beams or
-            Path.dirname(path) == consolidation_path,
           into: MapSet.new(),
           do: Path.relative_to_cwd(path)
 

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -448,7 +448,7 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
           )
 
         end_location = location[:closing] ->
-          # all closing tags we expect hera are 1 char width
+          # all closing tags we expect here are 1 char width
           SourceFile.elixir_position_to_lsp(
             text,
             {end_location[:line], end_location[:column] + 1}

--- a/apps/language_server/lib/language_server/providers/folding_range/token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/token.ex
@@ -34,6 +34,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Token do
             {:sigil, {b1 - 1, b2 - 1, b3}, delimiter}
 
           # Older versions of Tokenizer.tokenize/1
+          # TODO check which version
           {:sigil, {b1, b2, b3}, _, _, _, delimiter} ->
             {:sigil, {b1 - 1, b2 - 1, b3}, delimiter}
 


### PR DESCRIPTION
Disable protocol consolidation (we consolidate protocols in language server since https://github.com/elixir-lsp/elixir-ls/pull/743, note that consolidation is still disabled in debugger and it must stay so)
More consistently emit diagnostics from umbrella apps
Limit number of module redefinition warnings

Fixes https://github.com/elixir-lsp/elixir-ls/issues/838
Addresses https://github.com/elixir-lsp/elixir-ls/issues/839
Fixes https://github.com/elixir-lsp/elixir-ls/issues/858
