### PR TITLE
Add shell specific launch execution

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,36 @@ cd path/to/my_project
 ELS_LOCAL=1 /path/to/elixir-ls/scripts/language_server.sh
 ```
 
+#### Docker based test environment
+
+You are able to run the project in a container (based on Elixir Alpine) to quickly try different platforms or shells.
+
+To build and run the container (tagged `els` to make docker operations easier) run:
+
+```shell
+docker build -t els .
+docker run -it els
+```
+Please keep in mind that in this will take the current project contents and copy it into the container once when the
+container is being built.
+
+Since the container contains its own little Linux os the project content is copied into the `/app` directory to avoid
+interference with the surrounding system, when you enter the container using the interactive terminal (with the command
+above) you will start in that `/app` directory. The following examples expect you being in that project directory.
+
+The following example runs the language server in the default shell of Alpine Linux, which is the Almquist shell (`ash`):
+
+```shell
+ELS_LOCAL=1 SHELL=ash scripts/language_server.sh
+```
+Since `ash` is already the default shell for Alpine Linux we don't need to explicitly call a shell to run the script with.
+
+To run the same command with the `bash` you need to actually pass the shell as well:
+
+```shell
+ELS_LOCAL=1 SHELL=bash bash scripts/language_server.sh
+```
+
 ### Formatting
 
 You may need to separately run `mix format` in the ElixirLS root and in `apps/language_server` directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM index.docker.io/elixir:alpine
+
+ARG ELIXIR_LS_VERSION=v0.16.0
+ARG MIX_ENV=prod
+
+ADD . /app
+
+WORKDIR /app
+
+# Add build and test dependencies
+RUN apk add --no-cache \
+  git \
+  zsh \
+  bash \
+  fish
+
+CMD sh

--- a/scripts/exec.bash
+++ b/scripts/exec.bash
@@ -1,0 +1,8 @@
+# we need to make sure ELS_ELIXIR_OPTS gets splitted by word
+# parse it as bash array
+# shellcheck disable=SC3045
+# shellcheck disable=SC3011
+IFS=' ' read -ra elixir_opts <<< "$ELS_ELIXIR_OPTS"
+# shellcheck disable=SC3054
+# shellcheck disable=SC2068
+exec elixir ${elixir_opts[@]} --erl "$default_erl_opts $ELS_ERL_OPTS" "$SCRIPTPATH/launch.exs"

--- a/scripts/exec.zsh
+++ b/scripts/exec.zsh
@@ -1,0 +1,8 @@
+# we need to make sure ELS_ELIXIR_OPTS gets splitted by word
+# parse it as zsh array
+# shellcheck disable=SC3030
+# shellcheck disable=SC2296
+elixir_opts=("${(z)ELS_ELIXIR_OPTS}")
+# shellcheck disable=SC2128
+# shellcheck disable=SC2086
+exec elixir $elixir_opts --erl "$default_erl_opts $ELS_ERL_OPTS" "$SCRIPTPATH/launch.exs"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -13,6 +13,9 @@ did_relaunch=$1
 # Get the user's preferred shell
 preferred_shell=$(basename "$SHELL")
 
+# Get current dirname
+dirname=$(dirname "$0")
+
 case "${did_relaunch}" in
   "")
     if [ "$preferred_shell" = "bash" ]; then
@@ -23,7 +26,7 @@ case "${did_relaunch}" in
       exec "$(which zsh)" "$0" relaunch
     elif [ "$preferred_shell" = "fish" ]; then
       >&2 echo "Preferred shell is fish, launching launch.fish"
-      exec "$(which fish)" "$(dirname "$0")/launch.fish"
+      exec "$(which fish)" "$dirname/launch.fish"
     else
       >&2 echo "Preffered shell $preferred_shell is not supported, continuing in POSIX shell"
     fi
@@ -98,23 +101,9 @@ echo "" | elixir "$SCRIPTPATH/quiet_install.exs" >/dev/null || exit 1
 default_erl_opts="-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
 
 if [ "$preferred_shell" = "bash" ]; then
-  # we need to make sure ELS_ELIXIR_OPTS gets splitted by word
-  # parse it as bash array
-  # shellcheck disable=SC3045
-  # shellcheck disable=SC3011
-  IFS=' ' read -ra elixir_opts <<< "$ELS_ELIXIR_OPTS"
-  # shellcheck disable=SC3054
-  # shellcheck disable=SC2068
-  exec elixir ${elixir_opts[@]} --erl "$default_erl_opts $ELS_ERL_OPTS" "$SCRIPTPATH/launch.exs"
+  source "$dirname/exec.bash"
 elif [ "$preferred_shell" = "zsh" ]; then
-  # we need to make sure ELS_ELIXIR_OPTS gets splitted by word
-  # parse it as zsh array
-  # shellcheck disable=SC3030
-  # shellcheck disable=SC2296
-  elixir_opts=("${(z)ELS_ELIXIR_OPTS}")
-  # shellcheck disable=SC2128
-  # shellcheck disable=SC2086
-  exec elixir $elixir_opts --erl "$default_erl_opts $ELS_ERL_OPTS" "$SCRIPTPATH/launch.exs"
+  source "$dirname/exec.zsh"
 else
   if [ -z "$ELS_ELIXIR_OPTS" ]
   then


### PR DESCRIPTION
This aims to solve #981.

I

- moved the shell specific opts handling into dedicated `exec.*` scripts.
- added a `Dockerfile` make it easier testing different shells (i would be able to add VSCode devcontainer support if possible).
- added a dev docs section.