### PR TITLE
Bugfix/#967 fish shell support

### DIFF
--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -1,0 +1,83 @@
+#!/usr/bin/env fish
+# Actual launcher. This does the hard work of figuring out the best way
+# to launch the language server or the debugger.
+
+# Running this script is a one-time action per project launch, so we opt for
+# code simplicity instead of performance. Hence some potentially redundant
+# moves here.
+
+# First order of business, see whether we can setup asdf-vm
+
+set asdf_dir $ASDF_DIR
+
+test -z $asdf_dir; and set asdf_dir "$HOME/.asdf"
+
+set asdf_vm "$ASDF_DIR/asdf.fish"
+
+echo "Looking for ASDF install" >&2
+
+if test -f $asdf_vm
+  echo "ASDF install found in $asdf_vm, sourcing" >&2
+  . $asdf_vm
+else
+  echo "ASDF not found" >&2
+  echo "Looking for rtx executable" >&2
+
+  set rtx (which rtx)
+  if test -n $rtx
+    echo "rtx executable found in $rtx, activating" >&2
+    $rtx activate fish | source
+  else
+    echo "rtx not found" >&2
+  end
+end
+
+# In case that people want to tweak the path, which Elixir to use, or
+# whatever prior to launching the language server or the debugger, we
+# give them the chance here. ELS_MODE will be set for
+# the really complex stuff. Use an XDG compliant path.
+
+set els_dir $XDG_CONFIG_HOME
+test -z $els_dir; and set els_dir "$HOME/.config"
+
+set els_setup "$els_dir/elixir_ls/setup.fish"
+
+if test -f $els_setup
+  echo "Running setup script $els_setup" >&2
+  . $els_setup
+end
+
+# Setup done. Make sure that we have the proper actual path to this
+# script so we can correctly configure the Erlang library path to
+# include the local .ez files, and then do what we were asked to do.
+
+function readlink_f
+  cd (dirname $argv[1]) || exit 1
+  set filename (basename $argv[1])
+  if test -L $filename
+    readlink_f (readlink $filename)
+  else
+    echo (pwd -P)"/$filename"
+  end
+end
+
+if test -z $ELS_INSTALL_PREFIX
+  set scriptpath (dirname (readlink_f (status -f)))
+else
+  set scriptpath $ELS_INSTALL_PREFIX
+end
+
+set -x MIX_ENV prod
+# Mix.install prints to stdout and reads from stdin
+# we need to make sure it doesn't interfere with LSP/DAP
+echo "" | elixir "$scriptpath/quiet_install.exs" >/dev/null || exit 1
+
+set default_erl_opts "-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
+
+if test -n $ELS_ELIXIR_OPTS
+  set elixir_opts (string join ' ' (string split ' ' \"$ELS_ELIXIR_OPTS\"))
+else
+  set elixir_opts ""
+end
+
+exec elixir $elixir_opts --erl "$default_erl_opts $ELS_ERL_OPTS" "$scriptpath/launch.exs"

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -44,7 +44,7 @@ set els_setup "$els_dir/elixir_ls/setup.fish"
 
 if test -f "$els_setup"
   echo "Running setup script $els_setup" >&2
-  . "$els_setup"
+  source "$els_setup"
 end
 
 # Setup done. Make sure that we have the proper actual path to this

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -12,13 +12,13 @@ set asdf_dir $ASDF_DIR
 
 test -z "$asdf_dir"; and set asdf_dir "$HOME/.asdf"
 
-set asdf_vm "$ASDF_DIR/asdf.fish"
+set asdf_vm "$asdf_dir/asdf.fish"
 
 echo "Looking for ASDF install" >&2
 
 if test -f "$asdf_vm"
   echo "ASDF install found in $asdf_vm, sourcing" >&2
-  . "$asdf_vm"
+  source "$asdf_vm"
 else
   echo "ASDF not found" >&2
   echo "Looking for rtx executable" >&2

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -74,10 +74,6 @@ echo "" | elixir "$scriptpath/quiet_install.exs" >/dev/null || exit 1
 
 set default_erl_opts "-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
 
-if test -n $ELS_ELIXIR_OPTS
-  set elixir_opts (string join ' ' (string split ' ' \"$ELS_ELIXIR_OPTS\"))
-else
-  set elixir_opts ""
-end
+set elixir_opts "$ELS_ELIXIR_OPTS"
 
 exec elixir $elixir_opts --erl "$default_erl_opts $ELS_ERL_OPTS" "$scriptpath/launch.exs"

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -72,8 +72,18 @@ set -x MIX_ENV prod
 # we need to make sure it doesn't interfere with LSP/DAP
 echo "" | elixir "$scriptpath/quiet_install.exs" >/dev/null || exit 1
 
-set default_erl_opts "-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
+set erl_opts -kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none
 
-set elixir_opts "$ELS_ELIXIR_OPTS"
+if test -n "$ELS_ELIXIR_OPTS"
+  set elixir_opts (string join ' ' -- $ELS_ELIXIR_OPTS)
+else
+  set elixir_opts
+end
 
-exec elixir $elixir_opts --erl "$default_erl_opts $ELS_ERL_OPTS" "$scriptpath/launch.exs"
+if test -n "$ELS_ERL_OPTS"
+  set erl_opts -a $ELS_ERL_OPTS
+end
+
+set erl_opts (string join ' ' -- $erl_opts)
+
+eval elixir $elixir_opts --erl \"$erl_opts \" "$scriptpath/launch.exs"

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -10,23 +10,23 @@
 
 set asdf_dir $ASDF_DIR
 
-test -z $asdf_dir; and set asdf_dir "$HOME/.asdf"
+test -z "$asdf_dir"; and set asdf_dir "$HOME/.asdf"
 
 set asdf_vm "$ASDF_DIR/asdf.fish"
 
 echo "Looking for ASDF install" >&2
 
-if test -f $asdf_vm
+if test -f "$asdf_vm"
   echo "ASDF install found in $asdf_vm, sourcing" >&2
-  . $asdf_vm
+  . "$asdf_vm"
 else
   echo "ASDF not found" >&2
   echo "Looking for rtx executable" >&2
 
   set rtx (which rtx)
-  if test -n $rtx
+  if test -n "$rtx"
     echo "rtx executable found in $rtx, activating" >&2
-    $rtx activate fish | source
+    "$rtx" activate fish | source
   else
     echo "rtx not found" >&2
   end
@@ -37,14 +37,14 @@ end
 # give them the chance here. ELS_MODE will be set for
 # the really complex stuff. Use an XDG compliant path.
 
-set els_dir $XDG_CONFIG_HOME
-test -z $els_dir; and set els_dir "$HOME/.config"
+set els_dir "$XDG_CONFIG_HOME"
+test -z "$els_dir"; and set els_dir "$HOME/.config"
 
 set els_setup "$els_dir/elixir_ls/setup.fish"
 
-if test -f $els_setup
+if test -f "$els_setup"
   echo "Running setup script $els_setup" >&2
-  . $els_setup
+  . "$els_setup"
 end
 
 # Setup done. Make sure that we have the proper actual path to this
@@ -61,7 +61,7 @@ function readlink_f
   end
 end
 
-if test -z $ELS_INSTALL_PREFIX
+if test -z "$ELS_INSTALL_PREFIX"
   set scriptpath (dirname (readlink_f (status -f)))
 else
   set scriptpath $ELS_INSTALL_PREFIX

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -37,7 +37,7 @@ end
 # give them the chance here. ELS_MODE will be set for
 # the really complex stuff. Use an XDG compliant path.
 
-set els_dir "$XDG_CONFIG_HOME"
+set els_dir $XDG_CONFIG_HOME
 test -z "$els_dir"; and set els_dir "$HOME/.config"
 
 set els_setup "$els_dir/elixir_ls/setup.fish"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -21,6 +21,9 @@ case "${did_relaunch}" in
     elif [ "$preferred_shell" = "zsh" ]; then
       >&2 echo "Preffered shell is zsh, relaunching"
       exec "$(which zsh)" "$0" relaunch
+    elif [ "$preferred_shell" = "fish" ]; then
+      >&2 echo "Preferred shell is fish, launching launch.fish"
+      exec "$(which fish)" "$(dirname "$0")/launch.fish"
     else
       >&2 echo "Preffered shell $preferred_shell is not supported, continuing in POSIX shell"
     fi


### PR DESCRIPTION
Fix #967 

I'm no fish shell scripting expert, but it seems to be working:

```
Running /Users/defman/.vscode/extensions/jakebecker.elixir-ls-0.16.0/elixir-ls-release/launch.sh
Preferred shell is fish, launching launch.fish
Looking for ASDF install
ASDF not found
Looking for rtx executable
rtx executable found in /Users/defman/bin/rtx, activating
Installing ElixirLS release v0.16.0
Running in /Users/defman/.vscode/extensions/jakebecker.elixir-ls-0.16.0/elixir-ls-release
Install complete
[Info  - 11:04:09] Started ElixirLS v0.16.0
[Info  - 11:04:09] Running in /Users/defman/.vscode/extensions/jakebecker.elixir-ls-0.16.0/elixir-ls-release
[Info  - 11:04:09] ElixirLS built with elixir "1.15.4" on OTP "26"
[Info  - 11:04:09] Running on elixir "1.15.4 (compiled with Erlang/OTP 26)" on OTP "26"
[Info  - 11:04:09] Protocols are not consolidated
[Info  - 11:04:09] Elixir sources not found (checking in /home/runner/work/elixir/elixir). Code navigation to Elixir modules disabled.
[Info  - 11:04:09] Received client configuration via workspace/configuration
%{"additionalWatchedExtensions" => [], "autoBuild" => true, "autoInsertRequiredAlias" => true, "dialyzerEnabled" => true, "dialyzerFormat" => "dialyxir_long", "dialyzerWarnOpts" => ["error_handling", "underspecs", "unknown", "unmatched_returns"], "enableTestLenses" => true, "envVariables" => %{}, "fetchDeps" => false, "languageServerOverridePath" => "", "mixEnv" => "test", "mixTarget" => "", "projectDir" => "", "signatureAfterComplete" => true, "suggestSpecs" => true, "trace" => %{"server" => "off"}}
[Info  - 11:04:10] Loaded DETS databases in 118ms
[Info  - 11:04:10] Registering for workspace/didChangeConfiguration notifications
[Info  - 11:04:10] Starting build with MIX_ENV: test MIX_TARGET: host
[Info  - 11:04:10] client/registerCapability succeeded
[Info  - 11:04:10] Registering for workspace/didChangeWatchedFiles notifications
[Info  - 11:04:10] client/registerCapability succeeded
[Info  - 11:04:10] Compile took 165 milliseconds
[Info  - 11:04:10] [ElixirLS WorkspaceSymbols] Indexing...
[Info  - 11:04:10] [ElixirLS Dialyzer] Checking for stale beam files
[Info  - 11:04:10] [ElixirLS WorkspaceSymbols] Module discovery complete
[Info  - 11:04:10] [ElixirLS WorkspaceSymbols] 30 callbacks added to index
[Info  - 11:04:11] [ElixirLS WorkspaceSymbols] 255 modules added to index
[Info  - 11:04:11] [ElixirLS WorkspaceSymbols] 452 types added to index
[Info  - 11:04:12] [ElixirLS Dialyzer] Found 0 changed files in 633 milliseconds
[Info  - 11:04:12] [ElixirLS Dialyzer] Analyzing 0 modules: []
[Info  - 11:04:12] [ElixirLS Dialyzer] Analysis finished in 20 milliseconds
[Info  - 11:04:12] Dialyzer analysis is up to date
[Info  - 11:04:12] [ElixirLS Dialyzer] Writing manifest...
[Info  - 11:04:13] [ElixirLS WorkspaceSymbols] 5038 functions added to index
[Info  - 11:04:13] [ElixirLS Dialyzer] Done writing manifest in 668 milliseconds.
```

I haven't tested the `ELS_` stuff though. If anyone could provide some steps I should perform to test the ELS code, I'd be happy to do them.