### PR TITLE
Use elixir 1.15 `:root` in formatter_for

### DIFF
--- a/apps/language_server/lib/language_server/experimental/code_mod/format.ex
+++ b/apps/language_server/lib/language_server/experimental/code_mod/format.ex
@@ -52,7 +52,7 @@ defmodule ElixirLS.LanguageServer.Experimental.CodeMod.Format do
     try do
       true = Code.ensure_loaded?(Mix.Tasks.Format)
 
-      if project_dir && Version.match?(System.version(), ">= 1.15.0") do
+      if project_dir && Version.match?(System.version(), ">= 1.15.0-dev") do
         {formatter_function, options} = Mix.Tasks.Format.formatter_for_file(path, root: project_dir)
 
         wrapped_formatter_function = wrap_with_try_catch(formatter_function)

--- a/apps/language_server/lib/language_server/providers/execute_command/apply_spec.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/apply_spec.ex
@@ -56,7 +56,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ApplySpec do
     formatted =
       try do
         target_line_length =
-          case SourceFile.formatter_for(uri) do
+          case SourceFile.formatter_for(uri, state.project_dir) do
             {:ok, {_, opts}} -> Keyword.get(opts, :line_length, @default_target_line_length)
             :error -> @default_target_line_length
           end

--- a/apps/language_server/lib/language_server/providers/formatting.ex
+++ b/apps/language_server/lib/language_server/providers/formatting.ex
@@ -6,7 +6,7 @@ defmodule ElixirLS.LanguageServer.Providers.Formatting do
   def format(%SourceFile{} = source_file, uri = "file:" <> _, project_dir)
       when is_binary(project_dir) do
     if can_format?(uri, project_dir) do
-      case SourceFile.formatter_for(uri) do
+      case SourceFile.formatter_for(uri, project_dir) do
         {:ok, {formatter, opts}} ->
           if should_format?(uri, project_dir, opts[:inputs]) do
             do_format(source_file, formatter, opts)

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -706,7 +706,7 @@ defmodule ElixirLS.LanguageServer.Server do
       !!get_in(state.client_capabilities, ["textDocument", "signatureHelp"])
 
     locals_without_parens =
-      case SourceFile.formatter_for(uri) do
+      case SourceFile.formatter_for(uri, state.project_dir) do
         {:ok, {_, opts}} -> Keyword.get(opts, :locals_without_parens, [])
         :error -> []
       end

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -239,7 +239,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
     try do
       true = Code.ensure_loaded?(Mix.Tasks.Format)
 
-      if project_dir && Version.match?(System.version(), ">= 1.15.0") do
+      if project_dir && Version.match?(System.version(), ">= 1.15.0-dev") do
         {:ok, apply(Mix.Tasks.Format, :formatter_for_file, [path, {:root, project_dir }])}
       else if Version.match?(System.version(), ">= 1.13.0") do
         {:ok, apply(Mix.Tasks.Format, :formatter_for_file, [path])}

--- a/apps/language_server/test/source_file/invalid_project_test.exs
+++ b/apps/language_server/test/source_file/invalid_project_test.exs
@@ -26,7 +26,7 @@ defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
 
       output =
         capture_log(fn ->
-          assert :error = SourceFile.formatter_for("file:///root.ex")
+          assert :error = SourceFile.formatter_for("file:///root.ex", "")
         end)
 
       assert String.contains?(output, "Unable to get formatter options")
@@ -39,7 +39,7 @@ defmodule ElixirLS.LanguageServer.SourceFile.InvalidProjectTest do
 
       output =
         capture_log(fn ->
-          assert :error = SourceFile.formatter_for("file:///root.ex")
+          assert :error = SourceFile.formatter_for("file:///root.ex", "")
         end)
 
       assert String.contains?(output, "Unable to get formatter options")


### PR DESCRIPTION
fix #526 on elixir 1.15+. see https://github.com/elixir-lang/elixir/pull/12541

I am not a fan of the tests. I was not sure what to add. Everything passes locally but... eh

On the experimental side, I moved to version checking as @lukaszsamson asked. I did not touch the logic on the rest of the file.

Happy to do changes if you prefer.