### PR TITLE
Selection ranges porvider

### DIFF
--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -86,10 +86,10 @@ defmodule ElixirLS.LanguageServer.AstUtils do
     line = Keyword.get(meta, :line) - 1
     column = Keyword.get(meta, :column) - 1
     {end_line, end_column} = get_eoe_by_formatting(ast, {line, column})
-    # formatter changes charlist '' to ~c"" sigil so we need to correct columns
+    # on elixir 1.15+ formatter changes charlist '' to ~c"" sigil so we need to correct columns
     # if charlist is single line
     correction =
-      if end_line == line do
+      if end_line == line and Version.match?(System.version(), ">= 1.15.0-dev") do
         2
       else
         0

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -361,11 +361,14 @@ defmodule ElixirLS.LanguageServer.AstUtils do
     # TODO pass line_length to format
     # TODO locals_without_parens to quoted_to_algebra
     # TODO pass comments to quoted_to_algebra
-    code =
+    code = if Version.match?(System.version(), ">= 1.13.0-dev") do
       ast
       |> Code.quoted_to_algebra(escape: false)
       |> Inspect.Algebra.format(:infinity)
       |> IO.iodata_to_binary()
+    else
+      Macro.to_string(ast)
+    end
 
     lines = code |> SourceFile.lines()
 

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -161,6 +161,17 @@ defmodule ElixirLS.LanguageServer.AstUtils do
           match?({:., _, [Kernel, :to_string]}, form) ->
             {line, column}
 
+          match?({:., _, [Access, :get]}, form) and match?([_ | _], args) ->
+            [arg | _] = args
+
+            case node_range(arg) do
+              range(line, column, _, _) ->
+                {line, column}
+
+              nil ->
+                nil
+            end
+
           match?({:., _, [_ | _]}, form) ->
             {:., _, [module_or_var | _]} = form
 
@@ -257,7 +268,6 @@ defmodule ElixirLS.LanguageServer.AstUtils do
             case args do
               [] ->
                 {:., _, [_, fun]} = form
-                # TODO handle quotes
                 {line, column + String.length(to_string(fun))}
 
               _ ->

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -6,20 +6,26 @@ defmodule ElixirLS.LanguageServer.AstUtils do
   @unary_operators ~w[@ + - ! ^ not &]a
 
   def node_range(atom) when is_atom(atom), do: nil
+
   def node_range([{{:__block__, _, [atom]} = first, _} | _] = list) when is_atom(atom) do
     case List.last(list) do
       {_, last} ->
         case {node_range(first), node_range(last)} do
           {range(start_line, start_character, _, _), range(_, _, end_line, end_character)} ->
             range(start_line, start_character, end_line, end_character)
-          _ -> nil
-          end
-      _ -> nil
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
     end
   end
+
   def node_range(list) when is_list(list), do: nil
 
-  def node_range({:__block__, meta, args} = ast) do
+  def node_range({:__block__, meta, args} = _ast) do
     line = Keyword.get(meta, :line)
     column = Keyword.get(meta, :column)
 
@@ -31,68 +37,73 @@ defmodule ElixirLS.LanguageServer.AstUtils do
         case {node_range(first), node_range(last)} do
           {range(start_line, start_character, _, _), range(_, _, end_line, end_character)} ->
             range(start_line, start_character, end_line, end_character)
-          _ -> nil
+
+          _ ->
+            nil
         end
       end
     else
       line = line - 1
       column = column - 1
 
-      {end_line, end_column} = cond do
-        token = meta[:token] ->
-          {line, column + String.length(token)}
-        end_location = meta[:closing] ->
-          # 2 element tuple
-          {end_location[:line] - 1, end_location[:column] - 1 + 1}
-        match?([_], args) ->
-          [literal] = args
-          delimiter = meta[:delimiter]
-          if delimiter in ["\"\"\"", "'''"] do
-            literal = if is_list(literal) do
-              to_string(literal)
+      {end_line, end_column} =
+        cond do
+          token = meta[:token] ->
+            {line, column + String.length(token)}
+
+          end_location = meta[:closing] ->
+            # 2 element tuple
+            {end_location[:line] - 1, end_location[:column] - 1 + 1}
+
+          match?([_], args) ->
+            [literal] = args
+            delimiter = meta[:delimiter]
+
+            if delimiter in ["\"\"\"", "'''"] do
+              literal =
+                if is_list(literal) do
+                  to_string(literal)
+                else
+                  literal
+                end
+
+              lines = SourceFile.lines(literal)
+              {line + length(lines), meta[:indentation] + get_delimiter_length(delimiter)}
             else
-              literal
+              get_literal_end(literal, {line, column}, delimiter)
             end
-            lines = SourceFile.lines(literal)
-            {line + length(lines), meta[:indentation] + get_delimiter_length(delimiter)}
-          else
-            get_literal_end(literal, {line, column}, delimiter)
-          end
-          
-        true ->
-          {line, column}
-      end
+
+          true ->
+            {line, column}
+        end
 
       range(line, column, end_line, end_column)
     end
   end
 
-  # def node_range({left, right}) do
-  #   case {node_range(left), node_range(right)} do
-  #     {range(start_line, start_column, _, _), range(_, _, end_line, end_column)} ->
-  #       range(start_line, start_column, end_line, end_column)
-  #     _ -> nil
-  #   end
-  # end
-  # def node_range([node]) do
-  #   node_range(node)
-  # end
-
-  # def node_range()
-
   # interpolated charlist AST is too complicated to handle via the generic algorithm
-  def node_range({{:".", _, [List, :to_charlist]}, meta, _args} = ast) do
+  def node_range({{:., _, [List, :to_charlist]}, meta, _args} = ast) do
     line = Keyword.get(meta, :line) - 1
     column = Keyword.get(meta, :column) - 1
     {end_line, end_column} = get_eoe_by_formatting(ast, {line, column})
     # formatter changes charlist '' to ~c"" sigil so we need to correct columns
     # if charlist is single line
-    correction = if end_line == line do
-      2
-    else
-      0
-    end
+    correction =
+      if end_line == line do
+        2
+      else
+        0
+      end
+
     range(line, column, end_line, end_column - correction)
+  end
+
+  # interpolated atom AST is too complicated to handle via the generic algorithm
+  def node_range({{:., _, [:erlang, :binary_to_atom]}, meta, _args} = ast) do
+    line = Keyword.get(meta, :line) - 1
+    column = Keyword.get(meta, :column) - 1
+    {end_line, end_column} = get_eoe_by_formatting(ast, {line, column})
+    range(line, column, end_line, end_column)
   end
 
   def node_range({form, meta, args} = ast) do
@@ -105,158 +116,177 @@ defmodule ElixirLS.LanguageServer.AstUtils do
       line = line - 1
       column = column - 1
 
-      dbg({line, column})
+      {start_line, start_column} =
+        cond do
+          form == :%{} ->
+            # TODO elixir parser bug?
+            {line, column - 1}
 
-      {start_line, start_column} = cond do
-        form == :"%{}" ->
-          # TODO elixir parser bug?
-          {line, column - 1}
-        form == :-> and match?([[_|_], _], args) ->
-          [[left | _], _right] = args
-          operator_length = form |> to_string() |> String.length()
-          case node_range(left) do
-            range(line, column, _, _) ->
-              {line, column}
-            nil ->
-              # TODO is it needed
-              {line, column}
-          end
-        form == :"&" and match?([int] when is_integer(int), args) ->
-          [int] = args
-          {line, column}
-        form in @binary_operators and match?([_, _], args) ->
-          [left, _right] = args
-          operator_length = form |> to_string() |> String.length()
-          
-          case node_range(left) do
-            range(line, column, _, _) ->
-              {line, column}
-            nil ->
-              # TODO is it needed
-              {line, column}
-          end
-        match?({:., _, [_ | _]}, form) ->
-          {:., _, [module_or_var | _]} = form
-          case node_range(module_or_var) do
-            range(line, column, _, _) ->
-              {line, column}
-            nil ->
-              # TODO is it needed
-              {line, column}
-          end
-          |> dbg
-        true -> {line, column}
-      end
+          form == :-> and match?([[_ | _], _], args) ->
+            [[left | _], _right] = args
 
-      {end_line, end_column} = cond do
-        end_location = meta[:end] ->
-          {end_location[:line] - 1, end_location[:column] - 1 + 3}
+            case node_range(left) do
+              range(line, column, _, _) ->
+                {line, column}
 
-        end_location = meta[:end_of_expression] ->
-          {end_location[:line] - 1, end_location[:column] - 1}
-
-        end_location = meta[:closing] ->
-          closing_length =
-            case form do
-              :<<>> -> 2
-              :fn -> 3
-              _ -> 1
+              nil ->
+                # TODO is it needed
+                {line, column}
             end
 
-          {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
+          form == :& and match?([int] when is_integer(int), args) ->
+            {line, column}
 
-        form == :__aliases__ ->
-          last = meta[:last]
+          form in @binary_operators and match?([_, _], args) ->
+            [left, _right] = args
 
-          last_length =
-            case List.last(args) do
-              atom when is_atom(atom) -> atom |> to_string() |> String.length()
-              _ -> 0
+            case node_range(left) do
+              range(line, column, _, _) ->
+                {line, column}
+
+              nil ->
+                # TODO is it needed
+                {line, column}
             end
 
-          {last[:line] - 1, last[:column] - 1 + last_length}
+          match?({:., _, [_ | _]}, form) ->
+            {:., _, [module_or_var | _]} = form
 
-        form == :"%" and match?([_, _], args) ->
-          [_alias, map] = args
-          case node_range(map) do
-            range(_, _, end_line, end_column) ->
-              {end_line, end_column}
-            nil ->
-              # TODO is it needed
-              {line, column}
-          end
+            case node_range(module_or_var) do
+              range(line, column, _, _) ->
+                {line, column}
 
-        form == :"<<>>" or is_atom(form) and String.starts_with?(to_string(form), "sigil_") ->
-          # interpolated string AST is too complicated
-          # try to format it instead
-          get_eoe_by_formatting(ast, {line, column})
+              nil ->
+                # TODO is it needed
+                {line, column}
+            end
 
-        form == :"&" and match?([int] when is_integer(int), args) ->
-          [int] = args
-          {line, column + String.length(to_string(int))}
-        form in @binary_operators and match?([_, _], args) ->
-          [left, right] = args
-          operator_length = form |> to_string() |> String.length()
-          case node_range(right) do
-            range(_, _, end_line, end_column) ->
-              {end_line, end_column}
-            nil ->
-              # TODO is it needed
-              {line, column + operator_length}
-          end
+          true ->
+            {line, column}
+        end
 
-        form in @unary_operators and match?([_], args) ->
-          [right] = args
-          operator_length = form |> to_string() |> String.length()
-          case node_range(right) do
-            range(_, _, end_line, end_column) ->
-              {end_line, end_column}
-            nil ->
-              # TODO is it needed
-              {line, column + operator_length}
-          end
+      {end_line, end_column} =
+        cond do
+          end_location = meta[:end] ->
+            {end_location[:line] - 1, end_location[:column] - 1 + 3}
 
-        match?({:., _, [_, _ ]}, form) ->
-          case args do
-            [] ->
-              {:., _, [_, fun]} = form
-              # TODO handle quotes
-              {line, column + String.length(to_string(fun))}
-            _ ->
-              case node_range(List.last(args)) do
-                range(_, _, end_line, end_column) ->
-                  {end_line, end_column}
-                nil ->
-                  # TODO is it needed
-                  nil
-                  # {line, column + operator_length}
+          end_location = meta[:end_of_expression] ->
+            {end_location[:line] - 1, end_location[:column] - 1}
+
+          end_location = meta[:closing] ->
+            closing_length =
+              case form do
+                :<<>> -> 2
+                :fn -> 3
+                _ -> 1
               end
-          end
-          |> dbg
 
-        is_atom(form) ->
-          variable_length = form |> to_string() |> String.length()
-          case args do
-            nil ->
-              {line, column + variable_length}
-            [] -> 
-              {line, column + variable_length}
-            _ ->
-              # local call no parens
-              last_arg = List.last(args)
-              case node_range(last_arg |> dbg) |> dbg do
-                range(_, _, end_line, end_column) ->
-                  {end_line, end_column}
-                nil ->
-                  # TODO is it needed
-                  {line, column + variable_length}
+            {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
+
+          form == :__aliases__ ->
+            last = meta[:last]
+
+            last_length =
+              case List.last(args) do
+                atom when is_atom(atom) -> atom |> to_string() |> String.length()
+                _ -> 0
               end
-          end
-          
 
-        true ->
-          raise "unhandled block"
-      end
+            {last[:line] - 1, last[:column] - 1 + last_length}
+
+          form == :% and match?([_, _], args) ->
+            [_alias, map] = args
+
+            case node_range(map) do
+              range(_, _, end_line, end_column) ->
+                {end_line, end_column}
+
+              nil ->
+                # TODO is it needed
+                {line, column}
+            end
+
+          form == :<<>> or (is_atom(form) and String.starts_with?(to_string(form), "sigil_")) ->
+            # interpolated string AST is too complicated
+            # try to format it instead
+            get_eoe_by_formatting(ast, {line, column})
+
+          form == :& and match?([int] when is_integer(int), args) ->
+            [int] = args
+            {line, column + String.length(to_string(int))}
+
+          form in @binary_operators and match?([_, _], args) ->
+            [_left, right] = args
+            operator_length = form |> to_string() |> String.length()
+
+            case node_range(right) do
+              range(_, _, end_line, end_column) ->
+                {end_line, end_column}
+
+              nil ->
+                # TODO is it needed
+                {line, column + operator_length}
+            end
+
+          form in @unary_operators and match?([_], args) ->
+            [right] = args
+            operator_length = form |> to_string() |> String.length()
+
+            case node_range(right) do
+              range(_, _, end_line, end_column) ->
+                {end_line, end_column}
+
+              nil ->
+                # TODO is it needed
+                {line, column + operator_length}
+            end
+
+          match?({:., _, [_, _]}, form) ->
+            case args do
+              [] ->
+                {:., _, [_, fun]} = form
+                # TODO handle quotes
+                {line, column + String.length(to_string(fun))}
+
+              _ ->
+                case node_range(List.last(args)) do
+                  range(_, _, end_line, end_column) ->
+                    {end_line, end_column}
+
+                  nil ->
+                    # TODO is it needed
+                    nil
+                    # {line, column + operator_length}
+                end
+            end
+
+          is_atom(form) ->
+            variable_length = form |> to_string() |> String.length()
+
+            case args do
+              nil ->
+                {line, column + variable_length}
+
+              [] ->
+                {line, column + variable_length}
+
+              _ ->
+                # local call no parens
+                last_arg = List.last(args)
+
+                case node_range(last_arg) do
+                  range(_, _, end_line, end_column) ->
+                    {end_line, end_column}
+
+                  nil ->
+                    # TODO is it needed
+                    {line, column + variable_length}
+                end
+            end
+
+          true ->
+            raise "unhandled block"
+        end
 
       range(start_line, start_column, end_line, end_column)
     end
@@ -265,41 +295,50 @@ defmodule ElixirLS.LanguageServer.AstUtils do
   def get_literal_end(true, {line, column}, _), do: {line, column + 4}
   def get_literal_end(false, {line, column}, _), do: {line, column + 5}
   def get_literal_end(nil, {line, column}, _), do: {line, column + 3}
+
   def get_literal_end(atom, {line, column}, delimiter) when is_atom(atom) do
     delimiter_length = get_delimiter_length(delimiter)
-    lines = atom |> to_string() |> SourceFile.lines
+    lines = atom |> to_string() |> SourceFile.lines()
+
     case lines do
       [only_line] ->
         # add :
         {line, column + String.length(only_line) + 1 + 2 * delimiter_length}
+
       _ ->
-        last_line_length = lines |> List.last |> String.length
+        last_line_length = lines |> List.last() |> String.length()
         {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
     end
   end
+
   def get_literal_end(list, {line, column}, delimiter) when is_list(list) do
     delimiter_length = get_delimiter_length(delimiter)
-    lines = list |> to_string() |> SourceFile.lines
+    lines = list |> to_string() |> SourceFile.lines()
+
     case lines do
       [only_line] ->
         # add 2 x '
         {line, column + String.length(only_line) + 2 * delimiter_length}
+
       _ ->
         # add 1 x '
-        last_line_length = lines |> List.last |> String.length
+        last_line_length = lines |> List.last() |> String.length()
         {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
     end
   end
+
   def get_literal_end(binary, {line, column}, delimiter) when is_binary(binary) do
     delimiter_length = get_delimiter_length(delimiter)
-    lines = binary |> SourceFile.lines
+    lines = binary |> SourceFile.lines()
+
     case lines do
       [only_line] ->
         # add 2 x "
         {line, column + String.length(only_line) + 2 * delimiter_length}
+
       _ ->
         # add 1 x "
-        last_line_length = lines |> List.last |> String.length
+        last_line_length = lines |> List.last() |> String.length()
         {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
     end
   end
@@ -311,10 +350,21 @@ defmodule ElixirLS.LanguageServer.AstUtils do
   def get_delimiter_length("'''"), do: 3
 
   defp get_eoe_by_formatting(ast, {line, column}) do
-    code = ast |> Code.quoted_to_algebra |> Inspect.Algebra.format(:infinity) |> IO.iodata_to_binary() |> dbg
+    # TODO pass line_length to format
+    # TODO locals_without_parens to quoted_to_algebra
+    # TODO pass comments to quoted_to_algebra
+    code =
+      ast
+      |> Code.quoted_to_algebra(escape: false)
+      |> Inspect.Algebra.format(:infinity)
+      |> IO.iodata_to_binary()
+
     lines = code |> SourceFile.lines()
+
     case lines do
-      [_] -> {line, column + String.length(code)}
+      [_] ->
+        {line, column + String.length(code)}
+
       _ ->
         last_line = List.last(lines)
         {line + length(lines) - 1, String.length(last_line)}

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -1,0 +1,302 @@
+defmodule ElixirLS.LanguageServer.AstUtils do
+  import ElixirLS.LanguageServer.Protocol
+  alias ElixirLS.LanguageServer.SourceFile
+
+  @binary_operators ~w[. ** * / + - ++ -- +++ --- .. <> in |> <<< >>> <<~ ~>> <~ ~> <~> < > <= >= == != === !== =~ && &&& and || ||| or = => :: when <- -> \\]a
+  @unary_operators ~w[@ + - ! ^ not &]a
+
+  def node_range(atom) when is_atom(atom), do: nil
+  def node_range(list) when is_list(list), do: nil
+
+  def node_range({:__block__, meta, args} = ast) do
+    line = Keyword.get(meta, :line)
+    column = Keyword.get(meta, :column)
+
+    if line == nil or column == nil do
+      if match?([_ | _], args) do
+        first = List.first(args)
+        last = List.last(args)
+
+        case {node_range(first), node_range(last)} do
+          {range(start_line, start_character, _, _), range(_, _, end_line, end_character)} ->
+            range(start_line, start_character, end_line, end_character)
+          _ -> nil
+        end
+      end
+    else
+      line = line - 1
+      column = column - 1
+
+      {end_line, end_column} = cond do
+        token = meta[:token] ->
+          {line, column + String.length(token)}
+        end_location = meta[:closing] ->
+          # 2 element tuple
+          {end_location[:line] - 1, end_location[:column] - 1 + 1}
+        match?([_], args) ->
+          [literal] = args
+          delimiter = meta[:delimiter]
+          if delimiter in ["\"\"\"", "'''"] do
+            literal = if is_list(literal) do
+              to_string(literal)
+            else
+              literal
+            end
+            lines = SourceFile.lines(literal)
+            {line + length(lines), meta[:indentation] + get_delimiter_length(delimiter)}
+          else
+            get_literal_end(literal, {line, column}, delimiter)
+          end
+          
+        true ->
+          {line, column}
+      end
+
+      range(line, column, end_line, end_column)
+    end
+  end
+
+  # def node_range({left, right}) do
+  #   case {node_range(left), node_range(right)} do
+  #     {range(start_line, start_column, _, _), range(_, _, end_line, end_column)} ->
+  #       range(start_line, start_column, end_line, end_column)
+  #     _ -> nil
+  #   end
+  # end
+  # def node_range([node]) do
+  #   node_range(node)
+  # end
+
+  # def node_range()
+
+  # interpolated charlist AST is too complicated to handle via the generic algorithm
+  def node_range({{:".", _, [List, :to_charlist]}, meta, _args} = ast) do
+    line = Keyword.get(meta, :line) - 1
+    column = Keyword.get(meta, :column) - 1
+    {end_line, end_column} = get_eoe_by_formatting(ast, {line, column})
+    # formatter changes charlist '' to ~c"" sigil so we need to correct columns
+    # if charlist is single line
+    correction = if end_line == line do
+      2
+    else
+      0
+    end
+    range(line, column, end_line, end_column - correction)
+  end
+
+  def node_range({form, meta, args} = ast) do
+    line = Keyword.get(meta, :line)
+    column = Keyword.get(meta, :column)
+
+    if line == nil or column == nil do
+      nil
+    else
+      line = line - 1
+      column = column - 1
+
+      dbg({line, column})
+
+      {start_line, start_column} = cond do
+        form == :"%{}" ->
+          # TODO elixir parser bug?
+          {line, column - 1}
+        form == :-> and match?([[_|_], _], args) ->
+          [[left | _], _right] = args
+          operator_length = form |> to_string() |> String.length()
+          case node_range(left) do
+            range(line, column, _, _) ->
+              {line, column}
+            nil ->
+              # TODO is it needed
+              {line, column}
+          end
+        form in @binary_operators and match?([_, _], args) ->
+          [left, _right] = args
+          operator_length = form |> to_string() |> String.length()
+          case node_range(left) do
+            range(line, column, _, _) ->
+              {line, column}
+            nil ->
+              # TODO is it needed
+              {line, column}
+          end
+        match?({:., _, [_ | _]}, form) ->
+          {:., _, [module_or_var | _]} = form
+          case node_range(module_or_var) do
+            range(line, column, _, _) ->
+              {line, column}
+            nil ->
+              # TODO is it needed
+              {line, column}
+          end
+          |> dbg
+        true -> {line, column}
+      end
+
+      {end_line, end_column} = cond do
+        end_location = meta[:end] ->
+          {end_location[:line] - 1, end_location[:column] - 1 + 3}
+
+        end_location = meta[:end_of_expression] ->
+          {end_location[:line] - 1, end_location[:column] - 1}
+
+        end_location = meta[:closing] ->
+          closing_length =
+            case form do
+              :<<>> -> 2
+              _ -> 1
+            end
+
+          {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
+
+        form == :__aliases__ ->
+          last = meta[:last]
+
+          last_length =
+            case List.last(args) do
+              atom when is_atom(atom) -> atom |> to_string() |> String.length()
+              _ -> 0
+            end
+
+          {last[:line] - 1, last[:column] - 1 + last_length}
+
+        form == :"%" and match?([_, _], args) ->
+          [_alias, map] = args
+          case node_range(map) do
+            range(_, _, end_line, end_column) ->
+              {end_line, end_column}
+            nil ->
+              # TODO is it needed
+              {line, column}
+          end
+
+        form == :"<<>>" or is_atom(form) and String.starts_with?(to_string(form), "sigil_") ->
+          # interpolated string AST is too complicated
+          # try to format it instead
+          get_eoe_by_formatting(ast, {line, column})
+
+        form in @binary_operators and match?([_, _], args) ->
+          [left, right] = args
+          operator_length = form |> to_string() |> String.length()
+          case node_range(right) do
+            range(_, _, end_line, end_column) ->
+              {end_line, end_column}
+            nil ->
+              # TODO is it needed
+              {line, column + operator_length}
+          end
+
+        form in @unary_operators and match?([_], args) ->
+          [right] = args
+          operator_length = form |> to_string() |> String.length()
+          case node_range(right) do
+            range(_, _, end_line, end_column) ->
+              {end_line, end_column}
+            nil ->
+              # TODO is it needed
+              {line, column + operator_length}
+          end
+
+        match?({:., _, [_, _ ]}, form) ->
+          case args do
+            [] ->
+              {:., _, [_, fun]} = form
+              # TODO handle quotes
+              {line, column + String.length(to_string(fun))}
+            _ ->
+              case node_range(List.last(args)) do
+                range(_, _, end_line, end_column) ->
+                  {end_line, end_column}
+                nil ->
+                  # TODO is it needed
+              end
+          end
+          |> dbg
+
+        is_atom(form) ->
+          variable_length = form |> to_string() |> String.length()
+          case args do
+            nil ->
+              {line, column + variable_length}
+            [] -> 
+              {line, column + variable_length}
+            _ ->
+              # local call no parens
+              last_arg = List.last(args)
+              case node_range(last_arg) do
+                range(_, _, end_line, end_column) ->
+                  {end_line, end_column}
+                nil ->
+                  # TODO is it needed
+                  {line, column + variable_length}
+              end
+          end
+          
+
+        true ->
+          raise "unhandled block"
+      end
+
+      range(start_line, start_column, end_line, end_column)
+    end
+  end
+
+  def get_literal_end(true, {line, column}, _), do: {line, column + 4}
+  def get_literal_end(false, {line, column}, _), do: {line, column + 5}
+  def get_literal_end(nil, {line, column}, _), do: {line, column + 3}
+  def get_literal_end(atom, {line, column}, delimiter) when is_atom(atom) do
+    delimiter_length = get_delimiter_length(delimiter)
+    lines = atom |> to_string() |> SourceFile.lines
+    case lines do
+      [only_line] ->
+        # add :
+        {line, column + String.length(only_line) + 1 + 2 * delimiter_length}
+      _ ->
+        last_line_length = lines |> List.last |> String.length
+        {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
+    end
+  end
+  def get_literal_end(list, {line, column}, delimiter) when is_list(list) do
+    delimiter_length = get_delimiter_length(delimiter)
+    lines = list |> to_string() |> SourceFile.lines
+    case lines do
+      [only_line] ->
+        # add 2 x '
+        {line, column + String.length(only_line) + 2 * delimiter_length}
+      _ ->
+        # add 1 x '
+        last_line_length = lines |> List.last |> String.length
+        {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
+    end
+  end
+  def get_literal_end(binary, {line, column}, delimiter) when is_binary(binary) do
+    delimiter_length = get_delimiter_length(delimiter)
+    lines = binary |> SourceFile.lines
+    case lines do
+      [only_line] ->
+        # add 2 x "
+        {line, column + String.length(only_line) + 2 * delimiter_length}
+      _ ->
+        # add 1 x "
+        last_line_length = lines |> List.last |> String.length
+        {line + length(lines) - 1, last_line_length + 1 * delimiter_length}
+    end
+  end
+
+  def get_delimiter_length(nil), do: 0
+  def get_delimiter_length("\""), do: 1
+  def get_delimiter_length("'"), do: 1
+  def get_delimiter_length("\"\"\""), do: 3
+  def get_delimiter_length("'''"), do: 3
+
+  defp get_eoe_by_formatting(ast, {line, column}) do
+    code = ast |> Code.quoted_to_algebra |> Inspect.Algebra.format(:infinity) |> IO.iodata_to_binary() |> dbg
+    lines = code |> SourceFile.lines()
+    case lines do
+      [_] -> {line, column + String.length(code)}
+      _ ->
+        last_line = List.last(lines)
+        {line + length(lines) - 1, String.length(last_line)}
+    end
+  end
+end

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -119,8 +119,16 @@ defmodule ElixirLS.LanguageServer.AstUtils do
       {start_line, start_column} =
         cond do
           form == :%{} ->
-            # TODO elixir parser bug?
-            {line, column - 1}
+            column =
+              if Version.match?(System.version(), "< 1.16.2") do
+                # workaround elixir bug
+                # https://github.com/elixir-lang/elixir/commit/fd4e6b530c0e010712b06909c89820b08e49c238
+                column - 1
+              else
+                column
+              end
+
+            {line, column}
 
           form == :-> and match?([[_ | _], _], args) ->
             [[left | _], _right] = args

--- a/apps/language_server/lib/language_server/ast_utils.ex
+++ b/apps/language_server/lib/language_server/ast_utils.ex
@@ -300,6 +300,8 @@ defmodule ElixirLS.LanguageServer.AstUtils do
     end
   end
 
+  def node_range(_), do: nil
+
   def get_literal_end(true, {line, column}, _), do: {line, column + 4}
   def get_literal_end(false, {line, column}, _), do: {line, column + 5}
   def get_literal_end(nil, {line, column}, _), do: {line, column + 3}
@@ -361,14 +363,15 @@ defmodule ElixirLS.LanguageServer.AstUtils do
     # TODO pass line_length to format
     # TODO locals_without_parens to quoted_to_algebra
     # TODO pass comments to quoted_to_algebra
-    code = if Version.match?(System.version(), ">= 1.13.0-dev") do
-      ast
-      |> Code.quoted_to_algebra(escape: false)
-      |> Inspect.Algebra.format(:infinity)
-      |> IO.iodata_to_binary()
-    else
-      Macro.to_string(ast)
-    end
+    code =
+      if Version.match?(System.version(), ">= 1.13.0-dev") do
+        ast
+        |> Code.quoted_to_algebra(escape: false)
+        |> Inspect.Algebra.format(:infinity)
+        |> IO.iodata_to_binary()
+      else
+        Macro.to_string(ast)
+      end
 
     lines = code |> SourceFile.lines()
 

--- a/apps/language_server/lib/language_server/protocol.ex
+++ b/apps/language_server/lib/language_server/protocol.ex
@@ -181,6 +181,15 @@ defmodule ElixirLS.LanguageServer.Protocol do
     end
   end
 
+  defmacro selection_range_req(id, uri, positions) do
+    quote do
+      request(unquote(id), "textDocument/selectionRange", %{
+        "textDocument" => %{"uri" => unquote(uri)},
+        "positions" => unquote(positions)
+      })
+    end
+  end
+
   defmacro execute_command_req(id, command, arguments) do
     quote do
       request(unquote(id), "workspace/executeCommand", %{

--- a/apps/language_server/lib/language_server/providers/folding_range/comment_block.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/comment_block.ex
@@ -38,13 +38,14 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.CommentBlock do
     ranges =
       lines
       |> group_comments()
+      |> Enum.filter(fn group -> length(group) > 1 end)
       |> Enum.map(&convert_comment_group_to_range/1)
 
     {:ok, ranges}
   end
 
   @spec group_comments([Line.t()]) :: [[{Line.cell(), String.t()}]]
-  defp group_comments(lines) do
+  def group_comments(lines) do
     lines
     |> Enum.reduce([[]], fn
       {_, cell, "#"}, [[{_, "#"} | _] = head | tail] ->
@@ -59,7 +60,6 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.CommentBlock do
       _, acc ->
         acc
     end)
-    |> Enum.filter(fn group -> length(group) > 1 end)
   end
 
   @spec convert_comment_group_to_range([[{Line.cell(), String.t()}]]) :: FoldingRange.t()

--- a/apps/language_server/lib/language_server/providers/folding_range/indentation.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/indentation.ex
@@ -53,7 +53,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.Indentation do
     {:ok, ranges}
   end
 
-  defp extract_cell({_line, cell, _first}), do: cell
+  def extract_cell({_line, cell, _first}), do: cell
 
   @doc """
   Pairs cells into {start, end} tuples of regions

--- a/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/special_token.ex
@@ -63,9 +63,8 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
   defp do_group_tokens([], acc), do: acc
 
   # Don't create folding ranges for @doc false
-  # TODO why?
   defp do_group_tokens(
-         [{:at_op, _, _}, {:identifier, _, doc_identifier}, {false, _, _} | rest] = tokens,
+         [{:at_op, _, _}, {:identifier, _, doc_identifier}, {false, _, _} | rest],
          acc
        )
        when doc_identifier in @docs do
@@ -74,7 +73,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.SpecialToken do
 
   # Start a folding range for `@doc` and `@moduledoc`
   defp do_group_tokens(
-         [{:at_op, _, _} = at_op, {:identifier, _, doc_identifier} = token | rest] = tokens,
+         [{:at_op, _, _} = at_op, {:identifier, _, doc_identifier} = token | rest],
          acc
        )
        when doc_identifier in @docs do

--- a/apps/language_server/lib/language_server/providers/folding_range/token_pairs.ex
+++ b/apps/language_server/lib/language_server/providers/folding_range/token_pairs.ex
@@ -58,7 +58,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.TokenPair do
   end
 
   @spec pair_tokens([Token.t()]) :: [{Token.t(), Token.t()}]
-  defp pair_tokens(tokens) do
+  def pair_tokens(tokens) do
     do_pair_tokens(tokens, [], [])
   end
 
@@ -82,8 +82,8 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRange.TokenPair do
          pairs
        ) do
     head_matches_any? = @token_pairs |> Map.has_key?(head_kind)
-    # Map.get/2 will always succeed because we only push matches to the stack.
-    head_matches_top? = @token_pairs |> Map.get(top_kind) |> Enum.member?(head_kind)
+    # Map.fetch!/2 will always succeed because we only push matches to the stack.
+    head_matches_top? = @token_pairs |> Map.fetch!(top_kind) |> Enum.member?(head_kind)
 
     {new_stack, new_pairs} =
       case {head_matches_any?, head_matches_top?} do

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -427,8 +427,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
         token_pairs
         |> Enum.filter(fn {{_, {start_line, start_character, _}, _},
                            {_, {end_line, end_character, _}, _}} ->
-          (start_line < line or (start_line == line and start_character <= character)) and
-            (end_line > line or (end_line == line and end_character >= character))
+          in?(range(start_line, start_character, end_line, end_character), {line, character})
         end)
         |> Enum.min_by(
           fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character, _}, _}} ->

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -3,9 +3,21 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   This module provides document/selectionRanges support
 
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange
+
+  There is no one good way to get selection ranges that is bot robust and accurate. This module uses a combination of
+  different approaches. Each produces different ranges (possibly contradictory) that are finally merged and combined
+
+  Algorithms providers currently used:
+  1. Token pairs (), [], do-end etc. with stop tokens , ; eol eof |
+  2. Special token groups (regular/charlist strings/heredocs) and sigils
+  3. Comment blocks
+  4. Code.Fragment.surround_context
+  5. AST
+
+  First 3 algorithms reuse passes from folding ranges provider with some modifications
   """
 
-  alias ElixirLS.LanguageServer.{SourceFile}
+  alias ElixirLS.LanguageServer.SourceFile
   alias ElixirLS.LanguageServer.Providers.FoldingRange
   import ElixirLS.LanguageServer.Protocol
   import ElixirLS.LanguageServer.RangeUtils

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -16,22 +16,18 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   defp token_length(token) when token in [:"<<", :">>", :do, :fn], do: 2
   defp token_length(_), do: 0
 
-  # TODO =>
+  # TODO => |
   @stop_tokens [:",", :";", :eol]
-
-  @binary_operators ~w[. ** * / + - ++ -- +++ --- .. <> in |> <<< >>> <<~ ~>> <~ ~> <~> < > <= >= == != === !== =~ && &&& and || ||| or = => :: when <- -> \\]a
-  @unary_operators ~w[@ + - ! ^ not &]a
-  @unary_and_binary_operators ~w[+ -]a
 
   def selection_ranges(text, positions) do
     lines = SourceFile.lines(text)
     full_file_range = full_range(lines)
 
-    tokens = FoldingRange.Token.format_string(text) |> dbg(limit: :infinity)
+    tokens = FoldingRange.Token.format_string(text)
 
-    token_pairs = FoldingRange.TokenPair.pair_tokens(tokens) |> dbg
+    token_pairs = FoldingRange.TokenPair.pair_tokens(tokens)
 
-    stop_tokens = get_stop_tokens_in_token_pairs(tokens, token_pairs) |> dbg
+    stop_tokens = get_stop_tokens_in_token_pairs(tokens, token_pairs)
 
     special_token_groups =
       for group <- FoldingRange.SpecialToken.group_tokens(tokens) do
@@ -52,7 +48,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
         literal_encoder: fn literal, meta ->
           {:ok, {:__block__, meta, [literal]}}
         end
-      ) |> dbg
+      )
 
     cell_pairs =
       formatted_lines
@@ -66,8 +62,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
 
       cell_pair_ranges = cell_pair_ranges(lines, cell_pairs, line, character)
 
-      token_pair_ranges = token_pair_ranges(lines, token_pairs, stop_tokens, line, character)
-      |> deduplicate
+      token_pair_ranges =
+        token_pair_ranges(lines, token_pairs, stop_tokens, line, character)
+        |> deduplicate
 
       special_token_group_ranges =
         special_token_group_ranges(special_token_groups, line, character)
@@ -79,12 +76,12 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
       surround_context_ranges = surround_context_ranges(text, line, character)
 
       merged_ranges =
-        [full_file_range | token_pair_ranges] |> dbg
-        |> merge_ranges_lists([full_file_range | cell_pair_ranges] |> dbg)
-        |> merge_ranges_lists([full_file_range | special_token_group_ranges] |> dbg)
-        |> merge_ranges_lists([full_file_range | comment_block_ranges] |> dbg)
-        |> merge_ranges_lists([full_file_range | surround_context_ranges] |> dbg)
-        |> merge_ranges_lists([full_file_range | ast_node_ranges] |> dbg)
+        [full_file_range | token_pair_ranges]
+        |> merge_ranges_lists([full_file_range | cell_pair_ranges])
+        |> merge_ranges_lists([full_file_range | special_token_group_ranges])
+        |> merge_ranges_lists([full_file_range | comment_block_ranges])
+        |> merge_ranges_lists([full_file_range | surround_context_ranges])
+        |> merge_ranges_lists([full_file_range | ast_node_ranges])
 
       if not increasingly_narrowing?(merged_ranges) do
         raise "merged_ranges are not increasingly narrowing"
@@ -143,7 +140,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
     |> Enum.reduce([], fn {{start_token, {start_line, start_character, _}, _},
                            {end_token, {end_line, end_character, _}, _}} = pair,
                           acc ->
-      stop_tokens_in_pair = Map.get(stop_tokens, pair, []) |> dbg
+      stop_tokens_in_pair = Map.get(stop_tokens, pair, [])
       start_token_length = token_length(start_token)
       end_token_length = token_length(end_token)
 
@@ -160,8 +157,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
           else
             line_length = lines |> Enum.at(end_line - 1) |> String.length()
             inner_range = range(start_line + 1, 0, end_line - 1, line_length)
+
             find_stop_token_range(stop_tokens_in_pair, pair, inner_range, line, character) ++
-            [inner_range, outer_range | acc]
+              [inner_range, outer_range | acc]
           end
 
         _ ->
@@ -172,17 +170,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
             # ^        ^
             [outer_range | acc]
           else
-            inner_range = range(
-              start_line,
-              start_character + start_token_length,
-              end_line,
-              end_character
-            )
+            inner_range =
+              range(
+                start_line,
+                start_character + start_token_length,
+                end_line,
+                end_character
+              )
+
             find_stop_token_range(stop_tokens_in_pair, pair, inner_range, line, character) ++
-            [
-              inner_range,
-              outer_range | acc
-            ]
+              [
+                inner_range,
+                outer_range | acc
+              ]
           end
       end
     end)
@@ -190,42 +190,66 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   end
 
   defp find_stop_token_range([], _, _, _, _), do: []
+
   defp find_stop_token_range(tokens, {begin_token, end_token}, inner_range, line, character) do
-    {_, found} = Enum.reduce_while(tokens ++ [{end_token, nil, nil}], {{begin_token, nil, nil}, []}, fn
-      {token, before_stop, _} = token_tuple, {{previous_token, _, after_previous}, _} ->
-        {_, {start_line, start_character, _}, _} = previous_token
-        {_, {end_line, end_character, _}, _} = token
-        if (start_line < line or start_line == line and start_character <= character) and (end_line > line or end_line == line and end_character >= character) do
-          dbg({previous_token, after_previous, before_stop, token})
-          {end_line, end_character} = case before_stop do
-            {kind, _, _} when kind in [:bin_string, :list_string] ->
-              {end_line, end_character}
-            {kind, {before_start_line, before_start_character, list}, _} when is_list(list) ->
-              length_modifier = if kind == :atom do
-                1
-              else
-                0
+    {_, found} =
+      Enum.reduce_while(tokens ++ [{end_token, nil, nil}], {{begin_token, nil, nil}, []}, fn
+        {token, before_stop, _} = token_tuple, {{previous_token, _, after_previous}, _} ->
+          {_, {start_line, start_character, _}, _} = previous_token
+          {_, {end_line, end_character, _}, _} = token
+
+          if (start_line < line or (start_line == line and start_character <= character)) and
+               (end_line > line or (end_line == line and end_character >= character)) do
+            # dbg({previous_token, after_previous, before_stop, token})
+            {end_line, end_character} =
+              case before_stop do
+                {kind, _, _} when kind in [:bin_string, :list_string] ->
+                  {end_line, end_character}
+
+                {kind, {before_start_line, before_start_character, list}, _} when is_list(list) ->
+                  length_modifier =
+                    if kind == :atom do
+                      1
+                    else
+                      0
+                    end
+
+                  {before_start_line, before_start_character + length(list) + length_modifier}
+
+                {_, {before_start_line, before_start_character, _}, list} when is_list(list) ->
+                  {before_start_line, before_start_character + length(list)}
+
+                {:atom_quoted, {before_start_line, before_start_character, _}, atom} ->
+                  {before_start_line, before_start_character + String.length(to_string(atom)) + 3}
+
+                _ ->
+                  {end_line, end_character}
               end
-              {before_start_line, before_start_character + length(list) + length_modifier}
-            {_, {before_start_line, before_start_character, _}, list} when is_list(list) ->
-              {before_start_line, before_start_character + length(list)}
-            {:atom_quoted, {before_start_line, before_start_character, _}, atom} ->
-              {before_start_line, before_start_character + String.length(to_string(atom)) + 3}
-            _ -> {end_line, end_character}
+
+            {start_line, start_character} =
+              case after_previous do
+                {_, {after_end_line, after_end_character, _}, _} ->
+                  {after_end_line, after_end_character}
+
+                nil ->
+                  {start_line, start_character}
+              end
+
+            # TODO
+            {:halt,
+             {token_tuple,
+              [
+                intersection(
+                  range(start_line, start_character, end_line, end_character),
+                  inner_range
+                )
+              ]}}
+          else
+            {:cont, {token_tuple, []}}
           end
-          {start_line, start_character} = case after_previous do 
-            {_, {after_end_line, after_end_character, _}, _} ->
-              {after_end_line, after_end_character}
-            nil ->
-              {start_line, start_character}
-          end
-          # TODO
-          {:halt, {token_tuple, [intersection(range(start_line, start_character, end_line, end_character), inner_range)]}}
-        else
-          {:cont, {token_tuple, []}}
-        end
-    end)
-    found |> dbg
+      end)
+
+    found
   end
 
   def cell_pair_ranges(lines, cell_pairs, line, character) do
@@ -321,165 +345,41 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
         ast,
         {[], []},
         fn
-          {form, meta, args} = ast, {acc, parent_ast} ->
+          {form, _meta, _args} = ast, {acc, parent_ast} ->
             parent_ast_from_stack =
               case parent_ast do
                 [] -> []
                 [item | _] -> item
               end
 
-            # {start_line, start_character} =
-            #   cond do
-            #     node == :%{} and match?({:%, _, _}, parent_ast_from_stack) ->
-            #       # get line and column from parent % node, current node meta points to {
-            #       {_, parent_meta, _} = parent_ast_from_stack
+            case AstUtils.node_range(ast) do
+              range(start_line, start_character, end_line, end_character) ->
+                start_character =
+                  if form == :%{} and match?({:%, _, _}, parent_ast_from_stack) do
+                    # undo column offset for structs inner map node
+                    start_character + 1
+                  else
+                    start_character
+                  end
 
-            #       {Keyword.get(parent_meta, :line, 1) - 1,
-            #        Keyword.get(parent_meta, :column, 1) - 1}
-
-            #     node in @binary_operators and match?([_, _], args) ->
-            #       [left | _] = args
-            #       # dbg(binding(), limit: :infinity)
-            #       find_start_of_expression(left, {Keyword.get(meta, :line, 1) - 1, Keyword.get(meta, :column, 1) - 1})
-
-
-                
-            #     meta_line = meta[:line] ->
-            #       {meta_line - 1, Keyword.get(meta, :column, 1) - 1}
-                
-            #     true ->
-            #       find_start_of_expression(ast, {nil, nil})
-            #   end
-
-            # if start_line < 0 or start_character < 0 do
-            #   dbg(ast)
-            #   raise "could not find start of expression"
-            # end
-
-            # {end_line, end_character} =
-            #   cond do
-            #     node == :__aliases__ ->
-            #       last = meta[:last]
-
-            #       last_length =
-            #         case List.last(args) do
-            #           atom when is_atom(atom) -> atom |> to_string() |> String.length()
-            #           _ -> 0
-            #         end
-
-            #       {last[:line] - 1, last[:column] - 1 + last_length}
-
-            #     node in @binary_operators and match?([_, _], args) ->
-            #       dbg(ast)
-            #       dbg(parent_ast_from_stack)
-            #       [_left, right] = args
-            #       operator_length = node|> to_string() |> String.length()
-            #       find_end_of_expression(right, parent_ast_from_stack, {start_line, start_character + operator_length})
-
-            #     node in @unary_operators and match?([_], args) ->
-            #       [right] = args
-            #       operator_length = node|> to_string() |> String.length()
-            #       find_end_of_expression(right, parent_ast_from_stack, {start_line, start_character + operator_length})
-
-            #     end_location = meta[:end_of_expression] ->
-            #       {end_location[:line] - 1, end_location[:column] - 1}
-
-            #     end_location = meta[:end] ->
-            #       {end_location[:line] - 1, end_location[:column] - 1 + 3}
-
-            #     end_location = meta[:closing] ->
-            #       closing_length =
-            #         case node do
-            #           :<<>> -> 2
-            #           _ -> 1
-            #         end
-
-            #       {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
-
-            #     token = meta[:token] ->
-            #       {start_line, start_character + String.length(token)}
-
-            #     meta[:delimiter] && (is_list(node) or is_binary(node)) ->
-            #       {start_line, start_character + String.length(to_string(node))}
-
-            #     # TODO a few other cases
-
-            #     #   parent_end_line =
-            #     #   parent_meta_from_stack
-            #     #   |> dbg()
-            #     #   |> Keyword.get(:end, [])
-            #     #   |> Keyword.get(:line) ->
-            #     # # last expression in block does not have end_of_expression
-            #     # parent_do_line = parent_meta_from_stack[:do][:line]
-
-            #     # if parent_end_line > parent_do_line do
-            #     #   # take end location from parent and assume end_of_expression is last char in previous line
-            #     #   end_of_expression =
-            #     #     Enum.at(lines, max(parent_end_line - 2, 0))
-            #     #     |> String.length()
-
-            #     #   SourceFile.elixir_position_to_lsp(
-            #     #     lines,
-            #     #     {parent_end_line - 1, end_of_expression + 1}
-            #     #   )
-            #     # else
-            #     #   # take end location from parent and assume end_of_expression is last char before final ; trimmed
-            #     #   line = Enum.at(lines, parent_end_line - 1)
-            #     #   parent_end_column = parent_meta_from_stack[:end][:column]
-
-            #     #   end_of_expression =
-            #     #     line
-            #     #     |> String.slice(0..(parent_end_column - 2))
-            #     #     |> String.trim_trailing()
-            #     #     |> String.replace_trailing(";", "")
-            #     #     |> String.length()
-
-            #     #   SourceFile.elixir_position_to_lsp(
-            #     #     lines,
-            #     #     {parent_end_line, end_of_expression + 1}
-            #     #   )
-            #     # end
-            #     true ->
-            #       find_end_of_expression(ast, parent_ast_from_stack, {start_line, start_character})
-            #   end
-
-            range = AstUtils.node_range(ast) |> dbg
-            # range = try do
-            #   AstUtils.node_range(ast)
-            # rescue
-            #   _ -> nil
-            # end
-
-            case range do
-              range(start_line, start_character, end_line, end_character) = range ->
-                start_character = if form == :"%{}" and match?({:%, _, _}, parent_ast_from_stack) do
-                  # undo column offset for structs inner map node
-                  start_character + 1
-                else
-                  start_character
-                end
                 range = range(start_line, start_character, end_line, end_character)
+
                 if (start_line < line or (start_line == line and start_character <= character)) and
-                    (end_line > line or (end_line == line and end_character >= character)) do
-                      # range = range(start_line, start_character, end_line, end_character)
-                      if not valid?(range) do
-                        raise "invalid range"
-                      end
+                     (end_line > line or (end_line == line and end_character >= character)) do
                   # dbg({ast, range, parent_ast_from_stack})
-                  {ast,
-                  {[range | acc],
-                    [ast | parent_ast]}}
+                  {ast, {[range | acc], [ast | parent_ast]}}
                 else
-                  dbg({ast, range, {line, character}, "outside"})
+                  # dbg({ast, range, {line, character}, "outside"})
                   {ast, {acc, [ast | parent_ast]}}
                 end
+
               nil ->
-                dbg({ast, "nil"})
+                # dbg({ast, "nil"})
                 {ast, {acc, [ast | parent_ast]}}
-              end
+            end
 
           other, {acc, parent_ast} ->
-            dbg({other, "other"})
+            # dbg({other, "other"})
             {other, {acc, parent_ast}}
         end,
         fn
@@ -511,17 +411,24 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
     tokens_next = tl(tokens) ++ [nil]
     tokens_prev = [nil | Enum.slice(tokens, 0..-2//1)]
     tokens_prev_next = Enum.zip([tokens_prev, tokens, tokens_next])
-    for {prev_token, {token, {line, character, _}, _} = token_tuple, next_token} <- tokens_prev_next,
-    token in @stop_tokens
-    do
-      pair = token_pairs
-      |> Enum.filter(fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character, _}, _}} ->
-        (start_line < line or start_line == line and start_character <= character) and (end_line > line or end_line == line and end_character >= character)
-      end)
-      |> Enum.min_by(fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character,_}, _}} ->
-        {end_line - start_line, end_character - start_character}
-      end, &<=/2,
-      fn -> nil end)
+
+    for {prev_token, {token, {line, character, _}, _} = token_tuple, next_token} <-
+          tokens_prev_next,
+        token in @stop_tokens do
+      pair =
+        token_pairs
+        |> Enum.filter(fn {{_, {start_line, start_character, _}, _},
+                           {_, {end_line, end_character, _}, _}} ->
+          (start_line < line or (start_line == line and start_character <= character)) and
+            (end_line > line or (end_line == line and end_character >= character))
+        end)
+        |> Enum.min_by(
+          fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character, _}, _}} ->
+            {end_line - start_line, end_character - start_character}
+          end,
+          &<=/2,
+          fn -> nil end
+        )
 
       {pair, {token_tuple, prev_token, next_token}}
     end
@@ -530,128 +437,5 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
       {pair, Enum.map(tuples, &elem(&1, 1))}
     end)
     |> Map.new()
-  end
-
-  def find_start_of_expression(ast, acc) do
-    {_, soe} = Macro.prewalk(ast, acc, fn
-      {kind, meta, _} = node, {line, column} ->
-        if soe_line = meta[:line] do
-          soe_line = soe_line - 1
-          correction = if kind == :"%{}" do
-            # TODO is is a bug in parser? column is invalid
-            -1
-          else
-            0
-          end
-          soe_column = meta[:column] - 1 + correction
-          if soe_line < line or (soe_line == line and soe_column <= column) do
-            {node, {soe_line, soe_column}}
-          else
-            {node, {line, column}}
-          end
-        else
-          {node, {line, column}}
-        end
-      node, acc ->
-        {node, acc}
-    end)
-    dbg({ast, soe})
-    case soe do
-      {nil, nil} -> :ok
-      {l, c} when l < 0 or c < 0 -> raise "invalid start of expression"
-      _ -> :ok
-    end
-    soe
-  end
-
-  defp find_end_of_expression(ast, parent_node, acc) do
-    {soe_line, soe_column} = find_start_of_expression(ast, {nil, nil})
-      {soe_line, soe_column} = if {soe_line, soe_column} == {nil, nil} do
-        acc
-      else
-        {soe_line, soe_column}
-      end
-
-    # try to find it in meta recursively
-    {_, eoe} = Macro.prewalk(ast, acc, fn
-      {node, meta, args} = ast, {line, column} ->
-        {eoe_line, eoe_column} = cond do
-          node == :__aliases__ ->
-            last = meta[:last]
-
-            last_length =
-              case List.last(args) do
-                atom when is_atom(atom) -> atom |> to_string() |> String.length()
-                _ -> 0
-              end
-
-            {last[:line] - 1, last[:column] - 1 + last_length}
-
-          end_location = meta[:end_of_expression] ->
-            {end_location[:line] - 1, end_location[:column] - 1}
-
-          end_location = meta[:end] ->
-            {end_location[:line] - 1, end_location[:column] - 1 + 3}
-
-          end_location = meta[:closing] ->
-            closing_length =
-              case node do
-                :<<>> -> 2
-                _ -> 1
-              end
-
-            {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
-
-          token = meta[:token] ->
-            {soe_line, soe_column + String.length(token)}
-
-          meta[:delimiter] && (is_list(node) or is_binary(node)) ->
-            {soe_line, soe_column + String.length(to_string(node))}
-
-          true ->
-            {line, column}
-        end
-
-        if eoe_line > line or (eoe_line == line and eoe_column >= column) do
-          {node, {eoe_line, eoe_column}}
-        else
-          {node, {line, column}}
-        end
-      node, acc ->
-        {node, acc}
-    end)
-    
-    eoe = if eoe == acc do
-      # no end_of_expression in last expression in do block
-      # get from parent meta
-      case parent_node do
-        {_, parent_meta, _} ->
-          end_meta = parent_meta[:end]
-          if end_meta do
-            {end_meta[:line] - 1, end_meta[:column] - 1}
-          else
-            acc
-          end
-        _ -> acc
-      end
-    else
-      eoe
-    end
-
-    # try to format the expression and count chars
-    eoe = if eoe == acc do
-      code = ast |> dbg |> Code.quoted_to_algebra |> Inspect.Algebra.format(:infinity) |> IO.iodata_to_binary()
-      lines = code |> SourceFile.lines()
-      case lines do
-        [_] -> {soe_line, soe_column + String.length(code)}
-        _ ->
-          last_line = Enum.at(lines, -1)
-          {soe_line + length(lines) - 1, String.length(last_line)}
-      end
-    else
-      eoe
-    end
-    dbg({ast, eoe})
-    eoe
   end
 end

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -116,16 +116,6 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
     end)
   end
 
-  # this function differs from the one in SourceFile - it returns utf8 ranges
-  defp full_range(lines) do
-    utf8_size =
-      lines
-      |> List.last()
-      |> String.length()
-
-    range(0, 0, Enum.count(lines) - 1, utf8_size)
-  end
-
   def token_pair_ranges(lines, token_pairs, stop_tokens, line, character) do
     token_pairs
     |> Enum.filter(fn {{_, {start_line, start_character, _}, _},

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -15,15 +15,22 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   defp token_length(token) when token in [:"<<", :">>", :do, :fn], do: 2
   defp token_length(_), do: 0
 
-  # @stop_tokens [:",", :";", :|]
+  # TODO =>
+  @stop_tokens [:",", :";", :eol]
+
+  @binary_operators ~w[. ** * / + - ++ -- +++ --- .. <> in |> <<< >>> <<~ ~>> <~ ~> <~> < > <= >= == != === !== =~ && &&& and || ||| or = => :: when <- -> \\]a
+  @unary_operators ~w[@ + - ! ^ not &]a
+  @unary_and_binary_operators ~w[+ -]a
 
   def selection_ranges(text, positions) do
     lines = SourceFile.lines(text)
     full_file_range = full_range(lines)
 
-    tokens = FoldingRange.Token.format_string(text)
+    tokens = FoldingRange.Token.format_string(text) |> dbg(limit: :infinity)
 
-    token_pairs = FoldingRange.TokenPair.pair_tokens(tokens)
+    token_pairs = FoldingRange.TokenPair.pair_tokens(tokens) |> dbg
+
+    stop_tokens = get_stop_tokens_in_token_pairs(tokens, token_pairs) |> dbg
 
     special_token_groups =
       for group <- FoldingRange.SpecialToken.group_tokens(tokens) do
@@ -40,10 +47,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
       Code.string_to_quoted(text,
         token_metadata: true,
         columns: true,
+        unescape: false,
         literal_encoder: fn literal, meta ->
-          {:ok, {literal, meta, nil}}
+          {:ok, {:__block__, meta, [literal]}}
         end
-      )
+      ) |> dbg
 
     cell_pairs =
       formatted_lines
@@ -55,327 +63,60 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
       # for convenance the code in this module uses 0 based indexing
       {line, character} = {line - 1, character - 1}
 
-      cell_pair_ranges =
-        ([full_file_range] ++
-           for {{start_line, start_character}, {end_line, _end_line_start_character}} <-
-                 cell_pairs,
-               (start_line < line or (start_line == line and start_character <= character)) and
-                 end_line > line do
-             line_length = lines |> Enum.at(end_line - 1) |> String.length()
-             second_line = lines |> Enum.at(start_line + 1)
+      cell_pair_ranges = cell_pair_ranges(lines, cell_pairs, line, character)
 
-             second_line_indent =
-               String.length(second_line) - String.length(String.trim_leading(second_line))
-
-             [range(start_line, start_character, end_line - 1, line_length)]
-             |> Kernel.++(
-               if(line >= start_line + 1,
-                 do: [range(start_line + 1, 0, end_line - 1, line_length)],
-                 else: []
-               )
-             )
-             |> Kernel.++(
-               if(
-                 line > start_line + 1 or
-                   (line == start_line + 1 and character >= second_line_indent),
-                 do: [range(start_line + 1, second_line_indent, end_line - 1, line_length)],
-                 else: []
-               )
-             )
-           end)
-        |> List.flatten()
-
-      cell_pair_ranges = sort_ranges_widest_to_narrowest(cell_pair_ranges)
-
-      token_pair_ranges =
-        token_pairs
-        |> Enum.filter(fn {{_, {start_line, start_character, _}, _},
-                           {end_token, {end_line, end_character, _}, _}} ->
-          end_token_length = token_length(end_token)
-
-          (start_line < line or (start_line == line and start_character <= character)) and
-            (end_line > line or
-               (end_line == line and end_character + end_token_length >= character))
-        end)
-        |> Enum.reduce([full_file_range], fn {{start_token, {start_line, start_character, _}, _},
-                                              {end_token, {end_line, end_character, _}, _}},
-                                             acc ->
-          start_token_length = token_length(start_token)
-          end_token_length = token_length(end_token)
-
-          outer_range =
-            range(start_line, start_character, end_line, end_character + end_token_length)
-
-          case end_token do
-            :end ->
-              if line < start_line + 1 or line > end_line - 1 do
-                # do not include inner range if cursor is outside, e.g.
-                # do
-                # ^ 
-                [outer_range | acc]
-              else
-                line_length = lines |> Enum.at(end_line - 1) |> String.length()
-                [range(start_line + 1, 0, end_line - 1, line_length), outer_range | acc]
-              end
-
-            _ ->
-              if (start_line == line and start_character + start_token_length > character) or
-                   (end_line == line and end_character < character) do
-                # do not include inner range if cursor is outside, e.g.
-                # << 123 >>
-                # ^        ^
-                [outer_range | acc]
-              else
-                [
-                  range(
-                    start_line,
-                    start_character + start_token_length,
-                    end_line,
-                    end_character
-                  ),
-                  outer_range | acc
-                ]
-              end
-          end
-        end)
-        |> Enum.reverse()
+      token_pair_ranges = token_pair_ranges(lines, token_pairs, stop_tokens, line, character)
+      |> deduplicate
 
       special_token_group_ranges =
-        [full_file_range] ++
-          for {{_end_token, {end_line, end_character, _}, _},
-               {_start_token, {start_line, start_character, _}, _}} <- special_token_groups,
-              end_token_length = 0,
-              (start_line < line or (start_line == line and start_character <= character)) and
-                (end_line > line or
-                   (end_line == line and end_character + end_token_length >= character)) do
-            range(start_line, start_character, end_line, end_character)
-          end
+        special_token_group_ranges(special_token_groups, line, character)
 
-      comment_block_ranges =
-        [full_file_range] ++
-          (for group <- comment_groups,
-               group != [],
-               {{{end_line, end_line_start_character}, _}, {{start_line, start_character}, _}} =
-                 FoldingRange.Helpers.first_and_last_of_list(group),
-               (start_line < line or (start_line == line and start_character <= character)) and
-                 (end_line > line or (end_line == line and end_line_start_character <= character)) do
-             case group do
-               [_] ->
-                 line_length = lines |> Enum.at(start_line) |> String.length()
-                 full_line_range = range(start_line, 0, start_line, line_length)
-                 [full_line_range, range(start_line, start_character, start_line, line_length)]
+      comment_block_ranges = comment_block_ranges(lines, comment_groups, line, character)
 
-               _ ->
-                 end_line_length = lines |> Enum.at(end_line) |> String.length()
-                 full_block_full_line_range = range(start_line, 0, end_line, end_line_length)
-                 full_block_range = range(start_line, start_character, end_line, end_line_length)
+      ast_node_ranges = ast_node_ranges(parse_result, line, character)
 
-                 [full_block_full_line_range, full_block_range] ++
-                   Enum.find_value(group, fn {{cursor_line, cursor_line_character}, _} ->
-                     if cursor_line == line do
-                       cursor_line_length = lines |> Enum.at(cursor_line) |> String.length()
-
-                       line_range =
-                         range(
-                           cursor_line,
-                           cursor_line_character,
-                           cursor_line,
-                           cursor_line_length
-                         )
-
-                       if cursor_line > start_line do
-                         full_line_range = range(cursor_line, 0, cursor_line, cursor_line_length)
-                         [full_line_range, line_range]
-                       else
-                         # do not include full line range if cursor is on the first line of the block as it will conflict with full_block_range
-                         [line_range]
-                       end
-                     end
-                   end)
-             end
-           end
-           |> List.flatten())
-
-      ast_ranges =
-        case parse_result do
-          {:ok, ast} ->
-            {_new_ast, {acc, []}} =
-              Macro.traverse(
-                ast,
-                {[full_file_range], []},
-                fn
-                  {node, meta, args} = ast, {acc, parent_ast} ->
-                    parent_ast_from_stack =
-                      case parent_ast do
-                        [] -> []
-                        [item | _] -> item
-                      end
-
-                    {start_line, start_character} =
-                      cond do
-                        node == :%{} and match?({:%, _, _}, parent_ast_from_stack) ->
-                          # get line and column from parent % node, current node meta points to {
-                          {_, parent_meta, _} = parent_ast_from_stack
-
-                          {Keyword.get(parent_meta, :line, 0) - 1,
-                           Keyword.get(parent_meta, :column, 0) - 1}
-
-                        true ->
-                          {Keyword.get(meta, :line, 0) - 1, Keyword.get(meta, :column, 0) - 1}
-                      end
-
-                    {end_line, end_character} =
-                      cond do
-                        node == :__aliases__ ->
-                          last = meta[:last]
-
-                          last_length =
-                            case List.last(args) do
-                              atom when is_atom(atom) -> atom |> to_string() |> String.length()
-                              _ -> 0
-                            end
-
-                          {last[:line] - 1, last[:column] - 1 + last_length}
-
-                        end_location = meta[:end_of_expression] ->
-                          {end_location[:line] - 1, end_location[:column] - 1}
-
-                        end_location = meta[:end] ->
-                          {end_location[:line] - 1, end_location[:column] - 1 + 3}
-
-                        end_location = meta[:closing] ->
-                          closing_length =
-                            case node do
-                              :<<>> -> 2
-                              _ -> 1
-                            end
-
-                          {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
-
-                        token = meta[:token] ->
-                          {start_line, start_character + String.length(token)}
-
-                        # is_atom(node) ->
-                        #   {start_line, start_character + String.length(to_string(node))}
-
-                        meta[:delimiter] && (is_list(node) or is_binary(node)) ->
-                          {start_line, start_character + String.length(to_string(node))}
-
-                        # TODO a few other cases
-
-                        #   parent_end_line =
-                        #   parent_meta_from_stack
-                        #   |> dbg()
-                        #   |> Keyword.get(:end, [])
-                        #   |> Keyword.get(:line) ->
-                        # # last expression in block does not have end_of_expression
-                        # parent_do_line = parent_meta_from_stack[:do][:line]
-
-                        # if parent_end_line > parent_do_line do
-                        #   # take end location from parent and assume end_of_expression is last char in previous line
-                        #   end_of_expression =
-                        #     Enum.at(lines, max(parent_end_line - 2, 0))
-                        #     |> String.length()
-
-                        #   SourceFile.elixir_position_to_lsp(
-                        #     lines,
-                        #     {parent_end_line - 1, end_of_expression + 1}
-                        #   )
-                        # else
-                        #   # take end location from parent and assume end_of_expression is last char before final ; trimmed
-                        #   line = Enum.at(lines, parent_end_line - 1)
-                        #   parent_end_column = parent_meta_from_stack[:end][:column]
-
-                        #   end_of_expression =
-                        #     line
-                        #     |> String.slice(0..(parent_end_column - 2))
-                        #     |> String.trim_trailing()
-                        #     |> String.replace_trailing(";", "")
-                        #     |> String.length()
-
-                        #   SourceFile.elixir_position_to_lsp(
-                        #     lines,
-                        #     {parent_end_line, end_of_expression + 1}
-                        #   )
-                        # end
-                        true ->
-                          {start_line, start_character}
-                      end
-
-                    if (start_line < line or (start_line == line and start_character <= character)) and
-                         (end_line > line or (end_line == line and end_character >= character)) do
-                      {ast,
-                       {[range(start_line, start_character, end_line, end_character) | acc],
-                        [ast | parent_ast]}}
-                    else
-                      {ast, {acc, [ast | parent_ast]}}
-                    end
-
-                  other, {acc, parent_ast} ->
-                    {other, {acc, parent_ast}}
-                end,
-                fn
-                  {_, _meta, _} = ast, {acc, [_ | tail]} ->
-                    {ast, {acc, tail}}
-
-                  other, {acc, stack} ->
-                    {other, {acc, stack}}
-                end
-              )
-
-            acc
-            |> sort_ranges_widest_to_narrowest()
-
-          _ ->
-            [full_file_range]
-        end
-
-      surround_context_ranges =
-        [full_file_range] ++
-          case Code.Fragment.surround_context(text, {line + 1, character + 1}) do
-            :none ->
-              []
-
-            %{begin: {start_line, start_character}, end: {end_line, end_character}} ->
-              [range(start_line - 1, start_character - 1, end_line - 1, end_character - 1)]
-          end
+      surround_context_ranges = surround_context_ranges(text, line, character)
 
       merged_ranges =
-        token_pair_ranges
-        |> merge_ranges_lists(cell_pair_ranges)
-        |> merge_ranges_lists(special_token_group_ranges)
-        |> merge_ranges_lists(comment_block_ranges)
-        |> merge_ranges_lists(surround_context_ranges)
-        |> merge_ranges_lists(ast_ranges)
+        [full_file_range | token_pair_ranges] |> dbg
+        |> merge_ranges_lists([full_file_range | cell_pair_ranges])
+        |> merge_ranges_lists([full_file_range | special_token_group_ranges])
+        |> merge_ranges_lists([full_file_range | comment_block_ranges])
+        |> merge_ranges_lists([full_file_range | surround_context_ranges])
+        |> merge_ranges_lists([full_file_range | ast_node_ranges])
 
       if not increasingly_narrowing?(merged_ranges) do
         raise "merged_ranges are not increasingly narrowing"
       end
 
-      merged_ranges
-      |> Enum.reduce(nil, fn selection_range, parent ->
-        range(start_line_elixir, start_character_elixir, end_line_elixir, end_character_elixir) =
-          selection_range
-
-        # positions are 0-based
-        {start_line_lsp, start_character_lsp} =
-          SourceFile.elixir_position_to_lsp(
-            lines,
-            {start_line_elixir + 1, start_character_elixir + 1}
-          )
-
-        {end_line_lsp, end_character_lsp} =
-          SourceFile.elixir_position_to_lsp(
-            lines,
-            {end_line_elixir + 1, end_character_elixir + 1}
-          )
-
-        %{
-          "range" => range(start_line_lsp, start_character_lsp, end_line_lsp, end_character_lsp),
-          "parent" => parent
-        }
-      end)
+      to_nested_lsp_message(merged_ranges, lines)
     end
+  end
+
+  defp to_nested_lsp_message(ranges, lines) do
+    ranges
+    |> Enum.reduce(nil, fn selection_range, parent ->
+      range(start_line_elixir, start_character_elixir, end_line_elixir, end_character_elixir) =
+        selection_range
+
+      # positions are 0-based
+      {start_line_lsp, start_character_lsp} =
+        SourceFile.elixir_position_to_lsp(
+          lines,
+          {start_line_elixir + 1, start_character_elixir + 1}
+        )
+
+      {end_line_lsp, end_character_lsp} =
+        SourceFile.elixir_position_to_lsp(
+          lines,
+          {end_line_elixir + 1, end_character_elixir + 1}
+        )
+
+      %{
+        "range" => range(start_line_lsp, start_character_lsp, end_line_lsp, end_character_lsp),
+        "parent" => parent
+      }
+    end)
   end
 
   # this function differs from the one in SourceFile - it returns utf8 ranges
@@ -386,5 +127,455 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
       |> String.length()
 
     range(0, 0, Enum.count(lines) - 1, utf8_size)
+  end
+
+  def token_pair_ranges(lines, token_pairs, stop_tokens, line, character) do
+    token_pairs
+    |> Enum.filter(fn {{_, {start_line, start_character, _}, _},
+                       {end_token, {end_line, end_character, _}, _}} ->
+      end_token_length = token_length(end_token)
+
+      (start_line < line or (start_line == line and start_character <= character)) and
+        (end_line > line or
+           (end_line == line and end_character + end_token_length >= character))
+    end)
+    |> Enum.reduce([], fn {{start_token, {start_line, start_character, _}, _},
+                           {end_token, {end_line, end_character, _}, _}} = pair,
+                          acc ->
+      stop_tokens_in_pair = Map.get(stop_tokens, pair, []) |> dbg
+      start_token_length = token_length(start_token)
+      end_token_length = token_length(end_token)
+
+      outer_range =
+        range(start_line, start_character, end_line, end_character + end_token_length)
+
+      case end_token do
+        :end ->
+          if line < start_line + 1 or line > end_line - 1 do
+            # do not include inner range if cursor is outside, e.g.
+            # do
+            # ^ 
+            [outer_range | acc]
+          else
+            line_length = lines |> Enum.at(end_line - 1) |> String.length()
+            inner_range = range(start_line + 1, 0, end_line - 1, line_length)
+            find_stop_token_range(stop_tokens_in_pair, pair, inner_range, line, character) ++
+            [inner_range, outer_range | acc]
+          end
+
+        _ ->
+          if (start_line == line and start_character + start_token_length > character) or
+               (end_line == line and end_character < character) do
+            # do not include inner range if cursor is outside, e.g.
+            # << 123 >>
+            # ^        ^
+            [outer_range | acc]
+          else
+            inner_range = range(
+              start_line,
+              start_character + start_token_length,
+              end_line,
+              end_character
+            )
+            find_stop_token_range(stop_tokens_in_pair, pair, inner_range, line, character) ++
+            [
+              inner_range,
+              outer_range | acc
+            ]
+          end
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp find_stop_token_range([], _, _, _, _), do: []
+  defp find_stop_token_range(tokens, {begin_token, end_token}, inner_range, line, character) do
+    {_, found} = Enum.reduce_while(tokens ++ [{end_token, nil, nil}], {{begin_token, nil, nil}, []}, fn
+      {token, before_stop, _} = token_tuple, {{previous_token, _, after_previous}, _} ->
+        {_, {start_line, start_character, _}, _} = previous_token
+        {_, {end_line, end_character, _}, _} = token
+        if (start_line < line or start_line == line and start_character <= character) and (end_line > line or end_line == line and end_character >= character) do
+          dbg({previous_token, after_previous, before_stop, token})
+          {end_line, end_character} = case before_stop do
+            {kind, _, _} when kind in [:bin_string, :list_string] ->
+              {end_line, end_character}
+            {kind, {before_start_line, before_start_character, list}, _} when is_list(list) ->
+              length_modifier = if kind == :atom do
+                1
+              else
+                0
+              end
+              {before_start_line, before_start_character + length(list) + length_modifier}
+            {_, {before_start_line, before_start_character, _}, list} when is_list(list) ->
+              {before_start_line, before_start_character + length(list)}
+            {:atom_quoted, {before_start_line, before_start_character, _}, atom} ->
+              {before_start_line, before_start_character + String.length(to_string(atom)) + 3}
+            _ -> {end_line, end_character}
+          end
+          {start_line, start_character} = case after_previous do 
+            {_, {after_end_line, after_end_character, _}, _} ->
+              {after_end_line, after_end_character}
+            nil ->
+              {start_line, start_character}
+          end
+          # TODO
+          {:halt, {token_tuple, [intersection(range(start_line, start_character, end_line, end_character), inner_range)]}}
+        else
+          {:cont, {token_tuple, []}}
+        end
+    end)
+    found |> dbg
+  end
+
+  def cell_pair_ranges(lines, cell_pairs, line, character) do
+    for {{start_line, start_character}, {end_line, _end_line_start_character}} <-
+          cell_pairs,
+        (start_line < line or (start_line == line and start_character <= character)) and
+          end_line > line do
+      line_length = lines |> Enum.at(end_line - 1) |> String.length()
+      second_line = lines |> Enum.at(start_line + 1)
+
+      second_line_indent =
+        String.length(second_line) - String.length(String.trim_leading(second_line))
+
+      [range(start_line, start_character, end_line - 1, line_length)]
+      |> Kernel.++(
+        if(line >= start_line + 1,
+          do: [range(start_line + 1, 0, end_line - 1, line_length)],
+          else: []
+        )
+      )
+      |> Kernel.++(
+        if(
+          line > start_line + 1 or
+            (line == start_line + 1 and character >= second_line_indent),
+          do: [range(start_line + 1, second_line_indent, end_line - 1, line_length)],
+          else: []
+        )
+      )
+    end
+    |> List.flatten()
+    |> sort_ranges_widest_to_narrowest()
+  end
+
+  def special_token_group_ranges(special_token_groups, line, character) do
+    for {{_end_token, {end_line, end_character, _}, _},
+         {_start_token, {start_line, start_character, _}, _}} <- special_token_groups,
+        end_token_length = 0,
+        (start_line < line or (start_line == line and start_character <= character)) and
+          (end_line > line or
+             (end_line == line and end_character + end_token_length >= character)) do
+      range(start_line, start_character, end_line, end_character)
+    end
+  end
+
+  def comment_block_ranges(lines, comment_groups, line, character) do
+    for group <- comment_groups,
+        group != [],
+        {{{end_line, end_line_start_character}, _}, {{start_line, start_character}, _}} =
+          FoldingRange.Helpers.first_and_last_of_list(group),
+        (start_line < line or (start_line == line and start_character <= character)) and
+          (end_line > line or (end_line == line and end_line_start_character <= character)) do
+      case group do
+        [_] ->
+          line_length = lines |> Enum.at(start_line) |> String.length()
+          full_line_range = range(start_line, 0, start_line, line_length)
+          [full_line_range, range(start_line, start_character, start_line, line_length)]
+
+        _ ->
+          end_line_length = lines |> Enum.at(end_line) |> String.length()
+          full_block_full_line_range = range(start_line, 0, end_line, end_line_length)
+          full_block_range = range(start_line, start_character, end_line, end_line_length)
+
+          [full_block_full_line_range, full_block_range] ++
+            Enum.find_value(group, fn {{cursor_line, cursor_line_character}, _} ->
+              if cursor_line == line do
+                cursor_line_length = lines |> Enum.at(cursor_line) |> String.length()
+
+                line_range =
+                  range(
+                    cursor_line,
+                    cursor_line_character,
+                    cursor_line,
+                    cursor_line_length
+                  )
+
+                if cursor_line > start_line do
+                  full_line_range = range(cursor_line, 0, cursor_line, cursor_line_length)
+                  [full_line_range, line_range]
+                else
+                  # do not include full line range if cursor is on the first line of the block as it will conflict with full_block_range
+                  [line_range]
+                end
+              end
+            end)
+      end
+    end
+    |> List.flatten()
+  end
+
+  def ast_node_ranges({:ok, ast}, line, character) do
+    {_new_ast, {acc, []}} =
+      Macro.traverse(
+        ast,
+        {[], []},
+        fn
+          {node, meta, args} = ast, {acc, parent_ast} ->
+            parent_ast_from_stack =
+              case parent_ast do
+                [] -> []
+                [item | _] -> item
+              end
+
+            {start_line, start_character} =
+              cond do
+                node == :%{} and match?({:%, _, _}, parent_ast_from_stack) ->
+                  # get line and column from parent % node, current node meta points to {
+                  {_, parent_meta, _} = parent_ast_from_stack
+
+                  {Keyword.get(parent_meta, :line, 1) - 1,
+                   Keyword.get(parent_meta, :column, 1) - 1}
+
+                node in @binary_operators and match?([_, _], args) ->
+                  [left | _] = args
+                  # dbg(binding(), limit: :infinity)
+                  find_start_of_expression(left, {Keyword.get(meta, :line, 1) - 1, Keyword.get(meta, :column, 1) - 1})
+
+                true ->
+                  {Keyword.get(meta, :line, 0) - 1, Keyword.get(meta, :column, 1) - 1}
+              end
+
+            {end_line, end_character} =
+              cond do
+                node == :__aliases__ ->
+                  last = meta[:last]
+
+                  last_length =
+                    case List.last(args) do
+                      atom when is_atom(atom) -> atom |> to_string() |> String.length()
+                      _ -> 0
+                    end
+
+                  {last[:line] - 1, last[:column] - 1 + last_length}
+
+                node in @binary_operators and match?([_, _], args) ->
+                  dbg(ast)
+                  dbg(parent_ast_from_stack)
+                  [_left, right] = args
+                  operator_length = node|> to_string() |> String.length()
+                  find_end_of_expression(right, parent_ast_from_stack, {start_line, start_character + operator_length})
+
+                node in @unary_operators and match?([_], args) ->
+                  [right] = args
+                  operator_length = node|> to_string() |> String.length()
+                  find_end_of_expression(right, parent_ast_from_stack, {start_line, start_character + operator_length})
+
+                end_location = meta[:end_of_expression] ->
+                  {end_location[:line] - 1, end_location[:column] - 1}
+
+                end_location = meta[:end] ->
+                  {end_location[:line] - 1, end_location[:column] - 1 + 3}
+
+                end_location = meta[:closing] ->
+                  closing_length =
+                    case node do
+                      :<<>> -> 2
+                      _ -> 1
+                    end
+
+                  {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
+
+                token = meta[:token] ->
+                  {start_line, start_character + String.length(token)}
+
+                # is_atom(node) ->
+                #   {start_line, start_character + String.length(to_string(node))}
+
+                meta[:delimiter] && (is_list(node) or is_binary(node)) ->
+                  {start_line, start_character + String.length(to_string(node))}
+
+                # TODO a few other cases
+
+                #   parent_end_line =
+                #   parent_meta_from_stack
+                #   |> dbg()
+                #   |> Keyword.get(:end, [])
+                #   |> Keyword.get(:line) ->
+                # # last expression in block does not have end_of_expression
+                # parent_do_line = parent_meta_from_stack[:do][:line]
+
+                # if parent_end_line > parent_do_line do
+                #   # take end location from parent and assume end_of_expression is last char in previous line
+                #   end_of_expression =
+                #     Enum.at(lines, max(parent_end_line - 2, 0))
+                #     |> String.length()
+
+                #   SourceFile.elixir_position_to_lsp(
+                #     lines,
+                #     {parent_end_line - 1, end_of_expression + 1}
+                #   )
+                # else
+                #   # take end location from parent and assume end_of_expression is last char before final ; trimmed
+                #   line = Enum.at(lines, parent_end_line - 1)
+                #   parent_end_column = parent_meta_from_stack[:end][:column]
+
+                #   end_of_expression =
+                #     line
+                #     |> String.slice(0..(parent_end_column - 2))
+                #     |> String.trim_trailing()
+                #     |> String.replace_trailing(";", "")
+                #     |> String.length()
+
+                #   SourceFile.elixir_position_to_lsp(
+                #     lines,
+                #     {parent_end_line, end_of_expression + 1}
+                #   )
+                # end
+                true ->
+                  {start_line, start_character}
+              end
+
+            if (start_line < line or (start_line == line and start_character <= character)) and
+                 (end_line > line or (end_line == line and end_character >= character)) do
+              {ast,
+               {[range(start_line, start_character, end_line, end_character) | acc],
+                [ast | parent_ast]}}
+            else
+              {ast, {acc, [ast | parent_ast]}}
+            end
+
+          other, {acc, parent_ast} ->
+            {other, {acc, parent_ast}}
+        end,
+        fn
+          {_, _meta, _} = ast, {acc, [_ | tail]} ->
+            {ast, {acc, tail}}
+
+          other, {acc, stack} ->
+            {other, {acc, stack}}
+        end
+      )
+
+    acc
+    |> sort_ranges_widest_to_narrowest()
+  end
+
+  def ast_node_ranges(_, _, _), do: []
+
+  def surround_context_ranges(text, line, character) do
+    case Code.Fragment.surround_context(text, {line + 1, character + 1}) do
+      :none ->
+        []
+
+      %{begin: {start_line, start_character}, end: {end_line, end_character}} ->
+        [range(start_line - 1, start_character - 1, end_line - 1, end_character - 1)]
+    end
+  end
+
+  def get_stop_tokens_in_token_pairs(tokens, token_pairs) do
+    tokens_next = tl(tokens) ++ [nil]
+    tokens_prev = [nil | Enum.slice(tokens, 0..-2//1)]
+    tokens_prev_next = Enum.zip([tokens_prev, tokens, tokens_next])
+    for {prev_token, {token, {line, character, _}, _} = token_tuple, next_token} <- tokens_prev_next,
+    token in @stop_tokens
+    do
+      pair = token_pairs
+      |> Enum.filter(fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character, _}, _}} ->
+        (start_line < line or start_line == line and start_character <= character) and (end_line > line or end_line == line and end_character >= character)
+      end)
+      |> Enum.min_by(fn {{_, {start_line, start_character, _}, _}, {_, {end_line, end_character,_}, _}} ->
+        {end_line - start_line, end_character - start_character}
+      end, &<=/2,
+      fn -> nil end)
+
+      {pair, {token_tuple, prev_token, next_token}}
+    end
+    |> Enum.group_by(&elem(&1, 0))
+    |> Enum.map(fn {pair, tuples} ->
+      {pair, Enum.map(tuples, &elem(&1, 1))}
+    end)
+    |> Map.new()
+  end
+
+  def find_start_of_expression(ast, acc) do
+    {_, soe} = Macro.prewalk(ast, acc, fn
+      {kind, meta, _} = node, {line, column} ->
+        soe_line = meta[:line] - 1
+        correction = if kind == :"%{}" do
+          # TODO is is a bug in parser? column is invalid
+          -1
+        else
+          0
+        end
+        soe_column = meta[:column] - 1 + correction
+        if soe_line < line or (soe_line == line and soe_column <= column) do
+          {node, {soe_line, soe_column}}
+        else
+          {node, {line, column}}
+        end
+      node, acc ->
+        {node, acc}
+    end)
+    dbg({ast, soe})
+    soe
+  end
+
+  defp find_end_of_expression(ast, parent_node, acc) do
+    {_, eoe} = Macro.prewalk(ast, acc, fn
+      {_, meta, _} = node, {line, column} ->
+        end_of_expression = meta[:end_of_expression]
+        if end_of_expression do
+          eoe_line = end_of_expression[:line] - 1
+          eoe_column = end_of_expression[:column] - 1
+          if eoe_line > line or (eoe_line == line and eoe_column >= column) do
+            {node, {eoe_line, eoe_column}}
+          else
+            {node, {line, column}}
+          end
+        else
+          {node, {line, column}}
+        end
+      node, acc ->
+        {node, acc}
+    end)
+    
+    eoe = if eoe == acc do
+      # no end_of_expression in last expression in do block
+      # get from parent meta
+      case parent_node do
+        {_, parent_meta, _} ->
+          end_meta = parent_meta[:end]
+          if end_meta do
+            {end_meta[:line] - 1, end_meta[:column] - 1}
+          else
+            acc
+          end
+        _ -> acc
+      end
+    else
+      eoe
+    end
+
+    eoe = if eoe == acc do
+      {soe_line, soe_column} = find_start_of_expression(ast, {nil, nil})
+      {soe_line, soe_column} = if {soe_line, soe_column} == {nil, nil} do
+        acc
+      else
+        {soe_line, soe_column}
+      end
+
+      code = ast |> dbg |> Code.quoted_to_algebra |> Inspect.Algebra.format(:infinity) |> IO.iodata_to_binary()
+      lines = code |> SourceFile.lines()
+      case lines do
+        [_] -> {soe_line, soe_column + String.length(code)}
+        _ ->
+          last_line = Enum.at(lines, -1)
+          {soe_line + length(lines) - 1, String.length(last_line)}
+      end
+    else
+      eoe
+    end
+    dbg({ast, eoe})
+    eoe
   end
 end

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -16,8 +16,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   defp token_length(token) when token in [:"<<", :">>", :do, :fn], do: 2
   defp token_length(_), do: 0
 
-  # TODO => |
-  @stop_tokens [:",", :";", :eol]
+  @stop_tokens [:",", :";", :eol, :eof, :pipe_op]
 
   def selection_ranges(text, positions) do
     lines = SourceFile.lines(text)

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -10,6 +10,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   import ElixirLS.LanguageServer.Protocol
   import ElixirLS.LanguageServer.RangeUtils
   alias ElixirLS.LanguageServer.AstUtils
+  alias ElixirSense.Core.Normalized.Code, as: NormalizedCode
 
   defp token_length(:end), do: 3
   defp token_length(token) when token in [:"(", :"[", :"{", :")", :"]", :"}"], do: 1
@@ -402,7 +403,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
   def ast_node_ranges(_, _, _), do: []
 
   def surround_context_ranges(text, line, character) do
-    case Code.Fragment.surround_context(text, {line + 1, character + 1}) do
+    case NormalizedCode.Fragment.surround_context(text, {line + 1, character + 1}) do
       :none ->
         []
 

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -355,7 +355,10 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
             case AstUtils.node_range(ast) do
               range(start_line, start_character, end_line, end_character) ->
                 start_character =
-                  if form == :%{} and match?({:%, _, _}, parent_ast_from_stack) do
+                  if form == :%{} and match?({:%, _, _}, parent_ast_from_stack) and
+                       Version.match?(System.version(), "< 1.16.2") do
+                    # workaround elixir bug
+                    # https://github.com/elixir-lang/elixir/commit/fd4e6b530c0e010712b06909c89820b08e49c238
                     # undo column offset for structs inner map node
                     start_character + 1
                   else

--- a/apps/language_server/lib/language_server/providers/selection_ranges.ex
+++ b/apps/language_server/lib/language_server/providers/selection_ranges.ex
@@ -1,0 +1,483 @@
+defmodule ElixirLS.LanguageServer.Providers.SelectionRanges do
+  @moduledoc """
+  This module provides document/selectionRanges support
+
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange
+  """
+
+  alias ElixirLS.LanguageServer.{SourceFile}
+  alias ElixirLS.LanguageServer.Providers.FoldingRange
+  import ElixirLS.LanguageServer.Protocol
+
+  defp token_length(:end), do: 3
+  defp token_length(token) when token in [:"(", :"[", :"{", :")", :"]", :"}"], do: 1
+  defp token_length(token) when token in [:"<<", :">>", :do, :fn], do: 2
+  defp token_length(_), do: 0
+
+  def selection_ranges(text, positions) do
+    lines = SourceFile.lines(text)
+    full_file_range = full_range(lines)
+
+    tokens = FoldingRange.Token.format_string(text)
+
+    token_pairs = FoldingRange.TokenPair.pair_tokens(tokens)
+
+    special_token_groups =
+      for group <- FoldingRange.SpecialToken.group_tokens(tokens) do
+        FoldingRange.Helpers.first_and_last_of_list(group)
+      end
+
+    formatted_lines = FoldingRange.Line.format_string(text)
+
+    comment_groups =
+      formatted_lines
+      |> FoldingRange.CommentBlock.group_comments()
+
+    parse_result =
+      Code.string_to_quoted(text,
+        token_metadata: true,
+        columns: true,
+        literal_encoder: fn literal, meta ->
+          {:ok, {literal, meta, nil}}
+        end
+      )
+
+    cell_pairs =
+      formatted_lines
+      |> Enum.map(&FoldingRange.Indentation.extract_cell/1)
+      |> FoldingRange.Indentation.pair_cells()
+
+    for %{"line" => line, "character" => character} <- positions do
+      {line, character} = SourceFile.lsp_position_to_elixir(lines, {line, character})
+      # for convenance the code in this module uses 0 based indexing
+      {line, character} = {line - 1, character - 1}
+
+      cell_pair_ranges =
+        ([full_file_range] ++
+           for {{start_line, start_character}, {end_line, _end_line_start_character}} <-
+                 cell_pairs |> dbg,
+               (start_line < line or (start_line == line and start_character <= character)) and
+                 end_line > line do
+             line_length = lines |> Enum.at(end_line - 1) |> String.length()
+             second_line = lines |> Enum.at(start_line + 1)
+
+             second_line_indent =
+               String.length(second_line) - String.length(String.trim_leading(second_line))
+
+             [range(start_line, start_character, end_line - 1, line_length)]
+             |> Kernel.++(
+               if(line >= start_line + 1,
+                 do: [range(start_line + 1, 0, end_line - 1, line_length)],
+                 else: []
+               )
+             )
+             |> Kernel.++(
+               if(
+                 line > start_line + 1 or
+                   (line == start_line + 1 and character >= second_line_indent),
+                 do: [range(start_line + 1, second_line_indent, end_line - 1, line_length)],
+                 else: []
+               )
+             )
+           end)
+        |> List.flatten()
+
+      cell_pair_ranges = sort_ranges(cell_pair_ranges)
+
+      token_pair_ranges =
+        token_pairs
+        |> Enum.filter(fn {{_, {start_line, start_character, _}, _},
+                           {end_token, {end_line, end_character, _}, _}} ->
+          end_token_length = token_length(end_token)
+
+          (start_line < line or (start_line == line and start_character <= character)) and
+            (end_line > line or
+               (end_line == line and end_character + end_token_length >= character))
+        end)
+        |> Enum.reduce([full_file_range], fn {{start_token, {start_line, start_character, _}, _},
+                                              {end_token, {end_line, end_character, _}, _}},
+                                             acc ->
+          start_token_length = token_length(start_token)
+          end_token_length = token_length(end_token)
+
+          outer_range =
+            range(start_line, start_character, end_line, end_character + end_token_length)
+
+          case end_token do
+            :end ->
+              if line < start_line + 1 or line > end_line - 1 do
+                # do not include inner range if cursor is outside, e.g.
+                # do
+                # ^ 
+                [outer_range | acc]
+              else
+                line_length = lines |> Enum.at(end_line - 1) |> String.length()
+                [range(start_line + 1, 0, end_line - 1, line_length), outer_range | acc]
+              end
+
+            _ ->
+              if (start_line == line and start_character + start_token_length > character) or
+                   (end_line == line and end_character < character) do
+                # do not include inner range if cursor is outside, e.g.
+                # << 123 >>
+                # ^        ^
+                [outer_range | acc]
+              else
+                [
+                  range(
+                    start_line,
+                    start_character + start_token_length,
+                    end_line,
+                    end_character
+                  ),
+                  outer_range | acc
+                ]
+              end
+          end
+        end)
+        |> Enum.reverse()
+
+      special_token_group_ranges =
+        [full_file_range] ++
+          for {{_end_token, {end_line, end_character, _}, _},
+               {_start_token, {start_line, start_character, _}, _}} <- special_token_groups,
+              end_token_length = 0,
+              (start_line < line or (start_line == line and start_character <= character)) and
+                (end_line > line or
+                   (end_line == line and end_character + end_token_length >= character)) do
+            range(start_line, start_character, end_line, end_character)
+          end
+
+      comment_block_ranges =
+        [full_file_range] ++
+          (for group <- comment_groups,
+               group != [],
+               {{{end_line, end_line_start_character}, _}, {{start_line, start_character}, _}} =
+                 FoldingRange.Helpers.first_and_last_of_list(group),
+               (start_line < line or (start_line == line and start_character <= character)) and
+                 (end_line > line or (end_line == line and end_line_start_character <= character)) do
+             case group do
+               [_] ->
+                 line_length = lines |> Enum.at(start_line) |> String.length()
+                 full_line_range = range(start_line, 0, start_line, line_length)
+                 [full_line_range, range(start_line, start_character, start_line, line_length)]
+
+               _ ->
+                 end_line_length = lines |> Enum.at(end_line) |> String.length()
+                 full_block_full_line_range = range(start_line, 0, end_line, end_line_length)
+                 full_block_range = range(start_line, start_character, end_line, end_line_length)
+
+                 [full_block_full_line_range, full_block_range] ++
+                   Enum.find_value(group, fn {{cursor_line, cursor_line_character}, _} ->
+                     if cursor_line == line do
+                       cursor_line_length = lines |> Enum.at(cursor_line) |> String.length()
+
+                       line_range =
+                         range(
+                           cursor_line,
+                           cursor_line_character,
+                           cursor_line,
+                           cursor_line_length
+                         )
+
+                       if cursor_line > start_line do
+                         full_line_range = range(cursor_line, 0, cursor_line, cursor_line_length)
+                         [full_line_range, line_range]
+                       else
+                         # do not include full line range if cursor is on the first line of the block as it will conflict with full_block_range
+                         [line_range]
+                       end
+                     end
+                   end)
+             end
+           end
+           |> List.flatten())
+
+      ast_ranges =
+        case parse_result do
+          {:ok, ast} ->
+            {_new_ast, {acc, []}} =
+              Macro.traverse(
+                ast,
+                {[full_file_range], []},
+                fn
+                  {node, meta, _} = ast, {acc, parent_meta} ->
+                    parent_meta_from_stack =
+                      case parent_meta do
+                        [] -> []
+                        [item | _] -> item
+                      end
+
+                    {start_line, start_character} =
+                      {Keyword.get(meta, :line, 0) - 1, Keyword.get(meta, :column, 0) - 1}
+
+                    {end_line, end_character} =
+                      cond do
+                        end_location = meta[:end_of_expression] ->
+                          {end_location[:line] - 1, end_location[:column] - 1}
+
+                        end_location = meta[:end] ->
+                          {end_location[:line] - 1, end_location[:column] - 1 + 3}
+
+                        end_location = meta[:closing] ->
+                          closing_length =
+                            case node do
+                              :<<>> -> 2
+                              _ -> 1
+                            end
+
+                          {end_location[:line] - 1, end_location[:column] - 1 + closing_length}
+
+                        token = meta[:token] ->
+                          {start_line, start_character + String.length(token)}
+
+                        # is_atom(node) ->
+                        #   {start_line, start_character + String.length(to_string(node))}
+
+                        meta[:delimiter] && (is_list(node) or is_binary(node)) ->
+                          {start_line, start_character + String.length(to_string(node))}
+
+                        # TODO a few other cases
+
+                        #   parent_end_line =
+                        #   parent_meta_from_stack
+                        #   |> dbg()
+                        #   |> Keyword.get(:end, [])
+                        #   |> Keyword.get(:line) ->
+                        # # last expression in block does not have end_of_expression
+                        # parent_do_line = parent_meta_from_stack[:do][:line]
+
+                        # if parent_end_line > parent_do_line do
+                        #   # take end location from parent and assume end_of_expression is last char in previous line
+                        #   end_of_expression =
+                        #     Enum.at(lines, max(parent_end_line - 2, 0))
+                        #     |> String.length()
+
+                        #   SourceFile.elixir_position_to_lsp(
+                        #     lines,
+                        #     {parent_end_line - 1, end_of_expression + 1}
+                        #   )
+                        # else
+                        #   # take end location from parent and assume end_of_expression is last char before final ; trimmed
+                        #   line = Enum.at(lines, parent_end_line - 1)
+                        #   parent_end_column = parent_meta_from_stack[:end][:column]
+
+                        #   end_of_expression =
+                        #     line
+                        #     |> String.slice(0..(parent_end_column - 2))
+                        #     |> String.trim_trailing()
+                        #     |> String.replace_trailing(";", "")
+                        #     |> String.length()
+
+                        #   SourceFile.elixir_position_to_lsp(
+                        #     lines,
+                        #     {parent_end_line, end_of_expression + 1}
+                        #   )
+                        # end
+                        true ->
+                          {start_line, start_character}
+                      end
+
+                    if (start_line < line or (start_line == line and start_character <= character)) and
+                         (end_line > line or (end_line == line and end_character >= character)) do
+                      # dbg(ast)
+                      {ast,
+                       {[range(start_line, start_character, end_line, end_character) | acc],
+                        [meta | parent_meta]}}
+                    else
+                      {ast, {acc, [meta | parent_meta]}}
+                    end
+
+                  other, {acc, parent_meta} ->
+                    {other, {acc, parent_meta}}
+                end,
+                fn
+                  {_, _meta, _} = ast, {acc, [_ | tail]} ->
+                    {ast, {acc, tail}}
+
+                  other, {acc, stack} ->
+                    {other, {acc, stack}}
+                end
+              )
+
+            acc
+            |> sort_ranges()
+
+          _ ->
+            [full_file_range]
+        end
+        |> IO.inspect(label: "ast ranges")
+
+      surround_context_ranges =
+        [full_file_range] ++
+          case Code.Fragment.surround_context(text, {line + 1, character + 1}) do
+            :none ->
+              []
+
+            %{begin: {start_line, start_character}, end: {end_line, end_character}} ->
+              [range(start_line - 1, start_character - 1, end_line - 1, end_character - 1)]
+          end
+
+      token_pair_ranges
+      |> merge_ranges(cell_pair_ranges |> dbg)
+      |> merge_ranges(special_token_group_ranges |> dbg)
+      |> merge_ranges(comment_block_ranges |> dbg)
+      |> merge_ranges(surround_context_ranges |> dbg)
+      |> merge_ranges(ast_ranges |> dbg)
+      |> dbg
+      |> Enum.reduce(nil, fn selection_range, parent ->
+        range(start_line_elixir, start_character_elixir, end_line_elixir, end_character_elixir) =
+          selection_range
+
+        # positions are 0-based
+        {start_line_lsp, start_character_lsp} =
+          SourceFile.elixir_position_to_lsp(
+            lines,
+            {start_line_elixir + 1, start_character_elixir + 1}
+          )
+
+        {end_line_lsp, end_character_lsp} =
+          SourceFile.elixir_position_to_lsp(
+            lines,
+            {end_line_elixir + 1, end_character_elixir + 1}
+          )
+
+        %{
+          "range" => range(start_line_lsp, start_character_lsp, end_line_lsp, end_character_lsp),
+          "parent" => parent
+        }
+      end)
+      |> IO.inspect()
+
+      #       cursor_location = SourceFile.lsp_position_to_elixir(text, {line, character})
+    end
+  end
+
+  def merge_ranges(range_1, range_2) do
+    do_merge_ranges(range_1, range_2, [])
+    |> Enum.reverse()
+  end
+
+  def do_merge_ranges([], [], acc) do
+    acc
+  end
+
+  def do_merge_ranges([range | rest_1], [], acc) do
+    do_merge_ranges(rest_1, [], [range | acc])
+  end
+
+  def do_merge_ranges([], [range | rest_2], acc) do
+    do_merge_ranges([], rest_2, [range | acc])
+  end
+
+  def do_merge_ranges([range | rest_1], [range | rest_2], acc) do
+    do_merge_ranges(rest_1, rest_2, [range | acc])
+  end
+
+  def do_merge_ranges([range_1 | rest_1], [range_2 | rest_2], acc) do
+    IO.inspect({range_1, range_2}, label: "merging")
+    IO.inspect(acc, label: "acc")
+
+    range_2 =
+      case acc do
+        [] ->
+          range_2
+
+        [last_range | _] ->
+          # we might have added a narrower range by favoring range_1 in the previous iteration
+          # compute intersection
+          intersection(last_range, range_2)
+      end
+
+    cond do
+      left_in_right?(range_2, range_1) ->
+        # range_2 in range_1
+        IO.puts("range_2 in range_1")
+        do_merge_ranges(rest_1, [range_2 | rest_2], [range_1 | acc])
+
+      left_in_right?(range_1, range_2) ->
+        # range_1 in range_2
+        IO.puts("range_1 in range_2")
+        do_merge_ranges([range_1 | rest_1], rest_2, [range_2 | acc])
+
+      true ->
+        # ranges intersect - add union and favor range_1
+        union_range = union(range_1, range_2)
+        IO.inspect(union_range, label: "union")
+        do_merge_ranges(rest_1, rest_2, [range_1, union_range | acc])
+    end
+  end
+
+  # this function differs from the one in SourceFile - it returns utf8 ranges
+  defp full_range(lines) do
+    utf8_size =
+      lines
+      |> List.last()
+      |> String.length()
+
+    range(0, 0, Enum.count(lines) - 1, utf8_size)
+  end
+
+  defp sort_ranges(ranges) do
+    ranges
+    |> Enum.sort_by(fn range(start_line, start_character, end_line, end_character) ->
+      {start_line - end_line, start_character - end_character}
+    end)
+  end
+
+  defp union(
+         range(start_line_1, start_character_1, end_line_1, end_character_1),
+         range(start_line_2, start_character_2, end_line_2, end_character_2)
+       ) do
+    {start_line, start_character} =
+      cond do
+        start_line_1 < start_line_2 -> {start_line_1, start_character_1}
+        start_line_1 > start_line_2 -> {start_line_2, start_character_2}
+        true -> {start_line_1, min(start_character_1, start_character_2)}
+      end
+
+    {end_line, end_character} =
+      cond do
+        end_line_1 < end_line_2 -> {end_line_2, end_character_2}
+        end_line_1 > end_line_2 -> {end_line_1, end_character_1}
+        true -> {end_line_1, max(end_character_1, end_character_2)}
+      end
+
+    range(start_line, start_character, end_line, end_character)
+  end
+
+  defp intersection(
+         range(start_line_1, start_character_1, end_line_1, end_character_1),
+         range(start_line_2, start_character_2, end_line_2, end_character_2)
+       ) do
+    {start_line, start_character} =
+      cond do
+        start_line_1 < start_line_2 -> {start_line_2, start_character_2}
+        start_line_1 > start_line_2 -> {start_line_1, start_character_1}
+        true -> {start_line_1, max(start_character_1, start_character_2)}
+      end
+
+    {end_line, end_character} =
+      cond do
+        end_line_1 < end_line_2 -> {end_line_1, end_character_1}
+        end_line_1 > end_line_2 -> {end_line_2, end_character_2}
+        true -> {end_line_1, min(end_character_1, end_character_2)}
+      end
+
+    if start_line > end_line or (start_line == end_line and start_character > end_character) do
+      raise ArgumentError, message: "no intersection"
+    end
+
+    range(start_line, start_character, end_line, end_character)
+  end
+
+  defp left_in_right?(
+         range(start_line_1, start_character_1, end_line_1, end_character_1),
+         range(start_line_2, start_character_2, end_line_2, end_character_2)
+       ) do
+    (start_line_1 > start_line_2 or
+       (start_line_1 == start_line_2 and start_character_1 >= start_character_2)) and
+      (end_line_1 < end_line_2 or
+         (end_line_1 == end_line_2 and end_character_1 <= end_character_2))
+  end
+end

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -5,7 +5,15 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
 
   import ElixirLS.LanguageServer.Protocol
 
-  @type range_t :: map
+  # this function differs from the one in SourceFile - it returns utf8 ranges
+  def full_range(lines) do
+    utf8_size =
+      lines
+      |> List.last()
+      |> String.length()
+
+    range(0, 0, Enum.count(lines) - 1, utf8_size)
+  end
 
   def valid?(range(start_line, start_character, end_line, end_character))
       when is_integer(start_line) and is_integer(end_line) and is_integer(start_character) and
@@ -23,7 +31,6 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
       increasingly_narrowing?([right | rest])
   end
 
-  @spec left_in_right?(range_t, range_t) :: boolean
   def left_in_right?(
         range(start_line_1, start_character_1, end_line_1, end_character_1),
         range(start_line_2, start_character_2, end_line_2, end_character_2)

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -6,7 +6,7 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
   import ElixirLS.LanguageServer.Protocol
 
   # this function differs from the one in SourceFile - it returns utf8 ranges
-  def full_range(lines) do
+  def full_range(lines = [_ | _]) do
     utf8_size =
       lines
       |> List.last()

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -15,6 +15,11 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
     range(0, 0, Enum.count(lines) - 1, utf8_size)
   end
 
+  def in?(range(start_line, start_character, end_line, end_character), {line, character}) do
+    (start_line < line or (start_line == line and start_character <= character)) and
+      (end_line > line or (end_line == line and end_character >= character))
+  end
+
   def valid?(range(start_line, start_character, end_line, end_character))
       when is_integer(start_line) and is_integer(end_line) and is_integer(start_character) and
              is_integer(end_character) do

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -160,10 +160,12 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
   end
 
   defp do_deduplicate([], acc), do: acc
+
   defp do_deduplicate([range | rest], [range | _] = acc) do
     do_deduplicate(rest, acc)
   end
-  defp do_deduplicate([range | rest], acc) do 
+
+  defp do_deduplicate([range | rest], acc) do
     do_deduplicate(rest, [range | acc])
   end
 end

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -153,4 +153,17 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
   defp trim_range_to_acc(range, [acc_range | _]) do
     intersection(range, acc_range)
   end
+
+  def deduplicate(ranges) do
+    do_deduplicate(ranges, [])
+    |> Enum.reverse()
+  end
+
+  defp do_deduplicate([], acc), do: acc
+  defp do_deduplicate([range | rest], [range | _] = acc) do
+    do_deduplicate(rest, acc)
+  end
+  defp do_deduplicate([range | rest], acc) do 
+    do_deduplicate(rest, [range | acc])
+  end
 end

--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -1,0 +1,156 @@
+defmodule ElixirLS.LanguageServer.RangeUtils do
+  @moduledoc """
+  Utilities for working with ranges.
+  """
+
+  import ElixirLS.LanguageServer.Protocol
+
+  @type range_t :: map
+
+  def valid?(range(start_line, start_character, end_line, end_character))
+      when is_integer(start_line) and is_integer(end_line) and is_integer(start_character) and
+             is_integer(end_character) do
+    (start_line >= 0 and end_line >= 0 and start_character >= 0 and end_character >= 0 and
+       start_line < end_line) or (start_line == end_line and start_character <= end_character)
+  end
+
+  def valid?(_), do: false
+
+  def increasingly_narrowing?([left]), do: valid?(left)
+
+  def increasingly_narrowing?([left, right | rest]) do
+    valid?(left) and valid?(right) and left_in_right?(right, left) and
+      increasingly_narrowing?([right | rest])
+  end
+
+  @spec left_in_right?(range_t, range_t) :: boolean
+  def left_in_right?(
+        range(start_line_1, start_character_1, end_line_1, end_character_1),
+        range(start_line_2, start_character_2, end_line_2, end_character_2)
+      ) do
+    (start_line_1 > start_line_2 or
+       (start_line_1 == start_line_2 and start_character_1 >= start_character_2)) and
+      (end_line_1 < end_line_2 or
+         (end_line_1 == end_line_2 and end_character_1 <= end_character_2))
+  end
+
+  def sort_ranges_widest_to_narrowest(ranges) do
+    ranges
+    |> Enum.sort_by(fn range(start_line, start_character, end_line, end_character) ->
+      {start_line - end_line, start_character - end_character}
+    end)
+  end
+
+  def union(
+        range(start_line_1, start_character_1, end_line_1, end_character_1) = left,
+        range(start_line_2, start_character_2, end_line_2, end_character_2) = right
+      ) do
+    _intersection = intersection(left, right)
+
+    {start_line, start_character} =
+      cond do
+        start_line_1 < start_line_2 -> {start_line_1, start_character_1}
+        start_line_1 > start_line_2 -> {start_line_2, start_character_2}
+        true -> {start_line_1, min(start_character_1, start_character_2)}
+      end
+
+    {end_line, end_character} =
+      cond do
+        end_line_1 < end_line_2 -> {end_line_2, end_character_2}
+        end_line_1 > end_line_2 -> {end_line_1, end_character_1}
+        true -> {end_line_1, max(end_character_1, end_character_2)}
+      end
+
+    range(start_line, start_character, end_line, end_character)
+  end
+
+  def intersection(
+        range(start_line_1, start_character_1, end_line_1, end_character_1),
+        range(start_line_2, start_character_2, end_line_2, end_character_2)
+      ) do
+    {start_line, start_character} =
+      cond do
+        start_line_1 < start_line_2 -> {start_line_2, start_character_2}
+        start_line_1 > start_line_2 -> {start_line_1, start_character_1}
+        true -> {start_line_1, max(start_character_1, start_character_2)}
+      end
+
+    {end_line, end_character} =
+      cond do
+        end_line_1 < end_line_2 -> {end_line_1, end_character_1}
+        end_line_1 > end_line_2 -> {end_line_2, end_character_2}
+        true -> {end_line_1, min(end_character_1, end_character_2)}
+      end
+
+    result = range(start_line, start_character, end_line, end_character)
+
+    if not valid?(result) do
+      raise ArgumentError, message: "no intersection"
+    end
+
+    result
+  end
+
+  def merge_ranges_lists(ranges_1, ranges_2) do
+    if hd(ranges_1) != hd(ranges_2) do
+      raise ArgumentError, message: "range list do not start with the same range"
+    end
+
+    if not increasingly_narrowing?(ranges_1) do
+      raise ArgumentError, message: "ranges_1 is not increasingly narrowing"
+    end
+
+    if not increasingly_narrowing?(ranges_2) do
+      raise ArgumentError, message: "ranges_2 is not increasingly narrowing"
+    end
+
+    do_merge_ranges(ranges_1, ranges_2, [])
+    |> Enum.reverse()
+  end
+
+  defp do_merge_ranges([], [], acc) do
+    acc
+  end
+
+  defp do_merge_ranges([range_1 | rest_1], [], acc) do
+    # range_1 is guaranteed to be increasingly narrowing
+    do_merge_ranges(rest_1, [], [range_1 | acc])
+  end
+
+  defp do_merge_ranges([], [range_2 | rest_2], acc) do
+    # we might have added a narrower range by favoring range_1 in the previous iteration
+    range_2 = trim_range_to_acc(range_2, acc)
+
+    do_merge_ranges([], rest_2, [range_2 | acc])
+  end
+
+  defp do_merge_ranges([range | rest_1], [range | rest_2], acc) do
+    do_merge_ranges(rest_1, rest_2, [range | acc])
+  end
+
+  defp do_merge_ranges([range_1 | rest_1], [range_2 | rest_2], acc) do
+    # we might have added a narrower range by favoring range_1 in the previous iteration
+    range_2 = trim_range_to_acc(range_2, acc)
+
+    cond do
+      left_in_right?(range_2, range_1) ->
+        # range_2 in range_1
+        do_merge_ranges(rest_1, [range_2 | rest_2], [range_1 | acc])
+
+      left_in_right?(range_1, range_2) ->
+        # range_1 in range_2
+        do_merge_ranges([range_1 | rest_1], rest_2, [range_2 | acc])
+
+      true ->
+        # ranges intersect - add union and favor range_1
+        union_range = union(range_1, range_2)
+        do_merge_ranges(rest_1, rest_2, [range_1, union_range | acc])
+    end
+  end
+
+  defp trim_range_to_acc(range, []), do: range
+
+  defp trim_range_to_acc(range, [acc_range | _]) do
+    intersection(range, acc_range)
+  end
+end

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1224,7 +1224,17 @@ defmodule ElixirLS.LanguageServer.Server do
 
     fun = fn ->
       if String.ends_with?(uri, [".ex", ".exs"]) or source_file.language_id in ["elixir"] do
-        ranges = SelectionRanges.selection_ranges(source_file.text, positions)
+        formatter_opts =
+          case SourceFile.formatter_for(uri, state.project_dir, state.mix_project?) do
+            {:ok, {_, opts, _formatter_exs_dir}} -> opts
+            {:error, _} -> []
+          end
+
+        ranges =
+          SelectionRanges.selection_ranges(source_file.text, positions,
+            formatter_opts: formatter_opts
+          )
+
         {:ok, ranges}
       else
         # TODO no support for eex

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -940,7 +940,6 @@ defmodule ElixirLS.LanguageServer.Server do
        )
        when not is_initialized(server_instance_id) do
     show_version_warnings()
-    IO.inspect(client_capabilities)
 
     server_instance_id =
       :crypto.strong_rand_bytes(32) |> Base.url_encode64() |> binary_part(0, 32)

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -83,7 +83,7 @@ defmodule ElixirLS.LanguageServer.SourceFile do
   end
 
   def full_range(source_file) do
-    lines = lines(source_file)
+    [_ | _] = lines = lines(source_file)
 
     utf16_size =
       lines

--- a/apps/language_server/test/ast_utils_test.exs
+++ b/apps/language_server/test/ast_utils_test.exs
@@ -336,8 +336,10 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range("local.(123)") == range(0, 0, 0, 11)
     end
 
-    test "nested call" do
-      assert get_range("local.prop.foo") == range(0, 0, 0, 14)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "nested call" do
+        assert get_range("local.prop.foo") == range(0, 0, 0, 14)
+      end
     end
 
     test "access" do

--- a/apps/language_server/test/ast_utils_test.exs
+++ b/apps/language_server/test/ast_utils_test.exs
@@ -250,7 +250,6 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range(text) == range(0, 0, 4, 3)
     end
 
-    # TODO
     test "if short notation" do
       text = """
       if true, do: 1
@@ -353,6 +352,10 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range("&Some.fun/1") == range(0, 0, 0, 11)
     end
 
+    test "anonymous capture" do
+      assert get_range("& &1 + 1") == range(0, 0, 0, 8)
+    end
+
     test "complicated local call" do
       text = """
       fun(%My{} = my, keyword: 123, other: [:a, ""])
@@ -369,6 +372,47 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       """
 
       assert get_range(text) == range(0, 0, 2, 3)
+    end
+
+    test "anonymous function no args" do
+      test = """
+      fn -> 1 end
+      """
+      assert get_range(test) == range(0, 0, 0, 11)
+    end
+
+    test "anonymous function multiple args" do
+      test = """
+      fn a, b -> 1 end
+      """
+      assert get_range(test) == range(0, 0, 0, 16)
+    end
+
+    test "anonymous function multiple clauses" do
+      test = """
+      fn
+        1 -> 1
+        _ -> 2
+      end
+      """
+      assert get_range(test) == range(0, 0, 3, 3)
+    end
+
+    test "with" do
+      text = """
+      with {:ok, x} <- foo() do
+        x
+      end
+      """
+      assert get_range(text) == range(0, 0, 2, 3)
+    end
+
+    test "def short notation" do
+      test = ~S"""
+      defp name(%Config{} = config),
+        do: :"#{__MODULE__}_#{config.node_id}_#{config.channel_unique_id}"
+      """
+      assert get_range(test) == range(0, 0, 1, 39)
     end
   end
 end

--- a/apps/language_server/test/ast_utils_test.exs
+++ b/apps/language_server/test/ast_utils_test.exs
@@ -336,6 +336,18 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range("local.(123)") == range(0, 0, 0, 11)
     end
 
+    test "nested call" do
+      assert get_range("local.prop.foo") == range(0, 0, 0, 14)
+    end
+
+    test "access" do
+      assert get_range("local[\"some\"]") == range(0, 0, 0, 13)
+    end
+
+    test "nested access" do
+      assert get_range("local[\"some\"][1]") == range(0, 0, 0, 16)
+    end
+
     test "remote call" do
       assert get_range("Some.fun(123)") == range(0, 0, 0, 13)
     end
@@ -404,6 +416,10 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
 
     test "remote capture" do
       assert get_range("&Some.fun/1") == range(0, 0, 0, 11)
+    end
+
+    test "remote capture quoted" do
+      assert get_range("&Some.\"fun\"/1") == range(0, 0, 0, 13)
     end
 
     test "anonymous capture" do

--- a/apps/language_server/test/ast_utils_test.exs
+++ b/apps/language_server/test/ast_utils_test.exs
@@ -1,0 +1,374 @@
+defmodule ElixirLS.LanguageServer.AstUtilsTest do
+  use ExUnit.Case
+
+  import ElixirLS.LanguageServer.Protocol
+  import ElixirLS.LanguageServer.AstUtils
+
+  defp get_range(code) do
+    IO.puts(code)
+    {:ok, ast} = Code.string_to_quoted(code, columns: true, token_metadata: true, unescape: false, literal_encoder: &{:ok, {:__block__, &2, [&1]}})
+    dbg(ast)
+    node_range(ast)
+  end
+
+  describe "literals" do
+    test "true" do
+      assert get_range("true") == range(0, 0, 0, 4)
+    end
+
+    test "false" do
+      assert get_range("false") == range(0, 0, 0, 5)
+    end
+
+    test "nil" do
+      assert get_range("nil") == range(0, 0, 0, 3)
+    end
+
+    test "integer" do
+      assert get_range("1234") == range(0, 0, 0, 4)
+    end
+
+    test "float" do
+      assert get_range("123.4") == range(0, 0, 0, 5)
+    end
+
+    test "atom" do
+      assert get_range(":abc") == range(0, 0, 0, 4)
+    end
+
+    test "quoted atom string" do
+      assert get_range(":\"abc\"") == range(0, 0, 0, 6)
+    end
+
+    test "quoted atom charlist" do
+      assert get_range(":'abc'") == range(0, 0, 0, 6)
+    end
+
+    test "string" do
+      assert get_range("\"abc\"") == range(0, 0, 0, 5)
+    end
+
+    test "charlist" do
+      assert get_range("'abc'") == range(0, 0, 0, 5)
+    end
+
+    test "string with newlines" do
+      assert get_range("\"ab\nc\"") == range(0, 0, 1, 2)
+    end
+
+    test "charlist with newlines" do
+      assert get_range("'ab\nc'") == range(0, 0, 1, 2)
+    end
+
+    test "string heredoc" do
+      assert get_range("\"\"\"\nabc\n\"\"\"") == range(0, 0, 2, 3)
+    end
+
+    test "string heredoc with indentation" do
+      assert get_range("\"\"\"\n  abc\n  \"\"\"") == range(0, 0, 2, 5)
+    end
+
+    test "charlist heredoc" do
+      assert get_range("'''\nabc\n'''") == range(0, 0, 2, 3)
+    end
+
+    test "charlist heredoc with indentation" do
+      assert get_range("'''\n  abc\n  '''") == range(0, 0, 2, 5)
+    end
+
+    test "string interpolated" do
+      assert get_range("\"abc \#{inspect(a)} sd\"") == range(0, 0, 0, 22)
+    end
+
+    test "charlist interpolated" do
+      assert get_range("'abc \#{inspect(a)} sd'") == range(0, 0, 0, 22)
+    end
+
+    test "sigil" do
+      assert get_range("~w(asd fgh)") == range(0, 0, 0, 11)
+    end
+
+    test "sigil with modifier" do
+      assert get_range("~w(asd fgh)a") == range(0, 0, 0, 12)
+    end
+
+    test "sigil with interpolation" do
+      text = "~s(asd " <> "\#" <> "{" <> "inspect(self())" <> "} fgh)"
+      assert get_range(text) == range(0, 0, 0, 30)
+    end
+    
+    test "sigil with heredoc string" do
+      text = """
+      ~S\"\"\"
+      some text
+      \"\"\"
+      """
+      assert get_range(text) == range(0, 0, 2, 3)
+    end
+
+    test "sigil with heredoc charlist" do
+      text = """
+      ~S'''
+      some text
+      '''
+      """
+      assert get_range(text) == range(0, 0, 2, 3)
+    end
+
+    test "empty tuple" do
+      assert get_range("{}") == range(0, 0, 0, 2)
+    end
+
+    test "1 element tuple" do
+      assert get_range("{:ok}") == range(0, 0, 0, 5)
+    end
+
+    test "2 element tuple" do
+      assert get_range("{:ok, 123}") == range(0, 0, 0, 10)
+    end
+
+    test "3 element tuple" do
+      assert get_range("{:ok, 123, nil}") == range(0, 0, 0, 15)
+    end
+
+    test "empty list" do
+      assert get_range("[]") == range(0, 0, 0, 2)
+    end
+
+    test "1 element list" do
+      assert get_range("[123]") == range(0, 0, 0, 5)
+    end
+
+    test "2 element list" do
+      assert get_range("[123, 456]") == range(0, 0, 0, 10)
+    end
+
+    test "1 element list with cons operator" do
+      assert get_range("[123 | abc]") == range(0, 0, 0, 11)
+    end
+
+    test "2 element list with cons operator" do
+      assert get_range("[123, 456 | abc]") == range(0, 0, 0, 16)
+    end
+
+    test "keyword" do
+      assert get_range("[abc: 2]") == range(0, 0, 0, 8)
+    end
+
+    test "empty map" do
+      assert get_range("%{}") == range(0, 0, 0, 3)
+    end
+
+    test "map with string key" do
+      assert get_range("%{\"abc\" => 1}") == range(0, 0, 0, 13)
+    end
+
+    test "map with atom key" do
+      assert get_range("%{abc: 1}") == range(0, 0, 0, 9)
+    end
+
+    test "map update syntax" do
+      assert get_range("%{var | abc: 1}") == range(0, 0, 0, 15)
+    end
+
+    test "alias" do
+      assert get_range("Some") == range(0, 0, 0, 4)
+    end
+
+    test "alias nested" do
+      assert get_range("Some.Foo") == range(0, 0, 0, 8)
+    end
+
+    test "empty struct" do
+      assert get_range("%Some{}") == range(0, 0, 0, 7)
+    end
+
+    test "struct with atom key" do
+      assert get_range("%Some{abc: 1}") == range(0, 0, 0, 13)
+    end
+
+    test "struct update syntax" do
+      assert get_range("%Some{var | abc: 1}") == range(0, 0, 0, 19)
+    end
+
+    test "empty bitstring" do
+      assert get_range("<<>>") == range(0, 0, 0, 4)
+    end
+
+    test "bitstring with content" do
+      assert get_range("<< 0 >>") == range(0, 0, 0, 7)
+    end
+
+    test "variable" do
+      assert get_range("var") == range(0, 0, 0, 3)
+    end
+
+    test "module attribute" do
+      assert get_range("@attr") == range(0, 0, 0, 5)
+    end
+
+    test "module attribute definition" do
+      assert get_range("@attr 123") == range(0, 0, 0, 9)
+    end
+
+    test "binary operator" do
+      assert get_range("var + foo") == range(0, 0, 0, 9)
+    end
+
+    test "nested binary operators" do
+      assert get_range("var * 3 + foo / x") == range(0, 0, 0, 17)
+    end
+
+    # Parser is simplifying the expression and not including the parens
+    # test "nested binary operators with parens" do
+    #   assert get_range("var * 3 * (foo + x)") == range(0, 0, 0, 17)
+    # end
+
+    test "nested binary and unary operators" do
+      assert get_range("var * 3 + foo / -x") == range(0, 0, 0, 18)
+    end
+
+    test "if" do
+      text = """
+      if true do
+        1
+      end
+      """
+
+      assert get_range(text) == range(0, 0, 2, 3)
+    end
+
+    test "if else" do
+      text = """
+      if true do
+        1
+      else
+        2
+      end
+      """
+
+      assert get_range(text) == range(0, 0, 4, 3)
+    end
+
+    # TODO
+    test "if short notation" do
+      text = """
+      if true, do: 1
+      """
+
+      assert get_range(text) == range(0, 0, 0, 14)
+    end
+
+    test "case" do
+      text = """
+      case x do
+        ^abc ->
+          :ok
+        true ->
+          :error
+      end
+      """
+
+      assert get_range(text) == range(0, 0, 5, 3)
+    end
+
+    test "cond" do
+      text = """
+      cond do
+        abc == 1 ->
+          :ok
+        true ->
+          :error
+      end
+      """
+
+      assert get_range(text) == range(0, 0, 5, 3)
+    end
+
+    test "local call" do
+      assert get_range("local(123)") == range(0, 0, 0, 10)
+    end
+
+    test "variable call" do
+      assert get_range("local.(123)") == range(0, 0, 0, 11)
+    end
+
+    test "remote call" do
+      assert get_range("Some.fun(123)") == range(0, 0, 0, 13)
+    end
+
+    test "remote call on atom" do
+      assert get_range(":some.fun(123)") == range(0, 0, 0, 14)
+    end
+
+    test "remote call quoted" do
+      assert get_range("Some.\"0fun\"(123)") == range(0, 0, 0, 16)
+    end
+
+    test "remote call pipe" do
+      text = """
+      123
+      |> Some.fun1()
+      """
+      assert get_range(text) == range(0, 0, 1, 14)
+    end
+
+    test "remote call pipe no parens" do
+      text = """
+      123
+      |> Some.fun1
+      """
+      assert get_range(text) == range(0, 0, 1, 12)
+    end
+
+    test "local call pipe" do
+      text = """
+      123
+      |> local()
+      """
+      assert get_range(text) == range(0, 0, 1, 10)
+    end
+
+    test "local call pipe no parens" do
+      text = """
+      123
+      |> local
+      """
+      assert get_range(text) == range(0, 0, 1, 8)
+    end
+
+    test "local call no parens" do
+      assert get_range("local 123") == range(0, 0, 0, 9)
+    end
+
+    test "remote call no parens" do
+      assert get_range("Some.fun 123") == range(0, 0, 0, 12)
+    end
+
+    test "local capture" do
+      assert get_range("&local/1") == range(0, 0, 0, 8)
+    end
+
+    test "remote capture" do
+      assert get_range("&Some.fun/1") == range(0, 0, 0, 11)
+    end
+
+    test "complicated local call" do
+      text = """
+      fun(%My{} = my, keyword: 123, other: [:a, ""])
+      """
+
+      assert get_range(text) == range(0, 0, 0, 46)
+    end
+
+    test "block" do
+      text = """
+      a = foo()
+      b = bar()
+      :ok
+      """
+
+      assert get_range(text) == range(0, 0, 2, 3)
+    end
+  end
+end

--- a/apps/language_server/test/ast_utils_test.exs
+++ b/apps/language_server/test/ast_utils_test.exs
@@ -44,20 +44,28 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range(":abc") == range(0, 0, 0, 4)
     end
 
-    test "quoted atom string" do
-      assert get_range(":\"abc\"") == range(0, 0, 0, 6)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "quoted atom string" do
+        assert get_range(":\"abc\"") == range(0, 0, 0, 6)
+      end
     end
 
-    test "quoted atom charlist" do
-      assert get_range(":'abc'") == range(0, 0, 0, 6)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "quoted atom charlist" do
+        assert get_range(":'abc'") == range(0, 0, 0, 6)
+      end
     end
 
-    test "quoted atom string interpolated" do
-      assert get_range(":\"ab\#{inspect(self())}c\"") == range(0, 0, 0, 24)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "quoted atom string interpolated" do
+        assert get_range(":\"ab\#{inspect(self())}c\"") == range(0, 0, 0, 24)
+      end
     end
 
-    test "quoted atom charlist interpolated" do
-      assert get_range(":'ab\#{inspect(self())}c'") == range(0, 0, 0, 24)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "quoted atom charlist interpolated" do
+        assert get_range(":'ab\#{inspect(self())}c'") == range(0, 0, 0, 24)
+      end
     end
 
     test "string" do
@@ -80,32 +88,42 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range("\"\"\"\nabc\n\"\"\"") == range(0, 0, 2, 3)
     end
 
-    test "string heredoc with indentation" do
-      assert get_range("\"\"\"\n  abc\n  \"\"\"") == range(0, 0, 2, 5)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "string heredoc with indentation" do
+        assert get_range("\"\"\"\n  abc\n  \"\"\"") == range(0, 0, 2, 5)
+      end
     end
 
     test "charlist heredoc" do
       assert get_range("'''\nabc\n'''") == range(0, 0, 2, 3)
     end
 
-    test "charlist heredoc with indentation" do
-      assert get_range("'''\n  abc\n  '''") == range(0, 0, 2, 5)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "charlist heredoc with indentation" do
+        assert get_range("'''\n  abc\n  '''") == range(0, 0, 2, 5)
+      end
     end
 
     test "string interpolated" do
       assert get_range("\"abc \#{inspect(a)} sd\"") == range(0, 0, 0, 22)
     end
 
-    test "charlist interpolated" do
-      assert get_range("'abc \#{inspect(a)} sd'") == range(0, 0, 0, 22)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "charlist interpolated" do
+        assert get_range("'abc \#{inspect(a)} sd'") == range(0, 0, 0, 22)
+      end
     end
 
-    test "string heredoc interpolated" do
-      assert get_range("\"\"\"\nab\#{inspect(a)}c\n\"\"\"") == range(0, 0, 2, 3)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "string heredoc interpolated" do
+        assert get_range("\"\"\"\nab\#{inspect(a)}c\n\"\"\"") == range(0, 0, 2, 3)
+      end
     end
 
-    test "charlist heredoc interpolated" do
-      assert get_range("'''\nab\#{inspect(a)}c\n'''") == range(0, 0, 2, 3)
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "charlist heredoc interpolated" do
+        assert get_range("'''\nab\#{inspect(a)}c\n'''") == range(0, 0, 2, 3)
+      end
     end
 
     test "sigil" do
@@ -343,13 +361,15 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range(text) == range(0, 0, 1, 14)
     end
 
-    test "remote call pipe no parens" do
-      text = """
-      123
-      |> Some.fun1
-      """
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "remote call pipe no parens" do
+        text = """
+        123
+        |> Some.fun1
+        """
 
-      assert get_range(text) == range(0, 0, 1, 12)
+        assert get_range(text) == range(0, 0, 1, 12)
+      end
     end
 
     test "local call pipe" do
@@ -445,13 +465,15 @@ defmodule ElixirLS.LanguageServer.AstUtilsTest do
       assert get_range(text) == range(0, 0, 2, 3)
     end
 
-    test "def short notation" do
-      test = ~S"""
-      defp name(%Config{} = config),
-        do: :"#{__MODULE__}_#{config.node_id}_#{config.channel_unique_id}"
-      """
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
+      test "def short notation" do
+        test = ~S"""
+        defp name(%Config{} = config),
+          do: :"#{__MODULE__}_#{config.node_id}_#{config.channel_unique_id}"
+        """
 
-      assert get_range(test) == range(0, 0, 1, 68)
+        assert get_range(test) == range(0, 0, 1, 68)
+      end
     end
   end
 end

--- a/apps/language_server/test/providers/folding_range_test.exs
+++ b/apps/language_server/test/providers/folding_range_test.exs
@@ -355,7 +355,7 @@ defmodule ElixirLS.LanguageServer.Providers.FoldingRangeTest do
 
     @tag text: """
          defmodule A do          # 0
-           @module doc ~S\"\"\"
+           @moduledoc ~S\"\"\"
            sigil @moduledoc      # 2
            \"\"\"
 

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -1058,8 +1058,8 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       assert_range(ranges, range(0, 0, 1, 0))
       # full map
       assert_range(ranges, range(0, 0, 0, 79))
-      # |
-      assert_range(ranges, range(0, 8, 0, 9))
+      # | expression
+      assert_range(ranges, range(0, 2, 0, 78))
     end
   end
 end

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -21,8 +21,10 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     flatten(parent, [range | acc])
   end
 
-  defp assert_range(ranges, expected) do
-    assert Enum.any?(ranges, & &1 == expected)
+  defmacrop assert_range(ranges, expected) do
+    quote do
+      assert Enum.any?(unquote(ranges), &(&1 == unquote(expected)))
+    end
   end
 
   describe "token pair ranges" do
@@ -34,15 +36,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 3)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # [] outside
-      assert_range ranges, range(0, 0, 0, 11)
+      assert_range(ranges, range(0, 0, 0, 11))
       # [] inside
-      assert_range ranges, range(0, 1, 0, 10)
+      assert_range(ranges, range(0, 1, 0, 10))
       # {} outside
-      assert_range ranges, range(0, 1, 0, 7)
+      assert_range(ranges, range(0, 1, 0, 7))
       # {} inside
-      assert_range ranges, range(0, 2, 0, 6)
+      assert_range(ranges, range(0, 2, 0, 6))
     end
 
     test "brackets cursor inside left" do
@@ -53,11 +55,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 1)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # {} outside
-      assert_range ranges, range(0, 0, 0, 6)
+      assert_range(ranges, range(0, 0, 0, 6))
       # {} inside
-      assert_range ranges, range(0, 1, 0, 5)
+      assert_range(ranges, range(0, 1, 0, 5))
     end
 
     test "brackets cursor inside right" do
@@ -68,11 +70,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # {} outside
-      assert_range ranges, range(0, 0, 0, 6)
+      assert_range(ranges, range(0, 0, 0, 6))
       # {} inside
-      assert_range ranges, range(0, 1, 0, 5)
+      assert_range(ranges, range(0, 1, 0, 5))
     end
 
     test "brackets cursor outside left" do
@@ -83,9 +85,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 0)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # {} outside
-      assert_range ranges, range(0, 0, 0, 6)
+      assert_range(ranges, range(0, 0, 0, 6))
     end
 
     test "brackets cursor outside right" do
@@ -96,9 +98,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 0)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # {} outside
-      assert_range ranges, range(0, 0, 0, 6)
+      assert_range(ranges, range(0, 0, 0, 6))
     end
   end
 
@@ -110,9 +112,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 1)
 
     # full range
-    assert_range ranges, range(0, 0, 1, 0)
+    assert_range(ranges, range(0, 0, 1, 0))
     # full alias
-    assert_range ranges, range(0, 0, 0, 15)
+    assert_range(ranges, range(0, 0, 0, 15))
   end
 
   test "remote call" do
@@ -123,11 +125,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 17)
 
     # full range
-    assert_range ranges, range(0, 0, 1, 0)
+    assert_range(ranges, range(0, 0, 1, 0))
     # full remote call
-    assert_range ranges, range(0, 0, 0, 26)
+    assert_range(ranges, range(0, 0, 0, 26))
     # full remote call
-    assert_range ranges, range(0, 0, 0, 24)
+    assert_range(ranges, range(0, 0, 0, 24))
   end
 
   describe "comments" do
@@ -139,11 +141,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full line
-      assert_range ranges, range(0, 0, 0, 16)
+      assert_range(ranges, range(0, 0, 0, 16))
       # from #
-      assert_range ranges, range(0, 2, 0, 16)
+      assert_range(ranges, range(0, 2, 0, 16))
     end
 
     test "comment block on first line" do
@@ -156,13 +158,13 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full lines
-      assert_range ranges, range(0, 0, 2, 13)
+      assert_range(ranges, range(0, 0, 2, 13))
       # from #
-      assert_range ranges, range(0, 2, 2, 13)
+      assert_range(ranges, range(0, 2, 2, 13))
       # from # first line
-      assert_range ranges, range(0, 2, 0, 16)
+      assert_range(ranges, range(0, 2, 0, 16))
     end
 
     test "comment block on middle line" do
@@ -175,15 +177,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full lines
-      assert_range ranges, range(0, 0, 2, 13)
+      assert_range(ranges, range(0, 0, 2, 13))
       # from #
-      assert_range ranges, range(0, 2, 2, 13)
+      assert_range(ranges, range(0, 2, 2, 13))
       # full # middle line
-      assert_range ranges, range(1, 0, 1, 18)
+      assert_range(ranges, range(1, 0, 1, 18))
       # from # middle line
-      assert_range ranges, range(1, 2, 1, 18)
+      assert_range(ranges, range(1, 2, 1, 18))
     end
 
     test "comment block on last line" do
@@ -196,15 +198,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 2, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full lines
-      assert_range ranges, range(0, 0, 2, 13)
+      assert_range(ranges, range(0, 0, 2, 13))
       # from #
-      assert_range ranges, range(0, 2, 2, 13)
+      assert_range(ranges, range(0, 2, 2, 13))
       # full # last line
-      assert_range ranges, range(2, 0, 2, 13)
+      assert_range(ranges, range(2, 0, 2, 13))
       # from # last line
-      assert_range ranges, range(2, 2, 2, 13)
+      assert_range(ranges, range(2, 2, 2, 13))
     end
   end
 
@@ -219,11 +221,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 1)
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # outside do-end
-      assert_range ranges, range(0, 0, 3, 3)
+      assert_range(ranges, range(0, 0, 3, 3))
       # inside do-end
-      assert_range ranges, range(1, 0, 2, 4)
+      assert_range(ranges, range(1, 0, 2, 4))
     end
 
     test "left from do" do
@@ -236,11 +238,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 0)
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # outside do-end
-      assert_range ranges, range(0, 0, 3, 3)
+      assert_range(ranges, range(0, 0, 3, 3))
       # do
-      assert_range ranges, range(0, 0, 0, 2)
+      assert_range(ranges, range(0, 0, 0, 2))
     end
 
     test "right from do" do
@@ -253,9 +255,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 2)
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # outside do-end
-      assert_range ranges, range(0, 0, 3, 3)
+      assert_range(ranges, range(0, 0, 3, 3))
     end
 
     test "left from end" do
@@ -268,11 +270,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 3, 0)
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # outside do-end
-      assert_range ranges, range(0, 0, 3, 3)
+      assert_range(ranges, range(0, 0, 3, 3))
       # end
-      assert_range ranges, range(3, 0, 3, 3)
+      assert_range(ranges, range(3, 0, 3, 3))
     end
 
     test "right from end" do
@@ -285,9 +287,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 3, 3)
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # outside do-end
-      assert_range ranges, range(0, 0, 3, 3)
+      assert_range(ranges, range(0, 0, 3, 3))
     end
   end
 
@@ -302,11 +304,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
     ranges = get_ranges(text, 2, 4)
     # full range
-    assert_range ranges, range(0, 0, 5, 0)
+    assert_range(ranges, range(0, 0, 5, 0))
     # defmodule
-    assert_range ranges, range(0, 0, 4, 3)
+    assert_range(ranges, range(0, 0, 4, 3))
     # def
-    assert_range ranges, range(1, 2, 3, 5)
+    assert_range(ranges, range(1, 2, 3, 5))
   end
 
   describe "doc" do
@@ -319,9 +321,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full @doc
-      assert_range ranges, range(0, 0, 2, 3)
+      assert_range(ranges, range(0, 0, 2, 3))
     end
 
     test "heredoc" do
@@ -333,9 +335,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full @doc
-      assert_range ranges, range(0, 0, 2, 3)
+      assert_range(ranges, range(0, 0, 2, 3))
     end
 
     test "charlist heredoc" do
@@ -347,9 +349,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full @doc
-      assert_range ranges, range(0, 0, 2, 3)
+      assert_range(ranges, range(0, 0, 2, 3))
     end
   end
 
@@ -363,9 +365,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full literal
-      assert_range ranges, range(0, 2, 2, 3)
+      assert_range(ranges, range(0, 2, 2, 3))
     end
 
     test "number" do
@@ -375,11 +377,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 0)
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full expression
-      assert_range ranges, range(0, 0, 0, 9)
+      assert_range(ranges, range(0, 0, 0, 9))
       # full literal
-      assert_range ranges, range(0, 0, 0, 4)
+      assert_range(ranges, range(0, 0, 0, 4))
     end
 
     test "atom" do
@@ -389,9 +391,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 1)
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full literal
-      assert_range ranges, range(0, 0, 0, 8)
+      assert_range(ranges, range(0, 0, 0, 8))
     end
 
     test "interpolated string" do
@@ -401,18 +403,18 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 17)
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full literal
-      assert_range ranges, range(0, 0, 0, 28)
+      assert_range(ranges, range(0, 0, 0, 28))
       # full interpolation
-      assert_range ranges, range(0, 5, 0, 23)
+      assert_range(ranges, range(0, 5, 0, 23))
       # inside #{}
-      assert_range ranges, range(0, 7, 0, 22)
+      assert_range(ranges, range(0, 7, 0, 22))
       # inside ()
-      assert_range ranges, range(0, 15, 0, 21)
+      assert_range(ranges, range(0, 15, 0, 21))
       # literal
       # NOTE AST only matching - no tokens inside interpolation
-      assert_range ranges, range(0, 16, 0, 17)
+      assert_range(ranges, range(0, 16, 0, 17))
     end
   end
 
@@ -424,7 +426,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 1)
 
     # full range
-    assert_range ranges, range(0, 0, 1, 0)
+    assert_range(ranges, range(0, 0, 1, 0))
     # utf16 range
     assert range(0, 0, 0, end_character) = Enum.at(ranges, 1)
 
@@ -443,21 +445,21 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 2)
 
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # full struct
-      assert_range ranges, range(0, 0, 3, 1)
+      assert_range(ranges, range(0, 0, 3, 1))
       # full {} outside
-      assert_range ranges, range(0, 10, 3, 1)
+      assert_range(ranges, range(0, 10, 3, 1))
       # full {} inside
-      assert_range ranges, range(0, 11, 3, 0)
+      assert_range(ranges, range(0, 11, 3, 0))
       # full lines:
-      assert_range ranges, range(1, 0, 2, 14)
+      assert_range(ranges, range(1, 0, 2, 14))
       # full lines trimmed
-      assert_range ranges, range(1, 2, 2, 14)
+      assert_range(ranges, range(1, 2, 2, 14))
       # some: 123
-      assert_range ranges, range(1, 2, 1, 11)
+      assert_range(ranges, range(1, 2, 1, 11))
       # some
-      assert_range ranges, range(1, 2, 1, 6)
+      assert_range(ranges, range(1, 2, 1, 6))
     end
 
     test "on alias" do
@@ -471,13 +473,13 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 2)
 
       # full range
-      assert_range ranges, range(0, 0, 4, 0)
+      assert_range(ranges, range(0, 0, 4, 0))
       # full struct
-      assert_range ranges, range(0, 0, 3, 1)
+      assert_range(ranges, range(0, 0, 3, 1))
       # %My.Struct
-      assert_range ranges, range(0, 0, 0, 10)
+      assert_range(ranges, range(0, 0, 0, 10))
       # My.Struct
-      assert_range ranges, range(0, 1, 0, 10)
+      assert_range(ranges, range(0, 1, 0, 10))
     end
   end
 
@@ -490,15 +492,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 6)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full call
-      assert_range ranges, range(0, 0, 0, 46)
+      assert_range(ranges, range(0, 0, 0, 46))
       # full () outside
-      assert_range ranges, range(0, 3, 0, 46)
+      assert_range(ranges, range(0, 3, 0, 46))
       # full () inside
-      assert_range ranges, range(0, 4, 0, 45)
+      assert_range(ranges, range(0, 4, 0, 45))
       # %My{} = my
-      assert_range ranges, range(0, 4, 0, 14)
+      assert_range(ranges, range(0, 4, 0, 14))
     end
 
     test "between ," do
@@ -509,15 +511,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 18)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full call
-      assert_range ranges, range(0, 0, 0, 46)
+      assert_range(ranges, range(0, 0, 0, 46))
       # full () outside
-      assert_range ranges, range(0, 3, 0, 46)
+      assert_range(ranges, range(0, 3, 0, 46))
       # full () inside
-      assert_range ranges, range(0, 4, 0, 45)
+      assert_range(ranges, range(0, 4, 0, 45))
       # keyword: 123
-      assert_range ranges, range(0, 16, 0, 28)
+      assert_range(ranges, range(0, 16, 0, 28))
     end
 
     test "after last ," do
@@ -528,15 +530,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 31)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full call
-      assert_range ranges, range(0, 0, 0, 46)
+      assert_range(ranges, range(0, 0, 0, 46))
       # full () outside
-      assert_range ranges, range(0, 3, 0, 46)
+      assert_range(ranges, range(0, 3, 0, 46))
       # full () inside
-      assert_range ranges, range(0, 4, 0, 45)
+      assert_range(ranges, range(0, 4, 0, 45))
       # other: [:a, ""]
-      assert_range ranges, range(0, 30, 0, 45)
+      assert_range(ranges, range(0, 30, 0, 45))
     end
   end
 
@@ -551,17 +553,17 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
           funs()
       end
       """
-  
+
       ranges = get_ranges(text, 4, 5)
-  
+
       # full range
-      assert_range ranges, range(0, 0, 7, 0)
+      assert_range(ranges, range(0, 0, 7, 0))
       # full b case
-      assert_range ranges, range(3, 2, 5, 10)
+      assert_range(ranges, range(3, 2, 5, 10))
       # b block
-      assert_range ranges, range(4, 4, 5, 10)
+      assert_range(ranges, range(4, 4, 5, 10))
       # more()
-      assert_range ranges, range(4, 4, 4, 10)
+      assert_range(ranges, range(4, 4, 4, 10))
     end
 
     test "inside case arg" do
@@ -577,11 +579,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 6)
 
       # full range
-      assert_range ranges, range(0, 0, 6, 0)
+      assert_range(ranges, range(0, 0, 6, 0))
       # full case
-      assert_range ranges, range(0, 0, 5, 3)
+      assert_range(ranges, range(0, 0, 5, 3))
       # foo
-      assert_range ranges, range(0, 5, 0, 8)
+      assert_range(ranges, range(0, 5, 0, 8))
     end
 
     test "left side of -> single line" do
@@ -597,19 +599,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 3)
 
       # full range
-      assert_range ranges, range(0, 0, 6, 0)
+      assert_range(ranges, range(0, 0, 6, 0))
       # full case
-      assert_range ranges, range(0, 0, 5, 3)
+      assert_range(ranges, range(0, 0, 5, 3))
       # do block
-      assert_range ranges, range(0, 9, 5, 3)
+      assert_range(ranges, range(0, 9, 5, 3))
       # do block inside
-      assert_range ranges, range(1, 0, 4, 10)
+      assert_range(ranges, range(1, 0, 4, 10))
       # do block inside trimmed
-      assert_range ranges, range(1, 2, 4, 10)
+      assert_range(ranges, range(1, 2, 4, 10))
       # full expression
-      assert_range ranges, range(1, 2, 1, 17)
+      assert_range(ranges, range(1, 2, 1, 17))
       # {:ok, _}
-      assert_range ranges, range(1, 2, 1, 10)
+      assert_range(ranges, range(1, 2, 1, 10))
     end
 
     test "right side of -> single line" do
@@ -625,19 +627,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 16)
 
       # full range
-      assert_range ranges, range(0, 0, 6, 0)
+      assert_range(ranges, range(0, 0, 6, 0))
       # full case
-      assert_range ranges, range(0, 0, 5, 3)
+      assert_range(ranges, range(0, 0, 5, 3))
       # do block
-      assert_range ranges, range(0, 9, 5, 3)
+      assert_range(ranges, range(0, 9, 5, 3))
       # do block inside
-      assert_range ranges, range(1, 0, 4, 10)
+      assert_range(ranges, range(1, 0, 4, 10))
       # do block inside trimmed
-      assert_range ranges, range(1, 2, 4, 10)
+      assert_range(ranges, range(1, 2, 4, 10))
       # full expression
-      assert_range ranges, range(1, 2, 1, 17)
+      assert_range(ranges, range(1, 2, 1, 17))
       # :ok expression
-      assert_range ranges, range(1, 14, 1, 17)
+      assert_range(ranges, range(1, 14, 1, 17))
     end
 
     test "left side of -> multi line" do
@@ -656,18 +658,17 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 3, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 9, 0)
+      assert_range(ranges, range(0, 0, 9, 0))
       # full case
-      assert_range ranges, range(0, 0, 8, 3)
+      assert_range(ranges, range(0, 0, 8, 3))
       # do block
-      assert_range ranges, range(0, 9, 8, 3)
-      # TODO
+      assert_range(ranges, range(0, 9, 8, 3))
       # case -> expression
-      assert_range ranges, range(2, 2, 6, 10)
+      assert_range(ranges, range(2, 2, 6, 10))
       # pattern with ->
-      assert_range ranges, range(2, 2, 4, 6)
+      assert_range(ranges, range(2, 2, 4, 6))
       # pattern
-      assert_range ranges, range(2, 2, 4, 3)
+      assert_range(ranges, range(2, 2, 4, 3))
     end
 
     test "right side of -> multi line" do
@@ -686,19 +687,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 5, 5)
 
       # full range
-      assert_range ranges, range(0, 0, 9, 0)
+      assert_range(ranges, range(0, 0, 9, 0))
       # full case
-      assert_range ranges, range(0, 0, 8, 3)
+      assert_range(ranges, range(0, 0, 8, 3))
       # do block
-      assert_range ranges, range(0, 9, 8, 3)
+      assert_range(ranges, range(0, 9, 8, 3))
       # do block inside
-      assert_range ranges, range(1, 0, 7, 11)
+      assert_range(ranges, range(1, 0, 7, 11))
       # do block inside trimmed
-      assert_range ranges, range(1, 2, 7, 11)
+      assert_range(ranges, range(1, 2, 7, 11))
       # case -> expression
-      assert_range ranges, range(2, 2, 6, 10)
+      assert_range(ranges, range(2, 2, 6, 10))
       # full block
-      assert_range ranges, range(5, 4, 6, 10)
+      assert_range(ranges, range(5, 4, 6, 10))
     end
 
     test "right side of -> last expression in do block" do
@@ -717,17 +718,17 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 7, 8)
 
       # full range
-      assert_range ranges, range(0, 0, 9, 0)
+      assert_range(ranges, range(0, 0, 9, 0))
       # full case
-      assert_range ranges, range(0, 0, 8, 3)
+      assert_range(ranges, range(0, 0, 8, 3))
       # do block
-      assert_range ranges, range(0, 9, 8, 3)
+      assert_range(ranges, range(0, 9, 8, 3))
       # do block inside trimmed
-      assert_range ranges, range(1, 2, 7, 11)
+      assert_range(ranges, range(1, 2, 7, 11))
       # case -> expression
-      assert_range ranges, range(7, 2, 7, 11)
+      assert_range(ranges, range(7, 2, 7, 11))
       # :foo
-      assert_range ranges, range(7, 7, 7, 11)
+      assert_range(ranges, range(7, 7, 7, 11))
     end
   end
 
@@ -742,13 +743,13 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 2)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full for
-      assert_range ranges, range(0, 0, 2, 3)
+      assert_range(ranges, range(0, 0, 2, 3))
       # do block
-      assert_range ranges, range(0, 35, 2, 3)
+      assert_range(ranges, range(0, 35, 2, 3))
       # x + y expression
-      assert_range ranges, range(1, 2, 1, 7)
+      assert_range(ranges, range(1, 2, 1, 7))
     end
 
     test "inside do expression single line" do
@@ -759,11 +760,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 51)
 
       # full range
-      assert_range ranges, range(0, 0, 1, 0)
+      assert_range(ranges, range(0, 0, 1, 0))
       # full for
-      assert_range ranges, range(0, 0, 0, 56)
+      assert_range(ranges, range(0, 0, 0, 56))
       # x + y expression
-      assert_range ranges, range(0, 51, 0, 56)
+      assert_range(ranges, range(0, 51, 0, 56))
     end
 
     test "inside do expression" do
@@ -776,12 +777,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 2, 6)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
-      # TODO
-      # It's difficult to get the full range of for expression as Inspect.Algebra formats it differently
-      # and there is no usable metadata
+      assert_range(ranges, range(0, 0, 3, 0))
+      # full for expression
+      assert_range(ranges, range(0, 0, 2, 11))
       # x + y expression
-      assert_range ranges, range(2, 6, 2, 11)
+      assert_range(ranges, range(2, 6, 2, 11))
     end
 
     test "inside <- expression" do
@@ -794,13 +794,148 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 10)
 
       # full range
-      assert_range ranges, range(0, 0, 3, 0)
+      assert_range(ranges, range(0, 0, 3, 0))
       # full for
-      assert_range ranges, range(0, 0, 2, 3)
+      assert_range(ranges, range(0, 0, 2, 3))
       # x <- [1, 2, 3]
-      assert_range ranges, range(0, 4, 0, 18)
+      assert_range(ranges, range(0, 4, 0, 18))
       # [1, 2, 3]
-      assert_range ranges, range(0, 9, 0, 18)
+      assert_range(ranges, range(0, 9, 0, 18))
+    end
+  end
+
+  describe "with" do
+    test "inside do block" do
+      text = """
+      with x <- [1, 2, 3], y <- [4, 5, 6] do
+        x ++ y
+      end
+      """
+
+      ranges = get_ranges(text, 1, 2)
+
+      # full range
+      assert_range(ranges, range(0, 0, 3, 0))
+      # full for
+      assert_range(ranges, range(0, 0, 2, 3))
+      # do block
+      assert_range(ranges, range(0, 36, 2, 3))
+      # x ++ y expression
+      assert_range(ranges, range(1, 2, 1, 8))
+    end
+
+    test "inside do expression single line" do
+      text = """
+      with x <- [1, 2, 3], y <- [4, 5, 6], do: x ++ y
+      """
+
+      ranges = get_ranges(text, 0, 51)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full for
+      assert_range(ranges, range(0, 0, 0, 47))
+      # x ++ y expression
+      assert_range(ranges, range(0, 41, 0, 47))
+    end
+
+    test "inside do expression" do
+      text = """
+      with x <- [1, 2, 3],
+        y <- [4, 5, 6],
+        do: x ++ y
+      """
+
+      ranges = get_ranges(text, 2, 6)
+
+      # full range
+      assert_range(ranges, range(0, 0, 3, 0))
+      # full for expression
+      assert_range(ranges, range(0, 0, 2, 12))
+      # x ++ y expression
+      assert_range(ranges, range(2, 6, 2, 12))
+    end
+
+    test "inside <- expression" do
+      text = """
+      with x <- [1, 2, 3], y <- [4, 5, 6] do
+        x ++ y
+      end
+      """
+
+      ranges = get_ranges(text, 0, 10)
+
+      # full range
+      assert_range(ranges, range(0, 0, 3, 0))
+      # full for
+      assert_range(ranges, range(0, 0, 2, 3))
+      # x <- [1, 2, 3]
+      assert_range(ranges, range(0, 5, 0, 19))
+      # [1, 2, 3]
+      assert_range(ranges, range(0, 10, 0, 19))
+    end
+  end
+
+  describe "if" do
+    test "inside condition" do
+      text = """
+      if a + b > 1 do
+        :ok
+      else
+        :error
+      end
+      """
+
+      ranges = get_ranges(text, 0, 3)
+
+      # full range
+      assert_range(ranges, range(0, 0, 5, 0))
+      # full if
+      assert_range(ranges, range(0, 0, 4, 3))
+      # condition
+      assert_range(ranges, range(0, 3, 0, 12))
+    end
+
+    test "inside do block" do
+      text = """
+      if a + b > 1 do
+        :ok
+      else
+        :error
+      end
+      """
+
+      ranges = get_ranges(text, 1, 2)
+
+      # full range
+      assert_range(ranges, range(0, 0, 5, 0))
+      # full if
+      assert_range(ranges, range(0, 0, 4, 3))
+      # do-else
+      assert_range(ranges, range(0, 15, 2, 0))
+      # :ok
+      assert_range(ranges, range(1, 2, 1, 5))
+    end
+
+    test "inside else block" do
+      text = """
+      if a + b > 1 do
+        :ok
+      else
+        :error
+      end
+      """
+
+      ranges = get_ranges(text, 3, 2)
+
+      # full range
+      assert_range(ranges, range(0, 0, 5, 0))
+      # full if
+      assert_range(ranges, range(0, 0, 4, 3))
+      # else-end
+      assert_range(ranges, range(2, 0, 4, 3))
+      # :error
+      assert_range(ranges, range(3, 2, 3, 8))
     end
   end
 
@@ -812,14 +947,14 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 8)
 
     # full range
-    assert_range ranges, range(0, 0, 1, 0)
+    assert_range(ranges, range(0, 0, 1, 0))
     # full expression
-    assert_range ranges, range(0, 0, 0, 32)
+    assert_range(ranges, range(0, 0, 0, 32))
     # full left side of operator >
-    assert_range ranges, range(0, 0, 0, 18)
+    assert_range(ranges, range(0, 0, 0, 18))
     # var2 * var3
-    assert_range ranges, range(0, 7, 0, 18)
+    assert_range(ranges, range(0, 7, 0, 18))
     # var2
-    assert_range ranges, range(0, 7, 0, 11)
+    assert_range(ranges, range(0, 7, 0, 11))
   end
 end

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -228,21 +228,23 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       assert_range(ranges, range(1, 0, 2, 4))
     end
 
-    test "left from do" do
-      text = """
-      do
-        1
-        24
-      end
-      """
+    if Version.match?(System.version(), ">= 1.14.0-dev") do
+      test "left from do" do
+        text = """
+        do
+          1
+          24
+        end
+        """
 
-      ranges = get_ranges(text, 0, 0)
-      # full range
-      assert_range(ranges, range(0, 0, 4, 0))
-      # outside do-end
-      assert_range(ranges, range(0, 0, 3, 3))
-      # do
-      assert_range(ranges, range(0, 0, 0, 2))
+        ranges = get_ranges(text, 0, 0)
+        # full range
+        assert_range(ranges, range(0, 0, 4, 0))
+        # outside do-end
+        assert_range(ranges, range(0, 0, 3, 3))
+        # do
+        assert_range(ranges, range(0, 0, 0, 2))
+      end
     end
 
     test "right from do" do
@@ -260,21 +262,23 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       assert_range(ranges, range(0, 0, 3, 3))
     end
 
-    test "left from end" do
-      text = """
-      do
-        1
-        24
-      end
-      """
+    if Version.match?(System.version(), ">= 1.14.0-dev") do
+      test "left from end" do
+        text = """
+        do
+          1
+          24
+        end
+        """
 
-      ranges = get_ranges(text, 3, 0)
-      # full range
-      assert_range(ranges, range(0, 0, 4, 0))
-      # outside do-end
-      assert_range(ranges, range(0, 0, 3, 3))
-      # end
-      assert_range(ranges, range(3, 0, 3, 3))
+        ranges = get_ranges(text, 3, 0)
+        # full range
+        assert_range(ranges, range(0, 0, 4, 0))
+        # outside do-end
+        assert_range(ranges, range(0, 0, 3, 3))
+        # end
+        assert_range(ranges, range(3, 0, 3, 3))
+      end
     end
 
     test "right from end" do

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -21,6 +21,10 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     flatten(parent, [range | acc])
   end
 
+  defp assert_range(ranges, expected) do
+    assert Enum.any?(ranges, & &1 == expected)
+  end
+
   describe "token pair ranges" do
     test "brackets nested cursor inside" do
       text = """
@@ -30,15 +34,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 3)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # [] outside
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 11)
+      assert_range ranges, range(0, 0, 0, 11)
       # [] inside
-      assert Enum.at(ranges, 2) == range(0, 1, 0, 10)
+      assert_range ranges, range(0, 1, 0, 10)
       # {} outside
-      assert Enum.at(ranges, 3) == range(0, 1, 0, 7)
+      assert_range ranges, range(0, 1, 0, 7)
       # {} inside
-      assert Enum.at(ranges, 4) == range(0, 2, 0, 6)
+      assert_range ranges, range(0, 2, 0, 6)
     end
 
     test "brackets cursor inside left" do
@@ -49,11 +53,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 1)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # {} outside
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      assert_range ranges, range(0, 0, 0, 6)
       # {} inside
-      assert Enum.at(ranges, 2) == range(0, 1, 0, 5)
+      assert_range ranges, range(0, 1, 0, 5)
     end
 
     test "brackets cursor inside right" do
@@ -64,11 +68,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # {} outside
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      assert_range ranges, range(0, 0, 0, 6)
       # {} inside
-      assert Enum.at(ranges, 2) == range(0, 1, 0, 5)
+      assert_range ranges, range(0, 1, 0, 5)
     end
 
     test "brackets cursor outside left" do
@@ -79,9 +83,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 0)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # {} outside
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      assert_range ranges, range(0, 0, 0, 6)
     end
 
     test "brackets cursor outside right" do
@@ -92,9 +96,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 0)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # {} outside
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      assert_range ranges, range(0, 0, 0, 6)
     end
   end
 
@@ -106,9 +110,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 1)
 
     # full range
-    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    assert_range ranges, range(0, 0, 1, 0)
     # full alias
-    assert Enum.at(ranges, 1) == range(0, 0, 0, 15)
+    assert_range ranges, range(0, 0, 0, 15)
   end
 
   test "remote call" do
@@ -119,11 +123,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 17)
 
     # full range
-    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    assert_range ranges, range(0, 0, 1, 0)
     # full remote call
-    assert Enum.at(ranges, 1) == range(0, 0, 0, 26)
+    assert_range ranges, range(0, 0, 0, 26)
     # full remote call
-    assert Enum.at(ranges, 2) == range(0, 0, 0, 24)
+    assert_range ranges, range(0, 0, 0, 24)
   end
 
   describe "comments" do
@@ -135,11 +139,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full line
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 16)
+      assert_range ranges, range(0, 0, 0, 16)
       # from #
-      assert Enum.at(ranges, 2) == range(0, 2, 0, 16)
+      assert_range ranges, range(0, 2, 0, 16)
     end
 
     test "comment block on first line" do
@@ -152,13 +156,13 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full lines
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      assert_range ranges, range(0, 0, 2, 13)
       # from #
-      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      assert_range ranges, range(0, 2, 2, 13)
       # from # first line
-      assert Enum.at(ranges, 3) == range(0, 2, 0, 16)
+      assert_range ranges, range(0, 2, 0, 16)
     end
 
     test "comment block on middle line" do
@@ -171,15 +175,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full lines
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      assert_range ranges, range(0, 0, 2, 13)
       # from #
-      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      assert_range ranges, range(0, 2, 2, 13)
       # full # middle line
-      assert Enum.at(ranges, 3) == range(1, 0, 1, 18)
+      assert_range ranges, range(1, 0, 1, 18)
       # from # middle line
-      assert Enum.at(ranges, 4) == range(1, 2, 1, 18)
+      assert_range ranges, range(1, 2, 1, 18)
     end
 
     test "comment block on last line" do
@@ -192,15 +196,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 2, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full lines
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      assert_range ranges, range(0, 0, 2, 13)
       # from #
-      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      assert_range ranges, range(0, 2, 2, 13)
       # full # last line
-      assert Enum.at(ranges, 3) == range(2, 0, 2, 13)
+      assert_range ranges, range(2, 0, 2, 13)
       # from # last line
-      assert Enum.at(ranges, 4) == range(2, 2, 2, 13)
+      assert_range ranges, range(2, 2, 2, 13)
     end
   end
 
@@ -215,11 +219,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 1)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # outside do-end
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      assert_range ranges, range(0, 0, 3, 3)
       # inside do-end
-      assert Enum.at(ranges, 3) == range(1, 0, 2, 4)
+      assert_range ranges, range(1, 0, 2, 4)
     end
 
     test "left from do" do
@@ -232,11 +236,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # outside do-end
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      assert_range ranges, range(0, 0, 3, 3)
       # do
-      assert Enum.at(ranges, 3) == range(0, 0, 0, 2)
+      assert_range ranges, range(0, 0, 0, 2)
     end
 
     test "right from do" do
@@ -249,9 +253,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 2)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # outside do-end
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      assert_range ranges, range(0, 0, 3, 3)
     end
 
     test "left from end" do
@@ -264,11 +268,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 3, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # outside do-end
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      assert_range ranges, range(0, 0, 3, 3)
       # end
-      assert Enum.at(ranges, 2) == range(3, 0, 3, 3)
+      assert_range ranges, range(3, 0, 3, 3)
     end
 
     test "right from end" do
@@ -281,9 +285,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 3, 3)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # outside do-end
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      assert_range ranges, range(0, 0, 3, 3)
     end
   end
 
@@ -298,11 +302,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
     ranges = get_ranges(text, 2, 4)
     # full range
-    assert Enum.at(ranges, 0) == range(0, 0, 5, 0)
+    assert_range ranges, range(0, 0, 5, 0)
     # defmodule
-    assert Enum.at(ranges, 1) == range(0, 0, 4, 3)
+    assert_range ranges, range(0, 0, 4, 3)
     # def
-    assert Enum.at(ranges, 4) == range(1, 2, 3, 5)
+    assert_range ranges, range(1, 2, 3, 5)
   end
 
   describe "doc" do
@@ -315,9 +319,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full @doc
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+      assert_range ranges, range(0, 0, 2, 3)
     end
 
     test "heredoc" do
@@ -329,9 +333,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full @doc
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+      assert_range ranges, range(0, 0, 2, 3)
     end
 
     test "charlist heredoc" do
@@ -343,9 +347,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full @doc
-      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+      assert_range ranges, range(0, 0, 2, 3)
     end
   end
 
@@ -359,9 +363,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 1, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      assert_range ranges, range(0, 0, 3, 0)
       # full literal
-      assert Enum.at(ranges, 1) == range(0, 2, 2, 3)
+      assert_range ranges, range(0, 2, 2, 3)
     end
 
     test "number" do
@@ -371,11 +375,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 0)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full expression
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 9)
+      assert_range ranges, range(0, 0, 0, 9)
       # full literal
-      assert Enum.at(ranges, 2) == range(0, 0, 0, 4)
+      assert_range ranges, range(0, 0, 0, 4)
     end
 
     test "atom" do
@@ -385,9 +389,9 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 1)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full literal
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 8)
+      assert_range ranges, range(0, 0, 0, 8)
     end
 
     test "interpolated string" do
@@ -397,18 +401,18 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
 
       ranges = get_ranges(text, 0, 17)
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full literal
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 28)
+      assert_range ranges, range(0, 0, 0, 28)
       # full interpolation
-      assert Enum.at(ranges, 2) == range(0, 5, 0, 23)
+      assert_range ranges, range(0, 5, 0, 23)
       # inside #{}
-      assert Enum.at(ranges, 3) == range(0, 7, 0, 22)
+      assert_range ranges, range(0, 7, 0, 22)
       # inside ()
-      assert Enum.at(ranges, 4) == range(0, 15, 0, 21)
+      assert_range ranges, range(0, 15, 0, 21)
       # literal
       # NOTE AST only matching - no tokens inside interpolation
-      assert Enum.at(ranges, 5) == range(0, 16, 0, 17)
+      assert_range ranges, range(0, 16, 0, 17)
     end
   end
 
@@ -420,7 +424,7 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 1)
 
     # full range
-    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    assert_range ranges, range(0, 0, 1, 0)
     # utf16 range
     assert range(0, 0, 0, end_character) = Enum.at(ranges, 1)
 
@@ -439,21 +443,21 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 2)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # full struct
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 1)
+      assert_range ranges, range(0, 0, 3, 1)
       # full {} outside
-      assert Enum.at(ranges, 2) == range(0, 10, 3, 1)
+      assert_range ranges, range(0, 10, 3, 1)
       # full {} inside
-      assert Enum.at(ranges, 3) == range(0, 11, 3, 0)
+      assert_range ranges, range(0, 11, 3, 0)
       # full lines:
-      assert Enum.at(ranges, 4) == range(1, 0, 2, 14)
+      assert_range ranges, range(1, 0, 2, 14)
       # full lines trimmed
-      assert Enum.at(ranges, 5) == range(1, 2, 2, 14)
+      assert_range ranges, range(1, 2, 2, 14)
       # some: 123
-      assert Enum.at(ranges, 6) == range(1, 2, 1, 11)
+      assert_range ranges, range(1, 2, 1, 11)
       # some
-      assert Enum.at(ranges, 7) == range(1, 2, 1, 6)
+      assert_range ranges, range(1, 2, 1, 6)
     end
 
     test "on alias" do
@@ -467,13 +471,13 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 2)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      assert_range ranges, range(0, 0, 4, 0)
       # full struct
-      assert Enum.at(ranges, 1) == range(0, 0, 3, 1)
+      assert_range ranges, range(0, 0, 3, 1)
       # %My.Struct
-      assert Enum.at(ranges, 3) == range(0, 0, 0, 10)
+      assert_range ranges, range(0, 0, 0, 10)
       # My.Struct
-      assert Enum.at(ranges, 4) == range(0, 1, 0, 10)
+      assert_range ranges, range(0, 1, 0, 10)
     end
   end
 
@@ -486,15 +490,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 6)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full call
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 46)
+      assert_range ranges, range(0, 0, 0, 46)
       # full () outside
-      assert Enum.at(ranges, 2) == range(0, 3, 0, 46)
+      assert_range ranges, range(0, 3, 0, 46)
       # full () inside
-      assert Enum.at(ranges, 3) == range(0, 4, 0, 45)
+      assert_range ranges, range(0, 4, 0, 45)
       # %My{} = my
-      assert Enum.at(ranges, 4) == range(0, 4, 0, 14)
+      assert_range ranges, range(0, 4, 0, 14)
     end
 
     test "between ," do
@@ -505,15 +509,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 18)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full call
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 46)
+      assert_range ranges, range(0, 0, 0, 46)
       # full () outside
-      assert Enum.at(ranges, 2) == range(0, 3, 0, 46)
+      assert_range ranges, range(0, 3, 0, 46)
       # full () inside
-      assert Enum.at(ranges, 3) == range(0, 4, 0, 45)
+      assert_range ranges, range(0, 4, 0, 45)
       # keyword: 123
-      assert Enum.at(ranges, 4) == range(0, 16, 0, 28)
+      assert_range ranges, range(0, 16, 0, 28)
     end
 
     test "after last ," do
@@ -524,15 +528,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 31)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      assert_range ranges, range(0, 0, 1, 0)
       # full call
-      assert Enum.at(ranges, 1) == range(0, 0, 0, 46)
+      assert_range ranges, range(0, 0, 0, 46)
       # full () outside
-      assert Enum.at(ranges, 2) == range(0, 3, 0, 46)
+      assert_range ranges, range(0, 3, 0, 46)
       # full () inside
-      assert Enum.at(ranges, 3) == range(0, 4, 0, 45)
+      assert_range ranges, range(0, 4, 0, 45)
       # other: [:a, ""]
-      assert Enum.at(ranges, 4) == range(0, 30, 0, 45)
+      assert_range ranges, range(0, 30, 0, 45)
     end
   end
 
@@ -551,15 +555,15 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 4, 5)
   
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 7, 0)
+      assert_range ranges, range(0, 0, 7, 0)
       # full b case
-      assert Enum.at(ranges, 5) == range(3, 2, 5, 10)
+      assert_range ranges, range(3, 2, 5, 10)
       # b block
-      assert Enum.at(ranges, 8) == range(4, 4, 5, 10)
+      assert_range ranges, range(4, 4, 5, 10)
       # more()
-      assert Enum.at(ranges, 9) == range(4, 4, 4, 10)
+      assert_range ranges, range(4, 4, 4, 10)
     end
-    
+
     test "inside case arg" do
       text = """
       case foo do
@@ -573,11 +577,11 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 0, 6)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 6, 0)
+      assert_range ranges, range(0, 0, 6, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 5, 3)
+      assert_range ranges, range(0, 0, 5, 3)
       # foo
-      assert Enum.at(ranges, 3) == range(0, 5, 0, 8)
+      assert_range ranges, range(0, 5, 0, 8)
     end
 
     test "left side of -> single line" do
@@ -593,19 +597,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 3)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 6, 0)
+      assert_range ranges, range(0, 0, 6, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 5, 3)
+      assert_range ranges, range(0, 0, 5, 3)
       # do block
-      assert Enum.at(ranges, 2) == range(0, 9, 5, 3)
+      assert_range ranges, range(0, 9, 5, 3)
       # do block inside
-      assert Enum.at(ranges, 3) == range(1, 0, 4, 10)
+      assert_range ranges, range(1, 0, 4, 10)
       # do block inside trimmed
-      assert Enum.at(ranges, 4) == range(1, 2, 4, 10)
+      assert_range ranges, range(1, 2, 4, 10)
       # full expression
-      assert Enum.at(ranges, 5) == range(1, 2, 1, 17)
+      assert_range ranges, range(1, 2, 1, 17)
       # {:ok, _}
-      assert Enum.at(ranges, 6) == range(1, 2, 1, 10)
+      assert_range ranges, range(1, 2, 1, 10)
     end
 
     test "right side of -> single line" do
@@ -621,19 +625,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 1, 16)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 6, 0)
+      assert_range ranges, range(0, 0, 6, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 5, 3)
+      assert_range ranges, range(0, 0, 5, 3)
       # do block
-      assert Enum.at(ranges, 2) == range(0, 9, 5, 3)
+      assert_range ranges, range(0, 9, 5, 3)
       # do block inside
-      assert Enum.at(ranges, 3) == range(1, 0, 4, 10)
+      assert_range ranges, range(1, 0, 4, 10)
       # do block inside trimmed
-      assert Enum.at(ranges, 4) == range(1, 2, 4, 10)
+      assert_range ranges, range(1, 2, 4, 10)
       # full expression
-      assert Enum.at(ranges, 5) == range(1, 2, 1, 17)
+      assert_range ranges, range(1, 2, 1, 17)
       # :ok expression
-      assert Enum.at(ranges, 6) == range(1, 14, 1, 17)
+      assert_range ranges, range(1, 14, 1, 17)
     end
 
     test "left side of -> multi line" do
@@ -652,21 +656,18 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 3, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 9, 0)
+      assert_range ranges, range(0, 0, 9, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 8, 3)
+      assert_range ranges, range(0, 0, 8, 3)
       # do block
-      assert Enum.at(ranges, 2) == range(0, 9, 8, 3)
-      # do block inside
-      assert Enum.at(ranges, 3) == range(1, 0, 7, 11)
-      # do block inside trimmed
-      assert Enum.at(ranges, 4) == range(1, 2, 7, 11)
+      assert_range ranges, range(0, 9, 8, 3)
+      # TODO
       # case -> expression
-      assert Enum.at(ranges, 5) == range(2, 2, 6, 10)
+      assert_range ranges, range(2, 2, 6, 10)
       # pattern with ->
-      assert Enum.at(ranges, 6) == range(2, 2, 4, 6)
+      assert_range ranges, range(2, 2, 4, 6)
       # pattern
-      assert Enum.at(ranges, 7) == range(2, 2, 4, 3)
+      assert_range ranges, range(2, 2, 4, 3)
     end
 
     test "right side of -> multi line" do
@@ -685,19 +686,19 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 5, 5)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 9, 0)
+      assert_range ranges, range(0, 0, 9, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 8, 3)
+      assert_range ranges, range(0, 0, 8, 3)
       # do block
-      assert Enum.at(ranges, 2) == range(0, 9, 8, 3)
+      assert_range ranges, range(0, 9, 8, 3)
       # do block inside
-      assert Enum.at(ranges, 3) == range(1, 0, 7, 11)
+      assert_range ranges, range(1, 0, 7, 11)
       # do block inside trimmed
-      assert Enum.at(ranges, 4) == range(1, 2, 7, 11)
+      assert_range ranges, range(1, 2, 7, 11)
       # case -> expression
-      assert Enum.at(ranges, 5) == range(2, 2, 6, 10)
+      assert_range ranges, range(2, 2, 6, 10)
       # full block
-      assert Enum.at(ranges, 8) == range(5, 4, 6, 10)
+      assert_range ranges, range(5, 4, 6, 10)
     end
 
     test "right side of -> last expression in do block" do
@@ -716,17 +717,90 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       ranges = get_ranges(text, 7, 8)
 
       # full range
-      assert Enum.at(ranges, 0) == range(0, 0, 9, 0)
+      assert_range ranges, range(0, 0, 9, 0)
       # full case
-      assert Enum.at(ranges, 1) == range(0, 0, 8, 3)
+      assert_range ranges, range(0, 0, 8, 3)
       # do block
-      assert Enum.at(ranges, 2) == range(0, 9, 8, 3)
+      assert_range ranges, range(0, 9, 8, 3)
       # do block inside trimmed
-      assert Enum.at(ranges, 5) == range(1, 2, 7, 11)
+      assert_range ranges, range(1, 2, 7, 11)
       # case -> expression
-      assert Enum.at(ranges, 6) == range(7, 2, 7, 11)
+      assert_range ranges, range(7, 2, 7, 11)
       # :foo
-      assert Enum.at(ranges, 7) == range(7, 7, 7, 11)
+      assert_range ranges, range(7, 7, 7, 11)
+    end
+  end
+
+  describe "for" do
+    test "inside do block" do
+      text = """
+      for x <- [1, 2, 3], y <- [4, 5, 6] do
+        x + y
+      end
+      """
+
+      ranges = get_ranges(text, 1, 2)
+
+      # full range
+      assert_range ranges, range(0, 0, 3, 0)
+      # full for
+      assert_range ranges, range(0, 0, 2, 3)
+      # do block
+      assert_range ranges, range(0, 35, 2, 3)
+      # x + y expression
+      assert_range ranges, range(1, 2, 1, 7)
+    end
+
+    test "inside do expression single line" do
+      text = """
+      for x <- [1, 2, 3], y <- [4, 5, 6], into: %{}, do: x + y
+      """
+
+      ranges = get_ranges(text, 0, 51)
+
+      # full range
+      assert_range ranges, range(0, 0, 1, 0)
+      # full for
+      assert_range ranges, range(0, 0, 0, 56)
+      # x + y expression
+      assert_range ranges, range(0, 51, 0, 56)
+    end
+
+    test "inside do expression" do
+      text = """
+      for x <- [1, 2, 3], y <- [4, 5, 6],
+        into: %{},
+        do: x + y
+      """
+
+      ranges = get_ranges(text, 2, 6)
+
+      # full range
+      assert_range ranges, range(0, 0, 3, 0)
+      # TODO
+      # It's difficult to get the full range of for expression as Inspect.Algebra formats it differently
+      # and there is no usable metadata
+      # x + y expression
+      assert_range ranges, range(2, 6, 2, 11)
+    end
+
+    test "inside <- expression" do
+      text = """
+      for x <- [1, 2, 3], y <- [4, 5, 6] do
+        x + y
+      end
+      """
+
+      ranges = get_ranges(text, 0, 10)
+
+      # full range
+      assert_range ranges, range(0, 0, 3, 0)
+      # full for
+      assert_range ranges, range(0, 0, 2, 3)
+      # x <- [1, 2, 3]
+      assert_range ranges, range(0, 4, 0, 18)
+      # [1, 2, 3]
+      assert_range ranges, range(0, 9, 0, 18)
     end
   end
 
@@ -738,14 +812,14 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     ranges = get_ranges(text, 0, 8)
 
     # full range
-    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    assert_range ranges, range(0, 0, 1, 0)
     # full expression
-    assert Enum.at(ranges, 1) == range(0, 0, 0, 32)
+    assert_range ranges, range(0, 0, 0, 32)
     # full left side of operator >
-    assert Enum.at(ranges, 2) == range(0, 0, 0, 18)
+    assert_range ranges, range(0, 0, 0, 18)
     # var2 * var3
-    assert Enum.at(ranges, 3) == range(0, 7, 0, 18)
+    assert_range ranges, range(0, 7, 0, 18)
     # var2
-    assert Enum.at(ranges, 4) == range(0, 7, 0, 11)
+    assert_range ranges, range(0, 7, 0, 11)
   end
 end

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -1030,19 +1030,21 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       assert_range(ranges, range(0, 8, 0, 12))
     end
 
-    test "left side of | near" do
-      text = """
-      %{state | 1 => 1, counter: counter + to_dispatch, demand: demand - to_dispatch}
-      """
+    if Version.match?(System.version(), ">= 1.14.0-dev") do
+      test "left side of | near" do
+        text = """
+        %{state | 1 => 1, counter: counter + to_dispatch, demand: demand - to_dispatch}
+        """
 
-      ranges = get_ranges(text, 0, 8)
+        ranges = get_ranges(text, 0, 8)
 
-      # full range
-      assert_range(ranges, range(0, 0, 1, 0))
-      # full map
-      assert_range(ranges, range(0, 0, 0, 79))
-      # |
-      assert_range(ranges, range(0, 8, 0, 9))
+        # full range
+        assert_range(ranges, range(0, 0, 1, 0))
+        # full map
+        assert_range(ranges, range(0, 0, 0, 79))
+        # |
+        assert_range(ranges, range(0, 8, 0, 9))
+      end
     end
 
     test "right side of | near" do

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -1,0 +1,450 @@
+defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
+  use ExUnit.Case
+
+  alias ElixirLS.LanguageServer.Providers.SelectionRanges
+  alias ElixirLS.LanguageServer.{SourceFile}
+  import ElixirLS.LanguageServer.Protocol
+
+  defp get_ranges(text, line, character) do
+    SelectionRanges.selection_ranges(text, [%{"line" => line, "character" => character}])
+    |> hd
+    |> flatten
+  end
+
+  defp flatten(range) do
+    flatten(range, [])
+  end
+
+  defp flatten(nil, acc), do: acc
+
+  defp flatten(%{"range" => range, "parent" => parent}, acc) do
+    flatten(parent, [range | acc])
+  end
+
+  describe "token pair ranges" do
+    test "brackets nested cursor inside" do
+      text = """
+      [{1, 2}, 3]
+      """
+
+      ranges = get_ranges(text, 0, 3)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # [] outside
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 11)
+      # [] inside
+      assert Enum.at(ranges, 2) == range(0, 1, 0, 10)
+      # {} outside
+      assert Enum.at(ranges, 3) == range(0, 1, 0, 7)
+      # {} inside
+      assert Enum.at(ranges, 4) == range(0, 2, 0, 6)
+    end
+
+    test "brackets cursor inside left" do
+      text = """
+      {1, 2}
+      """
+
+      ranges = get_ranges(text, 0, 1)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # {} outside
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      # {} inside
+      assert Enum.at(ranges, 2) == range(0, 1, 0, 5)
+    end
+
+    test "brackets cursor inside right" do
+      text = """
+      {1, 2}
+      """
+
+      ranges = get_ranges(text, 0, 5)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # {} outside
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+      # {} inside
+      assert Enum.at(ranges, 2) == range(0, 1, 0, 5)
+    end
+
+    test "brackets cursor outside left" do
+      text = """
+      {1, 2}
+      """
+
+      ranges = get_ranges(text, 0, 0)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # {} outside
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+    end
+
+    test "brackets cursor outside right" do
+      text = """
+      {1, 2}
+      """
+
+      ranges = get_ranges(text, 0, 0)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # {} outside
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 6)
+    end
+  end
+
+  test "alias" do
+    text = """
+    Some.Module.Foo
+    """
+
+    ranges = get_ranges(text, 0, 1)
+
+    # full range
+    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    # full alias
+    assert Enum.at(ranges, 1) == range(0, 0, 0, 15)
+  end
+
+  test "remote call" do
+    text = """
+    Some.Module.Foo.some_fun()
+    """
+
+    ranges = get_ranges(text, 0, 17)
+
+    # full range
+    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    # full remote call
+    assert Enum.at(ranges, 1) == range(0, 0, 0, 26)
+    # full remote call
+    assert Enum.at(ranges, 2) == range(0, 0, 0, 24)
+  end
+
+  describe "comments" do
+    test "single comment" do
+      text = """
+        # some comment
+      """
+
+      ranges = get_ranges(text, 0, 5)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # full line
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 16)
+      # from #
+      assert Enum.at(ranges, 2) == range(0, 2, 0, 16)
+    end
+
+    test "comment block on first line" do
+      text = """
+        # some comment
+        # continues here
+        # ends here
+      """
+
+      ranges = get_ranges(text, 0, 5)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full lines
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      # from #
+      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      # from # first line
+      assert Enum.at(ranges, 3) == range(0, 2, 0, 16)
+    end
+
+    test "comment block on middle line" do
+      text = """
+        # some comment
+        # continues here
+        # ends here
+      """
+
+      ranges = get_ranges(text, 1, 5)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full lines
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      # from #
+      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      # full # middle line
+      assert Enum.at(ranges, 3) == range(1, 0, 1, 18)
+      # from # middle line
+      assert Enum.at(ranges, 4) == range(1, 2, 1, 18)
+    end
+
+    test "comment block on last line" do
+      text = """
+        # some comment
+        # continues here
+        # ends here
+      """
+
+      ranges = get_ranges(text, 2, 5)
+
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full lines
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 13)
+      # from #
+      assert Enum.at(ranges, 2) == range(0, 2, 2, 13)
+      # full # last line
+      assert Enum.at(ranges, 3) == range(2, 0, 2, 13)
+      # from # last line
+      assert Enum.at(ranges, 4) == range(2, 2, 2, 13)
+    end
+  end
+
+  describe "do-end" do
+    test "inside" do
+      text = """
+      do
+        1
+        24
+      end
+      """
+
+      ranges = get_ranges(text, 1, 1)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      # outside do-end
+      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      # inside do-end
+      assert Enum.at(ranges, 3) == range(1, 0, 2, 4)
+    end
+
+    test "left from do" do
+      text = """
+      do
+        1
+        24
+      end
+      """
+
+      ranges = get_ranges(text, 0, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      # outside do-end
+      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      # do
+      assert Enum.at(ranges, 3) == range(0, 0, 0, 2)
+    end
+
+    test "right from do" do
+      text = """
+      do
+        1
+        24
+      end
+      """
+
+      ranges = get_ranges(text, 0, 2)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      # outside do-end
+      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+    end
+
+    test "left from end" do
+      text = """
+      do
+        1
+        24
+      end
+      """
+
+      ranges = get_ranges(text, 3, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      # outside do-end
+      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+      # end
+      assert Enum.at(ranges, 2) == range(3, 0, 3, 3)
+    end
+
+    test "right from end" do
+      text = """
+      do
+        1
+        24
+      end
+      """
+
+      ranges = get_ranges(text, 3, 3)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 4, 0)
+      # outside do-end
+      assert Enum.at(ranges, 1) == range(0, 0, 3, 3)
+    end
+  end
+
+  test "module and def" do
+    text = """
+    defmodule Abc do
+      def some() do
+        :ok
+      end
+    end
+    """
+
+    ranges = get_ranges(text, 2, 4)
+    # full range
+    assert Enum.at(ranges, 0) == range(0, 0, 5, 0)
+    # defmodule
+    assert Enum.at(ranges, 1) == range(0, 0, 4, 3)
+    # def
+    assert Enum.at(ranges, 4) == range(1, 2, 3, 5)
+  end
+
+  describe "doc" do
+    test "sigil" do
+      text = """
+      @doc ~S\"""
+      This is a doc
+      \"""
+      """
+
+      ranges = get_ranges(text, 1, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full @doc
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+    end
+
+    test "heredoc" do
+      text = """
+      @doc \"""
+      This is a doc
+      \"""
+      """
+
+      ranges = get_ranges(text, 1, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full @doc
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+    end
+
+    test "charlist heredoc" do
+      text = """
+      @doc '''
+      This is a doc
+      '''
+      """
+
+      ranges = get_ranges(text, 1, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full @doc
+      assert Enum.at(ranges, 1) == range(0, 0, 2, 3)
+    end
+  end
+
+  describe "literals" do
+    test "heredoc" do
+      text = """
+        \"""
+      This is a doc
+      \"""
+      """
+
+      ranges = get_ranges(text, 1, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 3, 0)
+      # full literal
+      assert Enum.at(ranges, 1) == range(0, 2, 2, 3)
+    end
+
+    test "number" do
+      text = """
+      1234 + 43
+      """
+
+      ranges = get_ranges(text, 0, 0)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # full literal
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 4)
+    end
+
+    test "atom" do
+      text = """
+      :asdfghj
+      """
+
+      ranges = get_ranges(text, 0, 1)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # full literal
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 8)
+    end
+
+    test "interpolated string" do
+      text = """
+      "asdf\#{inspect([1, 2])}gfds"
+      """
+
+      ranges = get_ranges(text, 0, 17)
+      # full range
+      assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+      # full literal
+      assert Enum.at(ranges, 1) == range(0, 0, 0, 28)
+      # full interpolation
+      assert Enum.at(ranges, 2) == range(0, 5, 0, 23)
+      # inside #{}
+      assert Enum.at(ranges, 3) == range(0, 7, 0, 22)
+      # inside ()
+      assert Enum.at(ranges, 4) == range(0, 15, 0, 21)
+      # literal
+      # NOTE AST only matching - no tokens inside interpolation
+      assert Enum.at(ranges, 5) == range(0, 16, 0, 17)
+    end
+  end
+
+  test "case" do
+    text = """
+    case x do
+      a ->
+        some_fun()
+      b ->
+        more()
+        funs()
+    end
+    """
+
+    ranges = get_ranges(text, 4, 5)
+
+    # full range
+    assert Enum.at(ranges, 0) == range(0, 0, 7, 0)
+    # full b case
+    assert Enum.at(ranges, 5) == range(3, 2, 5, 10)
+    # b block
+    assert Enum.at(ranges, 7) == range(4, 4, 5, 10)
+    # more()
+    assert Enum.at(ranges, 8) == range(4, 4, 4, 10)
+  end
+
+  test "utf16" do
+    text = """
+    "foooob🏳️‍🌈rbaz"
+    """
+
+    ranges = get_ranges(text, 0, 1)
+
+    # full range
+    assert Enum.at(ranges, 0) == range(0, 0, 1, 0)
+    # utf16 range
+    assert range(0, 0, 0, end_character) = Enum.at(ranges, 1)
+
+    assert end_character == SourceFile.lines(text) |> Enum.at(0) |> SourceFile.line_length_utf16()
+  end
+end

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -996,4 +996,68 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
       assert_range(ranges, range(0, 6, 2, 6))
     end
   end
+
+  describe "map update" do
+    test "left side of |" do
+      text = """
+      %{asd | a: 1, b: x}
+      """
+
+      ranges = get_ranges(text, 0, 3)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full map
+      assert_range(ranges, range(0, 0, 0, 19))
+      # asd
+      assert_range(ranges, range(0, 2, 0, 5))
+    end
+
+    test "right side of |" do
+      text = """
+      %{asd | a: 1, b: x}
+      """
+
+      ranges = get_ranges(text, 0, 9)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full map
+      assert_range(ranges, range(0, 0, 0, 19))
+      # full keyword
+      assert_range(ranges, range(0, 8, 0, 18))
+      # a: 1
+      assert_range(ranges, range(0, 8, 0, 12))
+    end
+
+    test "left side of | near" do
+      text = """
+      %{state | 1 => 1, counter: counter + to_dispatch, demand: demand - to_dispatch}
+      """
+
+      ranges = get_ranges(text, 0, 8)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full map
+      assert_range(ranges, range(0, 0, 0, 79))
+      # |
+      assert_range(ranges, range(0, 8, 0, 9))
+    end
+
+    test "right side of | near" do
+      text = """
+      %{state | 1 => 1, counter: counter + to_dispatch, demand: demand - to_dispatch}
+      """
+
+      ranges = get_ranges(text, 0, 9)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full map
+      assert_range(ranges, range(0, 0, 0, 79))
+      # |
+      assert_range(ranges, range(0, 8, 0, 9))
+    end
+  end
 end

--- a/apps/language_server/test/providers/selection_ranges_test.exs
+++ b/apps/language_server/test/providers/selection_ranges_test.exs
@@ -957,4 +957,39 @@ defmodule ElixirLS.LanguageServer.Providers.SelectionRangesTest do
     # var2
     assert_range(ranges, range(0, 7, 0, 11))
   end
+
+  describe "keyword args" do
+    test "single line" do
+      text = """
+      my(1, a: 2, b: 3)
+      """
+
+      ranges = get_ranges(text, 0, 6)
+
+      # full range
+      assert_range(ranges, range(0, 0, 1, 0))
+      # full call
+      assert_range(ranges, range(0, 0, 0, 17))
+      # full keyword
+      assert_range(ranges, range(0, 6, 0, 16))
+    end
+
+    test "multi line" do
+      text = """
+      my(1, a: 2, 
+        b: 3,
+        c: 4
+      )
+      """
+
+      ranges = get_ranges(text, 1, 2)
+
+      # full range
+      assert_range(ranges, range(0, 0, 4, 0))
+      # full call
+      assert_range(ranges, range(0, 0, 3, 1))
+      # full keyword
+      assert_range(ranges, range(0, 6, 2, 6))
+    end
+  end
 end

--- a/apps/language_server/test/range_utils_test.exs
+++ b/apps/language_server/test/range_utils_test.exs
@@ -1,0 +1,510 @@
+defmodule ElixirLS.LanguageServer.RangeUtilsTest do
+  use ExUnit.Case
+
+  import ElixirLS.LanguageServer.Protocol
+  import ElixirLS.LanguageServer.RangeUtils
+
+  describe "valid?/1" do
+    test "returns true if range is valid" do
+      assert valid?(range(0, 0, 0, 0))
+      assert valid?(range(1, 1, 1, 2))
+      assert valid?(range(1, 1, 2, 0))
+      assert valid?(range(1, 1, 2, 6))
+    end
+
+    test "returns false if range is invalid" do
+      refute valid?(range(1, 1, 1, 0))
+      refute valid?(range(1, 1, 0, 1))
+      refute valid?(range(-1, 1, 5, 5))
+      refute valid?(range(1, -1, 5, 5))
+      refute valid?(range(1, 1, -5, 5))
+      refute valid?(range(1, 1, 5, -5))
+      refute valid?(range(1, 1, 5, nil))
+      refute valid?(range(1, 1, nil, 5))
+      refute valid?(range(1, nil, 5, 5))
+      refute valid?(range(nil, 1, 5, 5))
+    end
+  end
+
+  describe "left_in_right?" do
+    test "returns true if range 1 is inside range 2" do
+      range1 = range(2, 1, 3, 20)
+      range2 = range(1, 2, 4, 15)
+      assert left_in_right?(range1, range2)
+    end
+
+    test "returns true if range 1 is inside range 2 columns equal" do
+      range1 = range(2, 1, 3, 20)
+      range2 = range(2, 1, 3, 20)
+      assert left_in_right?(range1, range2)
+    end
+
+    test "returns true if range 1 is inside range 2 same line" do
+      range1 = range(1, 5, 1, 10)
+      range2 = range(1, 2, 1, 15)
+      assert left_in_right?(range1, range2)
+    end
+
+    test "returns false if ranges overlap but range 1 is wider" do
+      range2 = range(2, 1, 3, 20)
+
+      range1 = range(2, 0, 3, 20)
+      refute left_in_right?(range1, range2)
+
+      range1 = range(2, 1, 3, 21)
+      refute left_in_right?(range1, range2)
+
+      range1 = range(1, 1, 3, 21)
+      refute left_in_right?(range1, range2)
+
+      range1 = range(2, 1, 4, 21)
+      refute left_in_right?(range1, range2)
+    end
+
+    test "returns false if range 1 starts after range 2" do
+      range1 = range(3, 5, 4, 10)
+      range2 = range(1, 2, 2, 15)
+      refute left_in_right?(range1, range2)
+    end
+
+    test "returns false if range 1 starts after range 2 same line" do
+      range1 = range(1, 16, 1, 18)
+      range2 = range(1, 2, 1, 15)
+      refute left_in_right?(range1, range2)
+    end
+
+    test "returns false if range 1 ends before range 2" do
+      range1 = range(1, 5, 2, 10)
+      range2 = range(3, 7, 4, 15)
+      refute left_in_right?(range1, range2)
+    end
+
+    test "returns false if range 1 ends before range 2 same line" do
+      range1 = range(1, 5, 1, 10)
+      range2 = range(1, 11, 1, 15)
+      refute left_in_right?(range1, range2)
+    end
+  end
+
+  describe "sort_ranges_widest_to_narrowest/1" do
+    test "sorts ranges" do
+      ranges = [
+        range(1, 5, 1, 10),
+        range(1, 5, 1, 5),
+        range(0, 0, 3, 10),
+        range(1, 1, 2, 15),
+        range(1, 4, 1, 20),
+        range(1, 3, 2, 10)
+      ]
+
+      expected = [
+        range(0, 0, 3, 10),
+        range(1, 1, 2, 15),
+        range(1, 3, 2, 10),
+        range(1, 4, 1, 20),
+        range(1, 5, 1, 10),
+        range(1, 5, 1, 5)
+      ]
+
+      assert sort_ranges_widest_to_narrowest(ranges) == expected
+    end
+  end
+
+  describe "increasingly_narrowing?/1" do
+    test "returns true if only one range" do
+      ranges = [
+        range(0, 0, 3, 10)
+      ]
+
+      assert increasingly_narrowing?(ranges)
+    end
+
+    test "returns true if ranges are increasingly narrowing" do
+      ranges = [
+        range(0, 0, 3, 10),
+        range(1, 1, 2, 15),
+        range(1, 3, 2, 10),
+        range(1, 4, 1, 20),
+        range(1, 5, 1, 10),
+        range(1, 5, 1, 5)
+      ]
+
+      assert increasingly_narrowing?(ranges)
+    end
+
+    test "returns false if order is broken" do
+      ranges = [
+        range(0, 0, 3, 10),
+        range(1, 1, 3, 11)
+      ]
+
+      refute increasingly_narrowing?(ranges)
+    end
+  end
+
+  describe "union/2" do
+    test "right in left" do
+      left = range(1, 1, 4, 10)
+      right = range(2, 5, 3, 5)
+
+      expected = left
+
+      assert union(left, right) == expected
+      assert union(right, left) == expected
+    end
+
+    test "right in left same line" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 5, 1, 5)
+
+      expected = left
+
+      assert union(left, right) == expected
+      assert union(right, left) == expected
+    end
+
+    test "right equal left" do
+      left = range(1, 1, 2, 10)
+      right = left
+
+      expected = left
+
+      assert union(left, right) == expected
+    end
+
+    test "overlap" do
+      left = range(1, 1, 3, 10)
+      right = range(2, 5, 4, 15)
+
+      expected = range(1, 1, 4, 15)
+
+      assert union(left, right) == expected
+      assert union(right, left) == expected
+    end
+
+    test "overlap same line" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 5, 1, 15)
+
+      expected = range(1, 1, 1, 15)
+
+      assert union(left, right) == expected
+      assert union(right, left) == expected
+    end
+
+    test "overlap same line one column" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 10, 1, 15)
+
+      expected = range(1, 1, 1, 15)
+
+      assert union(left, right) == expected
+      assert union(right, left) == expected
+    end
+
+    test "raises if ranges do not intersect" do
+      left = range(1, 1, 2, 5)
+      right = range(3, 1, 4, 1)
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        union(left, right)
+      end
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        union(right, left)
+      end
+    end
+
+    test "raises if ranges do not intersect same line" do
+      left = range(1, 1, 1, 5)
+      right = range(1, 8, 1, 10)
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        union(left, right)
+      end
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        union(right, left)
+      end
+    end
+  end
+
+  describe "intersection/2" do
+    test "right in left" do
+      left = range(1, 1, 4, 10)
+      right = range(2, 5, 3, 5)
+
+      expected = right
+
+      assert intersection(left, right) == expected
+      assert intersection(right, left) == expected
+    end
+
+    test "right in left same line" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 5, 1, 5)
+
+      expected = right
+
+      assert intersection(left, right) == expected
+      assert intersection(right, left) == expected
+    end
+
+    test "right equal left" do
+      left = range(1, 1, 2, 10)
+      right = left
+
+      expected = left
+
+      assert intersection(left, right) == expected
+    end
+
+    test "overlap" do
+      left = range(1, 1, 3, 10)
+      right = range(2, 5, 4, 15)
+
+      expected = range(2, 5, 3, 10)
+
+      assert intersection(left, right) == expected
+      assert intersection(right, left) == expected
+    end
+
+    test "overlap same line" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 5, 1, 15)
+
+      expected = range(1, 5, 1, 10)
+
+      assert intersection(left, right) == expected
+      assert intersection(right, left) == expected
+    end
+
+    test "overlap same line one column" do
+      left = range(1, 1, 1, 10)
+      right = range(1, 10, 1, 15)
+
+      expected = range(1, 10, 1, 10)
+
+      assert intersection(left, right) == expected
+      assert intersection(right, left) == expected
+    end
+
+    test "raises if ranges do not intersect" do
+      left = range(1, 1, 2, 5)
+      right = range(3, 1, 4, 1)
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        intersection(left, right)
+      end
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        intersection(right, left)
+      end
+    end
+
+    test "raises if ranges do not intersect same line" do
+      left = range(1, 1, 1, 5)
+      right = range(1, 8, 1, 10)
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        intersection(left, right)
+      end
+
+      assert_raise ArgumentError, "no intersection", fn ->
+        intersection(right, left)
+      end
+    end
+  end
+
+  describe "merge_ranges_lists/2" do
+    test "equal length, 2 in 1" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      range_2 = [
+        range(1, 1, 5, 5),
+        range(3, 1, 3, 5)
+      ]
+
+      expected = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4),
+        range(3, 1, 3, 5)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+
+    test "equal length, 1 in 2" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(3, 1, 3, 5)
+      ]
+
+      range_2 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      expected = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4),
+        range(3, 1, 3, 5)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+
+    test "equal length, ranges intersect" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      range_2 = [
+        range(1, 1, 5, 5),
+        range(2, 5, 4, 8)
+      ]
+
+      expected = [
+        range(1, 1, 5, 5),
+        # union
+        range(2, 2, 4, 8),
+        # preferred from range_1
+        range(2, 2, 4, 4)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+
+    test "equal length, ranges intersect, last range_2 wider than range_1" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4),
+        range(3, 6, 3, 8)
+      ]
+
+      range_2 = [
+        range(1, 1, 5, 5),
+        range(2, 5, 4, 8),
+        range(2, 6, 4, 8)
+      ]
+
+      expected = [
+        range(1, 1, 5, 5),
+        # union
+        range(2, 2, 4, 8),
+        # preferred from range_1
+        range(2, 2, 4, 4),
+        # intersection of range_2 and range_1
+        range(2, 6, 4, 4),
+        # last range_1 range
+        range(3, 6, 3, 8)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+
+    test "ranges intersect, last range_2 wider than range_1" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      range_2 = [
+        range(1, 1, 5, 5),
+        range(2, 5, 4, 8),
+        range(2, 6, 4, 8)
+      ]
+
+      expected = [
+        range(1, 1, 5, 5),
+        # union
+        range(2, 2, 4, 8),
+        # preferred from range_1
+        range(2, 2, 4, 4),
+        # intersection of range_2 and range_1
+        range(2, 6, 4, 4)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+
+    test "raises if range list do not start with the same range" do
+      range_1 = [
+        range(2, 2, 4, 4),
+        range(1, 1, 5, 5)
+      ]
+
+      range_2 = [
+        range(1, 1, 3, 3),
+        range(2, 2, 2, 2)
+      ]
+
+      assert_raise ArgumentError, fn ->
+        merge_ranges_lists(range_1, range_2)
+      end
+    end
+
+    test "raises if range_1 is not increasingly narrowing" do
+      range_1 = [
+        range(0, 0, 10, 10),
+        range(2, 2, 4, 4),
+        range(1, 1, 5, 5)
+      ]
+
+      range_2 = [
+        range(0, 0, 10, 10),
+        range(1, 1, 3, 3),
+        range(2, 2, 2, 2)
+      ]
+
+      assert_raise ArgumentError, fn ->
+        merge_ranges_lists(range_1, range_2)
+      end
+    end
+
+    test "raises if range_2 is not increasingly narrowing" do
+      range_1 = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      range_2 = [
+        range(0, 0, 10, 10),
+        range(2, 2, 2, 2),
+        range(1, 1, 3, 3)
+      ]
+
+      assert_raise ArgumentError, fn ->
+        merge_ranges_lists(range_1, range_2)
+      end
+    end
+
+    test "handles equal ranges" do
+      range_1 = [range(1, 1, 5, 5)]
+      range_2 = [range(1, 1, 5, 5)]
+
+      assert merge_ranges_lists(range_1, range_2) == [range(1, 1, 5, 5)]
+    end
+
+    test "handles one empty range" do
+      range_1 = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      range_2 = [range(1, 1, 5, 5)]
+
+      expected = [
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      assert merge_ranges_lists(range_1, range_2) == expected
+    end
+  end
+end

--- a/apps/language_server/test/range_utils_test.exs
+++ b/apps/language_server/test/range_utils_test.exs
@@ -26,6 +26,27 @@ defmodule ElixirLS.LanguageServer.RangeUtilsTest do
     end
   end
 
+  describe "in?" do
+    test "empty range" do
+      assert in?(range(1, 2, 1, 2), {1, 2})
+    end
+
+    test "in range" do
+      assert in?(range(1, 2, 3, 4), {1, 2})
+      assert in?(range(1, 2, 3, 4), {1, 3})
+      assert in?(range(1, 2, 3, 4), {2, 2})
+      assert in?(range(1, 2, 5, 6), {5, 5})
+      assert in?(range(1, 2, 5, 6), {5, 6})
+    end
+
+    test "out of range" do
+      refute in?(range(1, 2, 3, 4), {0, 3})
+      refute in?(range(1, 2, 3, 4), {1, 1})
+      refute in?(range(1, 2, 5, 6), {5, 7})
+      refute in?(range(1, 2, 5, 6), {6, 3})
+    end
+  end
+
   describe "left_in_right?" do
     test "returns true if range 1 is inside range 2" do
       range1 = range(2, 1, 3, 20)

--- a/apps/language_server/test/range_utils_test.exs
+++ b/apps/language_server/test/range_utils_test.exs
@@ -507,4 +507,66 @@ defmodule ElixirLS.LanguageServer.RangeUtilsTest do
       assert merge_ranges_lists(range_1, range_2) == expected
     end
   end
+
+  describe "deduplicate/1" do
+    test "removes duplicates in the middle" do
+      range_1 = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(1, 1, 5, 5),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      expected = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      assert deduplicate(range_1) == expected
+    end
+
+    test "removes duplicates at start" do
+      range_1 = [
+        range(0, 0, 10, 10),
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      expected = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      assert deduplicate(range_1) == expected
+    end
+
+    test "removes duplicates at end" do
+      range_1 = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4),
+        range(2, 2, 4, 4)
+      ]
+
+      expected = [
+        range(0, 0, 10, 10),
+        range(1, 1, 5, 5),
+        range(2, 2, 4, 4)
+      ]
+
+      assert deduplicate(range_1) == expected
+    end
+
+    test "handles empty list" do
+      assert deduplicate([]) == []
+    end
+
+    test "handles one element list" do
+      assert deduplicate([range(0, 0, 10, 10)]) == [range(0, 0, 10, 10)]
+    end
+  end
 end


### PR DESCRIPTION
This PR bases on tools built for folding ranges provider in https://github.com/elixir-lsp/elixir-ls/pull/492 with the addition of AST and Code.Fragment.

Similarly to folding ranges, selection ranges works in a number of passes. Each pass generates sets of ranges, that are filtered based on cursor position and sorted from widest to narrowest.
Then ranges from each pass are recursively merged with an algorithm that sorts ranges and resolves conflicts.

Addresses https://github.com/elixir-lsp/elixir-ls/issues/534