### PR TITLE
fix: check if cursor is on definition(#1042)

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -987,7 +987,7 @@ defmodule ElixirLS.LanguageServer.Server do
       {:ok, result} =
         Definition.definition(uri, parser_context, line, character, state.project_dir)
 
-      if result.uri == uri && result.range["start"]["line"] == line - 1 do
+      if result != nil && result.uri == uri && result.range["start"]["line"] == line - 1 do
         case References.references(parser_context, uri, line, character, false, state.project_dir) do
           [] -> {:ok, result}
           refs -> {:ok, refs}


### PR DESCRIPTION
This pr addresses #1042 by checking if the cursor is on the same line as the definition of the symbol, if so, it will return references to the symbol instead.

