### PR TITLE
fix 'unkown command elxir with rtx' and fish

### DIFF
--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -26,7 +26,8 @@ else
   set rtx (which rtx)
   if test -n "$rtx"
     echo "rtx executable found in $rtx, activating" >&2
-    "$rtx" activate fish | source
+
+    "$rtx" env -s fish | source
   else
     echo "rtx not found" >&2
   end


### PR DESCRIPTION
Currently, when I try to use elixir-ls with fish in vscode it fails to start with the following failure:

```
Preferred shell is fish, launching launch.fish
Looking for ASDF install
ASDF not found
Looking for rtx executable
rtx executable found in /usr/bin/rtx, activating
fish: Unknown command: elixir
./scripts/launch.fish (line 79): 
echo "" | elixir "$scriptpath/quiet_install.exs" >/dev/null || exit 1
```

Chasing this down a bit, RTX relies on the `fish_prompt` and `fish_preexec` to do its magic, and `fish_prompt` is never fired in a script, so unless vscode is launched from a shell where RTX has already set its environment variables, activating RTX won't work. Since Elixir-LS doesn't need the directory-changing magic, I think [rtx env](https://github.com/jdx/rtx#rtx-env-options-toolversion) is the way to go here.
