### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,25 @@ The original repository has now been deprecated in favor of this one. Any IDE ex
 
 ![Screenshot](images/screenshot.png?raw=true)
 
-Note: On first run Dialyzer will build a PLT cache which will take a considerable amount of CPU time (usually 10+ minutes). After that is complete the CPU usage will go back to normal. Alternatively instead of waiting you can disable Dialyzer in the settings.
+Note: On its first run, Dialyzer will build a PLT cache.  This will take a considerable amount of CPU time (usually 10+ minutes). After that is complete, the CPU usage will go back to normal. Alternatively, instead of waiting you can disable Dialyzer in the settings.
 
 ## IDE plugins
 
 | IDE          | Plugin                                                                                             | Support                                                               |
-| ------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Emacs        | [eglot](https://github.com/joaotavora/eglot)                                                       |                                                                       |
+| ------------ | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| BBEdit       | [bbpackage](https://github.com/chipotle/Elixir.bbpackage)                                          |                                                                            |
+| Emacs        | [eglot](https://github.com/joaotavora/eglot)                                                       |                                                                            |
 | Emacs        | [lsp-mode](https://github.com/emacs-lsp/lsp-mode)                                                  | Supports debugger via [dap-mode](https://github.com/yyoncho/dap-mode) |
 | Kakoune      | [kak-lsp](https://github.com/kak-lsp/kak-lsp)                                                      | [Limitations](https://github.com/kak-lsp/kak-lsp/#limitations)        |
-| Kate         | [built-in LSP Client plugin](https://kate-editor.org/post/2020/2020-01-01-kate-lsp-client-status/) | Does not support debugger                                             |
-| Neovim       | [coc.nvim](https://github.com/neoclide/coc.nvim)                                                   | Does not support debugger                                             |
+| Kate         | [built-in LSP Client plugin](https://kate-editor.org/post/2020/2020-01-01-kate-lsp-client-status/) | Does not support debugger                                                  |
+| Neovim       | [coc.nvim](https://github.com/neoclide/coc.nvim)                                                   | Does not support debugger                                                  |
 | Neovim       | [nvim-dap](https://github.com/mfussenegger/nvim-dap)                                               | Supports debugger only                                                |
-| Neovim       | [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)                                         | Does not support debugger                                             |
-| Nova         | [nova-elixir-ls](https://github.com/raulchedrese/nova-elixir-ls)                                   |                                                                       |
-| Sublime Text | [LSP-elixir](https://github.com/sublimelsp/LSP-elixir)                                             | Does not support debugger                                             |
-| Vim/Neovim   | [ALE](https://github.com/w0rp/ale)                                                                 | Does not support debugger or @spec suggestions                        |
-| Vim/Neovim   | [elixir-lsp/coc-elixir](https://github.com/elixir-lsp/coc-elixir)                                  | Does not support debugger                                             |
-| Vim/Neovim   | [vim-lsp](https://github.com/prabirshrestha/vim-lsp)                                               | Does not support debugger                                             |
+| Neovim       | [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)                                         | Does not support debugger                                                  |
+| Nova         | [nova-elixir-ls](https://github.com/raulchedrese/nova-elixir-ls)                                   |                                                                            |
+| Sublime Text | [LSP-elixir](https://github.com/sublimelsp/LSP-elixir)                                             | Does not support debugger                                                  |
+| Vim/Neovim   | [ALE](https://github.com/w0rp/ale)                                                                 | Does not support debugger or @spec suggestions                             |
+| Vim/Neovim   | [elixir-lsp/coc-elixir](https://github.com/elixir-lsp/coc-elixir)                                  | Does not support debugger                                                  |
+| Vim/Neovim   | [vim-lsp](https://github.com/prabirshrestha/vim-lsp)                                               | Does not support debugger                                                  |
 | VS Code      | [elixir-lsp/vscode-elixir-ls](https://github.com/elixir-lsp/vscode-elixir-ls)                      | Supports all ElixirLS features                                        |
 
 Please feel free to create and publish your own client packages and add them to this list!
@@ -62,10 +63,9 @@ Please install the extension via the following link: https://marketplace.visuals
 
 Download the latest release:
 https://github.com/elixir-lsp/elixir-ls/releases/latest and unzip it into a
-directory (this is the directory referred to as the
-`"path-to-elixir-ls/release"` below)
+directory (this is the directory referred to as the `"path-to-elixir-ls/release"` below)
 
-If using `lsp-mode` add this configuration:
+If using `lsp-mode`, add this configuration:
 
 ```elisp
   (use-package lsp-mode
@@ -86,7 +86,7 @@ For eglot use:
 ;; This is optional. It automatically runs `M-x eglot` for you whenever you are in `elixir-mode`
 (add-hook 'elixir-mode-hook 'eglot-ensure)
 
-;; Make sure to edit the path appropriately, use the .bat script instead for Windows
+;; Make sure to edit the path appropriately; use the `.bat` script instead for Windows
 (add-to-list 'eglot-server-programs '(elixir-mode "path-to-elixir-ls/release/language_server.sh"))
 ```
 
@@ -94,39 +94,39 @@ For eglot use:
 
 ## Supported elixir and OTP versions
 
-Elixir itself supports 5 versions with security updates:
+Elixir itself supports five versions with security updates:
 https://hexdocs.pm/elixir/compatibility-and-deprecations.html#content
 
-OTP Supports the last 3 versions:
+OTP Supports the last three versions:
 http://erlang.2086793.n4.nabble.com/OTP-Versions-and-Maint-Branches-td4722416.html
 
-ElixirLS generally aims to support the last 3 released versions of Elixir and the last 3 versions of OTP. However this is not a hard and fast rule and may change in the future.
+ElixirLS generally aims to support the last three released versions of Elixir and the last three versions of OTP. However this is not a hard and fast rule and may change in the future.
 
 ### Support matrix
 
-| OTP Versions | Elixir Versions | Supports ElixirLS |                          Issue(s)                          |
-| :----------: | :-------------: | :---------------: | :--------------------------------------------------------: |
-|      any     |     <= 1.12     |        No         |                No support for Code.Fragment                |
-|      22      |       1.13      |        Yes        |         Erlang docs not working (requires EIP 48)          |
-|      23      |   1.13 - 1.14   |        Yes        |                            None                            |
-|      24      |   1.13 - 1.15   |        Yes        |                            None                            |
-|      25      |  1.13.4 - 1.15  |        Yes        |                            None                            |
+|  OTP Versions   | Elixir Versions | Supports ElixirLS |                          Issue(s)                          |
+| :-------------: | :-------------: | :---------------: | :--------------------------------------------------------: |
+|      any        |     <= 1.12     |        No         |                No support for Code.Fragment                |
+|      22         |       1.13      |        Yes        |         Erlang docs not working (requires EIP 48)          |
+|      23         |   1.13 - 1.14   |        Yes        |                            None                            |
+|      24         |   1.13 - 1.15   |        Yes        |                            None                            |
+|      25         |  1.13.4 - 1.15  |        Yes        |                            None                            |
 | 26.0.0 - 26.0.1 |       any       |        No         | [#886](https://github.com/elixir-lsp/elixir-ls/issues/886) |
-|   >= 26.0.2  |  1.14.5 - 1.15  |    *nix only       |                  https://github.com/elixir-lsp/elixir-ls/issues/927                            |
+|   >= 26.0.2     |  1.14.5 - 1.15  |    *nix only      | https://github.com/elixir-lsp/elixir-ls/issues/927         |
 
 ### Version management
 
-It is generally recommended to install Elixir and Erlang via [ASDF](https://github.com/asdf-vm/asdf) so that you can have different projects using different versions of Elixir without having to change your system-installed version. ElixirLS can detect and use the version of Elixir and Erlang that you have configured in ASDF.
+It is generally recommended to install Elixir and Erlang via [ASDF](https://github.com/asdf-vm/asdf) so that you can have different projects using different versions of Elixir without having to change your system-installed version. ElixirLS can detect and use the versions of Elixir and Erlang that you have configured in ASDF.
 
 ## Debugger support
 
-ElixirLS provides debugger support adhering to the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) which is closely related to the Language Server Protocol.
+ElixirLS provides debugger support adhering to the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/), which is closely related to the Language Server Protocol.
 
 When debugging in Elixir or Erlang, only modules that have been "interpreted" (using `:int.ni/1` or `:int.i/1`) will accept breakpoints or show up in stack traces. The debugger in ElixirLS automatically interprets all modules in the Mix project and its dependencies before launching the Mix task. Therefore, you can set breakpoints anywhere in your project or dependency modules.
 
 Please note that there is currently a limit of 100 breakpoints.
 
-To debug modules in .exs files (such as tests), they must be specified under requireFiles in your launch configuration so that they can be loaded and interpreted before running the task. For example, the default launch configuration for "mix test" in the VSCode plugin is shown below:
+To debug modules in `.exs` files (such as tests), they must be specified under requireFiles in your launch configuration so that they can be loaded and interpreted before running the task. For example, the default launch configuration for `mix test` in the VSCode plugin is shown below:
 
 ```json
 {
@@ -170,7 +170,7 @@ To debug Phoenix applications using ElixirLS, you can use the following launch c
 }
 ```
 
-Please make sure that `startApps` is not set to `true`. To clarify, `startApps` is a configuration option in ElixirLS debugger that controls whether or not to start the applications in the mix project before running the task. In the case of Phoenix applications, setting `startApps` to `true` can interfere with the application's normal startup process and cause issues.
+Please make sure that `startApps` is not set to `true`. To clarify, `startApps` is a configuration option in ElixirLS debugger that controls whether or not to start the applications in the Mix project before running the task. In the case of Phoenix applications, setting `startApps` to `true` can interfere with the application's normal startup process and cause issues.
 
 If you are running tests in the Phoenix application, you may need to set `startApps` to true to ensure that the necessary applications are started before the tests run.
 
@@ -197,7 +197,7 @@ Function breakpoints in ElixirLS allow you to break on the first line of every c
 
 For example, to set a function breakpoint on the `foo` function in the `MyModule` module that takes one argument, you would specify it as `MyModule.foo/1`.
 
-Please note that function breakpoints only work for public functions, and do not support breaking on private functions.
+Please note that function breakpoints only work for public functions and do not support breaking on private functions.
 
 ### Conditional breakpoints
 
@@ -209,19 +209,19 @@ However, it's important to note that the expression evaluator used by ElixirLS h
 
 ### Hit conditions
 
-A hit condition is an optional parameter that can be set on a breakpoint to control how many times a breakpoint should be hit before stopping the process. It is expressed as an integer and can be used to filter out uninteresting hits, allowing the process to continue until a certain condition is met.
+A "hit condition" is an optional parameter that can be set on a breakpoint to control how many times a breakpoint should be hit before stopping the process. It is expressed as an integer and can be used to filter out uninteresting hits, allowing the process to continue until a certain condition is met.
 
-For example, if you have a loop that runs 10 times and you want to stop the process only when the loop reaches the 5th iteration, you can set a breakpoint with a hit condition of 5. This will cause the breakpoint to be hit only on the 5th iteration of the loop, and the process will continue to run until then.
+For example, if you have a loop that runs 10 times and you want to stop the process only when the loop reaches the 5th iteration, you can set a breakpoint with a hit condition of five. This will cause the breakpoint to be hit only on the 5th iteration of the loop, and the process will continue to run until then.
 
 ### Log points
 
-Log points are a type of breakpoint that logs a message to the standard output without stopping the program execution. When a log point is hit, the message is evaluated and printed to the console. The message can include interpolated expressions enclosed in curly braces `{}`, e.g. `my_var is {inspect(my_var)}` which will be evaluated in the context of the breakpoint. To escape the curly braces, you can use the escape sequence `\{` and `\}`.
+"Log points" are a type of breakpoint that logs a message to the standard output without stopping the program execution. When a log point is hit, the message is evaluated and printed to the console. The message can include interpolated expressions enclosed in curly braces `{}`, e.g. `my_var is {inspect(my_var)}` which will be evaluated in the context of the breakpoint. To escape the curly braces, you can use the escape sequence `\{` and `\}`.
 
 It's important to note that as of version 1.51 of the Debug Adapter Protocol specification, log messages are not supported on function breakpoints.
 
 ### Expression evaluator
 
-The debugger's expression evaluator has some limitations due to how the Erlang VM works. Specifically, the evaluator is implemented using :int, which works at the level of individual BEAM instructions. As a result, it returns multiple versions of variables in Static Single Assignment form, without indicating which one is valid in the current Elixir scope.
+The debugger's expression evaluator has some limitations due to how the Erlang VM works. Specifically, the evaluator is implemented using `:int`, which works at the level of individual BEAM instructions. As a result, it returns multiple versions of variables in Static Single Assignment form, without indicating which one is valid in the current Elixir scope.
 
 To work around this, the evaluator uses a heuristic to select the highest versions of variables, but this doesn't always behave correctly in all cases. For example, in the following code snippet:
 
@@ -233,13 +233,13 @@ end
 some
 ```
 
-If a breakpoint is set on the line with `some_function()`, the last bound value for a seen by the expression breakpoint evaluator will be `5`, even though it should be `4`.
+If a breakpoint is set on the line with `some_function()`, the last bound value for `a` seen by the expression breakpoint evaluator will be `5`, even though it should be `4`.
 
-Additionally, while all bound variables are accessible in the expression evaluator, it doesn't support accessing module attributes since those are determined at compile-time.
+Additionally, although all bound variables are accessible in the expression evaluator, the evaluator doesn't support accessing module attributes because those are determined at compile time.
 
 ### Connecting to debugger
 
-It may be useful to connect to a running debugger node via OTP distribution. This enables inspecting the running application and remotely triggering debugged functions. In order to do so set `ELS_ELIXIR_OPTS` in launch configuration and pass appropriate node name/sname and cookie.
+It may be useful to connect to a running debugger node via OTP distribution. This enables inspecting the running application and remotely triggering debugged functions. In order to do so, set `ELS_ELIXIR_OPTS` in the launch configuration and pass in the appropriate node `name/sname` and `cookie`.
 
 ```json
 {
@@ -251,7 +251,7 @@ It may be useful to connect to a running debugger node via OTP distribution. Thi
 
 ## Automatic builds and error reporting
 
-The ElixirLS provides automatic builds and error reporting. By default, builds are triggered automatically when files are saved, but you can also enable "autosave" in your IDE to trigger builds as you type. If you prefer to disable automatic builds, you can set the `elixirLS.autoBuild` configuration option to `false`.
+ElixirLS provides automatic builds and error reporting. By default, builds are triggered automatically when files are saved, but you can also enable "autosave" in your IDE to trigger builds as you type. If you prefer to disable automatic builds, you can set the `elixirLS.autoBuild` configuration option to `false`.
 
 Internally, ElixirLS uses the `mix compile` task to compile Elixir code. When errors or warnings are encountered during compilation, they are returned as LSP diagnostics. Your IDE may display them inline in your code as well as in the "Problems" pane. This allows you to quickly identify and fix errors in your code as you work.
 
@@ -265,7 +265,7 @@ You can control which warnings are shown using the `elixirLS.dialyzerWarnOpts` s
 
 To disable Dialyzer completely, set `elixirLS.dialyzerEnabled` to false.
 
-If Dialyzer gets stuck and emits incorrect or no longer applying warnings, it's best to restart the language server.
+If Dialyzer gets stuck and emits incorrect or outdated warnings, it's best to restart the language server.
 
 ## Code completion
 
@@ -296,43 +296,43 @@ The completions include:
 
 ## Workspace Symbols
 
-With Dialyzer integration enabled ElixirLS will build an index of symbols (modules, functions, types and callbacks). The symbols are taken from the current workspace, all dependencies and stdlib (Elixir and erlang). This feature enables quick navigation to symbol definitions.
+With Dialyzer integration enabled, ElixirLS will build an index of symbols (modules, functions, types, and callbacks). The symbols are taken from the current workspace, all dependencies, and stdlib (Elixir and Erlang). This feature enables quick navigation to symbol definitions.
 
 ## ElixirLS configuration settings
 
-Below is a list configuration options supported by ElixirLS language server. Please refer to your editor's documentation on how to configure language servers.
+Below is a list of configuration options supported by the ElixirLS language server. Please refer to your editor's documentation to determine how to configure language servers.
 
 <dl>
 <dt>elixirLS.autoBuild</dt><dd>Trigger ElixirLS build when code is saved</dd>
 <dt>elixirLS.dialyzerEnabled</dt><dd>Run ElixirLS's rapid Dialyzer when code is saved</dd>
-<dt>elixirLS.dialyzerWarnOpts</dt><dd>Dialyzer options to enable or disable warnings. See Dialyzer's documentation for options. Note that the "race_conditions" option is unsupported</dd>
+<dt>elixirLS.dialyzerWarnOpts</dt><dd>Dialyzer options to enable or disable warnings. See Dialyzer's documentation for options. Note that the `race_conditions` option is unsupported</dd>
 <dt>elixirLS.dialyzerFormat</dt><dd>Formatter to use for Dialyzer warnings</dd>
 <dt>elixirLS.envVariables</dt><dd>Environment variables to use for compilation</dd>
 <dt>elixirLS.mixEnv</dt><dd>Mix environment to use for compilation</dd>
 <dt>elixirLS.mixTarget</dt><dd>Mix target to use for compilation</dd>
-<dt>elixirLS.projectDir</dt><dd>Subdirectory containing Mix project if not in the project root</dd>
+<dt>elixirLS.projectDir</dt><dd>Subdirectory containing the Mix project if it is not in the project root</dd>
 <dt>elixirLS.fetchDeps</dt><dd>Automatically fetch project dependencies when compiling</dd>
 <dt>elixirLS.suggestSpecs</dt><dd>Suggest @spec annotations inline using Dialyzer's inferred success typings (Requires Dialyzer)</dd>
-<dt>elixirLS.trace.server</dt><dd>Traces the communication between VS Code and the Elixir language server.</dd>
+<dt>elixirLS.trace.server</dt><dd>Traces communication between VS Code and the Elixir language server.</dd>
 <dt>elixirLS.autoInsertRequiredAlias</dt><dd>Enable auto-insert required alias. By default, it's true, which means enabled.</dd>
 <dt>elixirLS.signatureAfterComplete</dt><dd>Show signature help after confirming autocomplete</dd>
 <dt>elixirLS.enableTestLenses</dt><dd>Show code lenses to run tests in terminal</dd>
 <dt>elixirLS.additionalWatchedExtensions</dt><dd>Additional file types capable of triggering a build on change</dd>
-<dt>elixirLS.languageServerOverridePath</dt><dd>Absolute path to alternative ElixirLS release that will override packaged release.</dd>
+<dt>elixirLS.languageServerOverridePath</dt><dd>Absolute path to an alternative ElixirLS release that will override packaged release.</dd>
 </dl>
 
 ## Debugger configuration options
 
-Below is a list of configuration options supported by ElixirLS Debugger. Configuration options can be supplied via debugger launch configuration. Please refer to your editor's documentation on how to configure debugger adapters.
+Below is a list of configuration options supported by the ElixirLS Debugger. Configuration options can be supplied via the debugger launch configuration. Please refer to your editor's documentation on how to configure debugger adapters.
 
 <dl>
   <dt>startApps</dt><dd>Run `mix app.start` before launching the debugger. Some tasks (such as Phoenix tests) expect apps to already be running before the test files are required</dd>
   <dt>task</dt><dd>Mix task to run with debugger. Defaults to task set under `:default_task` key in mixfile</dd>
   <dt>taskArgs</dt><dd>A list of arguments to mix task</dd>
   <dt>debugAutoInterpretAllModules</dt><dd>Auto interpret all modules from project build path. Defaults to `true`.</dd>
-  <dt>env</dt><dd>An object with environment variables to set. Object keys specify environment variables, values should be strings</dd>
+  <dt>env</dt><dd>An object with environment variables to set. Object keys specify environment variables; values should be strings</dd>
   <dt>stackTraceMode</dt><dd>Debugger stacktrace mode. Allowed values: `all`, `no_tail`, or `false`.</dd>
-  <dt>requireFiles</dt><dd>A list of additional files that should be required and interpreted. Useful especially for debugging tests</dd>
+  <dt>requireFiles</dt><dd>A list of additional files that should be required and interpreted. Especially useful for debugging tests</dd>
   <dt>debugInterpretModulesPatterns</dt><dd>A list of globs specifying modules that should be interpreted</dd>
   <dt>debugExpressionTimeoutMs</dt><dd>Expression evaluator timeout in milliseconds. Defaults to 10 000</dd>
   <dt>projectDir</dt><dd>An absolute path to the directory where `mix.exs` is located. In VSCode `${workspaceRoot}` can be used</dd>
@@ -343,16 +343,16 @@ Below is a list of configuration options supported by ElixirLS Debugger. Configu
 
 Basic troubleshooting steps:
 
-- Make sure you have hex and git installed
-- Make sure github.com and hex.pm are accessible. You may need to configure HTTPS proxy. If your setup uses TLS man-in-the-middle inspection you may need to set `HEX_UNSAFE_HTTPS=1`.
-- If ElixirLS fails to start you can try cleaning the `Mix.install` directory (location on your system can be obtained by calling `Path.join(Mix.Utils.mix_cache(), "installs")` from `iex` session)
+- Make sure you have `hex` and `git` installed.
+- Make sure `github.com` and `hex.pm` are accessible. You may need to configure an HTTPS proxy. If your setup uses TLS man-in-the-middle inspection, you may need to set `HEX_UNSAFE_HTTPS=1`.
+- If ElixirLS fails to start, you can try cleaning the `Mix.install` directory (location on your system can be obtained by calling `Path.join(Mix.Utils.mix_cache(), "installs")` from `iex` session)
 - Restart ElixirLS with a custom command `restart`
-- Run `mix clean` or `mix clean --deps` in ElixirLS with custom command `mixClean`
-- Restart your editor (which will restart ElixirLS)
-- After stopping your editor, remove the entire `.elixir_ls` directory, then restart your editor
+- Run `mix clean` or `mix clean --deps` in ElixirLS with custom command `mixClean`.
+- Restart your editor (which will restart ElixirLS).
+- After stopping your editor, remove the entire `.elixir_ls` directory, then restart your editor.
   - NOTE: This will cause you to have to re-run the entire dialyzer build
 
-You may need to set `elixirLS.mixEnv`, `elixirLS.mixTarget` and `elixirLS.projectDir` if your project requires it. By default ElixirLS compiles code with `MIX_ENV=test`, `MIX_TARGET=host` and assumes that `mix.exs` is located in the workspace root directory.
+You may need to set `elixirLS.mixEnv`, `elixirLS.mixTarget`, and `elixirLS.projectDir` if your project requires it. By default, ElixirLS compiles code with `MIX_ENV=test`, `MIX_TARGET=host`, and assumes that `mix.exs` is located in the workspace root directory.
 
 If you get an error like the following immediately on startup:
 
@@ -361,9 +361,9 @@ If you get an error like the following immediately on startup:
     ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
 ```
 
-and you installed Elixir and Erlang from the Erlang Solutions repository, you may not have a full installation of erlang. This can be solved with `sudo apt-get install esl-erlang`. Originally reported in [#208](https://github.com/elixir-lsp/elixir-ls/issues/208).
+and you installed Elixir and Erlang from the Erlang Solutions repository, you may not have a full installation of Erlang. This can be solved with `sudo apt-get install esl-erlang`. (This was originally reported in [#208](https://github.com/elixir-lsp/elixir-ls/issues/208).)
 
-On fedora if you only install the elixir package you will not have a full erlang installation, this can be fixed by running `sudo dnf install erlang` (reported in [#231](https://github.com/elixir-lsp/elixir-ls/issues/231))
+On Fedora Linux, if you only install the Elixir package you will not have a full Erlang installation. This can be fixed by running `sudo dnf install erlang` (This was reported in [#231](https://github.com/elixir-lsp/elixir-ls/issues/231).)
 
 If you are seeing the message "Invalid beam file or no abstract code", you need to make sure that your Mix project is set to use the `elixirc` compiler option `--debug-info`, which can be done by adding the following line to your `mix.exs` `project` section:
 
@@ -387,9 +387,9 @@ defmodule MyApp.MixProject do
     ...
 ```
 
-If you are using Emacs with lsp-mode there's a possibility that you have set the
+If you are using Emacs with `lsp-mode`, there's a possibility that you have set the
 wrong directory as the project root (especially if that directory does not have
-a `mix.exs` file). To fix that you should remove the project and re-initialize:
+a `mix.exs` file). To fix that, you should remove the project and re-initialize:
 https://github.com/elixir-lsp/elixir-ls/issues/364#issuecomment-829589139
 
 ## Known Issues/Limitations
@@ -397,7 +397,7 @@ https://github.com/elixir-lsp/elixir-ls/issues/364#issuecomment-829589139
 - `.exs` files don't return compilation errors
 - "Fetching n dependencies" sometimes get stuck (remove the `.elixir_ls` directory to fix)
 - "Go to definition" does not work within the `scope` of a Phoenix router
-- On first launch dialyzer will cause high CPU usage for a considerable time
+- On first launch, Dialyzer will cause high CPU usage for a considerable time.
 - Dialyzer does not pick up changes involving remote types (https://github.com/elixir-lsp/elixir-ls/issues/502)
 
 ## Building and running
@@ -412,7 +412,7 @@ MIX_ENV=prod mix compile
 MIX_ENV=prod mix elixir_ls.release2 -o <release_dir>
 ```
 
-This copies language server and debugger adapter launch scripts to the `<release_dir>` and includes `VERSION` manifest file. The launch scripts install a release specified by version manifest via `Mix.install` and launch it. This ensures that ElixirLS is built by the correct combination of elixir and OTP.
+This copies language server and debugger adapter launch scripts to the `<release_dir>` and includes a `VERSION` manifest file. The launch scripts install a release specified by the version manifest via `Mix.install` and then launch it. This ensures that ElixirLS is built with the correct combination of Elixir and OTP.
 
 ### Deprecated `.ez` archives release
 
@@ -424,21 +424,21 @@ MIX_ENV=prod mix elixir_ls.release -o <release_dir>
 
 This builds the language server and debugger as a set of `.ez` archives and creates `.sh` and `.bat` scripts to launch them.
 
-If you're packaging these archives in an IDE plugin, make sure to build using the minimum supported OTP version for the best backwards-compatibility.
+If you're packaging these archives in an IDE plugin, make sure to build using the minimum supported OTP version for the best backwards compatibility.
 
 ### Local setup
 
 This section provides additional information on how to set up the ElixirLS locally.
 
-When launching ElixirLS from an IDE that is itself launched from a graphical shell, the environment may not be complete enough to find or run the correct Elixir/OTP version. To address this on unix, the ElixirLS wrapper scripts try to configure [ASDF](https://github.com/asdf-vm/asdf) (a version manager for Elixir and other languages), but that may not always be what is needed.
+When launching ElixirLS from an IDE that is itself launched from a graphical shell, the environment may not be complete enough to find or run the correct Elixir/OTP version. To address this on Unix or Linux, the ElixirLS wrapper scripts try to configure [ASDF](https://github.com/asdf-vm/asdf) (a version manager for Elixir and other languages), but that may not always be what is needed.
 
 To ensure that the correct environment is set up, you can create a setup script at `$XDG_CONFIG_HOME/elixir_ls/setup.sh` (for Unix-based systems) or `%APPDATA%\elixir_ls\setup.bat` (for Windows).
 
-In the setup script the environment variable `ELS_MODE` is available and set to either `debugger` or `language_server` to help you decide what to do.
+In the setup script, the environment variable `ELS_MODE` is available and set to either `debugger` or `language_server` to help you decide what to do.
 
-Note: The setup script must not read from `stdin` and write to `stdout`. On unix/linux/macOS
+Note: The setup script must not read from `stdin` and write to `stdout`. On Unix, Linux, and macOS
 this might be accomplished by adding `>/dev/null` at the end of any line that produces
-output, and for a windows batch script you will want `@echo off` at the top and `>nul`.
+output; for a Windows batch script, you will want `@echo off` at the top and `>nul`.
 
 ### Development
 
@@ -452,11 +452,11 @@ ElixirLS supports the following environment variables.
 
   <dt>ELS_INSTALL_PREFIX</dt><dd>(not supported on Windows) The folder where the language server got installed to. If set, it makes maintaining multiple versions/instances on the same host much easier. If not set or empty, a heuristic will be used to discover the install location.</dd>
 
-  <dt>ELS_LOCAL</dt><dd>If set to `1` will make ElixirLS run local release. If it is not set a published release matching `VERSION` will be used (default).</dd>
+  <dt>ELS_LOCAL</dt><dd>If set to `1` will make ElixirLS run local release. If it is not set, a published release matching `VERSION` will be used (default).</dd>
 
   <dt>ELS_ELIXIR_OPTS</dt><dd>Optional parameters to pass to elixir CLI. May be used to set a node name and cookie.</dd>
 
-  <dt>ELS_ERL_OPTS</dt><dd>Optional parameters to pass to erl CLI.</dd>
+  <dt>ELS_ERL_OPTS</dt><dd>Optional parameters to pass to the erl CLI.</dd>
 
   <dt>ASDF_DIR</dt><dd>(not supported on Windows) If set, ElixirLS will look for [ASDF](https://github.com/asdf-vm/asdf) script in a directory given by that variable</dd>
 


### PR DESCRIPTION
Fixed assorted minor punctuation and wording issues. For some reason, backticks aren't  working in the "Debugger configuration options" section. Not sure how to reword this: "... you will want @echo off at the top and >nul."