### PR TITLE
Quote interpolated path when launching server in fish launch script

### DIFF
--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -86,4 +86,4 @@ end
 
 set erl_opts (string join ' ' -- $erl_opts)
 
-eval elixir $elixir_opts --erl \"$erl_opts \" "$scriptpath/launch.exs"
+eval elixir $elixir_opts --erl \"$erl_opts \" \"$scriptpath/launch.exs\"


### PR DESCRIPTION
Fixes an issue where attempting to launch the server stored in a path containing a space would error out

<img width="831" alt="CleanShot 2023-10-25 at 18 52 59@2x" src="https://github.com/elixir-lsp/elixir-ls/assets/30666851/d3c531ca-17d5-444e-866f-9908067fe4b9">
