### PR TITLE
add missing keyword completion

### DIFF
--- a/apps/language_server/test/providers/completion_test.exs
+++ b/apps/language_server/test/providers/completion_test.exs
@@ -685,6 +685,42 @@ defmodule ElixirLS.LanguageServer.Providers.CompletionTest do
     end
   end
 
+  describe "keyword completion" do
+    setup do
+      text = """
+      defmodule MyModule do
+        def dummy_function() do
+          t
+          #^
+        end
+      end
+      """
+
+      %{text: text, location: {2, 5}}
+    end
+
+    test "first", context do
+      %{text: text, location: {line, char}} = context
+
+      TestUtils.assert_has_cursor_char(text, line, char)
+
+      opts = Keyword.merge(@supports, signature_after_complete: true)
+      {:ok, %{"items" => items}} = Completion.completion(text, line, char, opts)
+
+      [item] = items |> Enum.filter(&(&1["insertText"] == "true"))
+
+      assert %{
+               "detail" => "keyword",
+               "documentation" => %{:kind => "markdown", "value" => ""},
+               "insertText" => "true",
+               "insertTextFormat" => 2,
+               "kind" => 14,
+               "label" => "true",
+               "sortText" => "00000000"
+             } = item
+    end
+  end
+
   describe "function completion" do
     setup do
       text = """


### PR DESCRIPTION
Closes #937 

added true, false and nil as keywords for completion

Missing command key in resulting item map. Any suggestions?
Also I used TDD and did not manage to test this in vsc-elixir-ls or similar yet.

Update: I replaced the submodule of vscode-elixir-ls with my fork of elixir-ls and it worked; check screenshots:

![image](https://github.com/elixir-lsp/elixir-ls/assets/41344758/5e42340c-5478-455d-9d0e-f2c04a8f80ad)

![image](https://github.com/elixir-lsp/elixir-ls/assets/41344758/2cf93893-e902-4e68-9ba3-07e24a72ab6e)

![image](https://github.com/elixir-lsp/elixir-ls/assets/41344758/e3bdf657-faef-48d0-adee-c55ba12fbcde)

Also I do not know which priority they deserve.

Update 2:

May we add a new kind atom at
```diff
case kind do
...
- :value -> 12
+ :atom-> 12
+ :value -> 13
...
```
or
```diff
case kind do
...
- :keyword -> 14
+ :atom-> 14
+ :keyword -> 15
...
```
or do we leave it as 
```elixir
:keyword
```