### PR TITLE
Remove duplicated JsonRpc logger backend

### DIFF
--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -16,7 +16,6 @@ defmodule ElixirLS.LanguageServer.CLI do
       :ok =
         :logger.add_handler(
           Logger.Backends.JsonRpc,
-          Logger.Backends.JsonRpc,
           Logger.Backends.JsonRpc.handler_config()
         )
     else


### PR DESCRIPTION
I was having problems running elixir-ls `master` on Elixir 1.15.0

```
...lsp/handlers.lua:537	"** (MatchError) no match of right hand side value: {:error, :already_present}\n    lib/language_server/cli.ex:20: ElixirLS.LanguageServer.CLI.main/0\n    nofile:1: (file)\n    (stdlib 4.3.1.1) erl_eval.erl:748: :erl_eval.do_apply/7\n    (elixir 1.15.0-rc.1) lib/code.ex:543: Code.validated_eval_string/3"
```
After making this change, I compiled a `Mix.install` release and am now able to use elixirls with Elixir 1.15.0 (OTP 25)
