### PR TITLE
Update get_release to look for VERSION in the correct place

### DIFF
--- a/scripts/installer.exs
+++ b/scripts/installer.exs
@@ -504,7 +504,7 @@ defmodule ElixirLS.Installer do
 
   defp get_release do
     version =
-      Path.expand("#{__DIR__}/VERSION")
+      Path.expand("../#{__DIR__}/VERSION")
       |> File.read!()
       |> String.trim()
 


### PR DESCRIPTION
The installer.exs file in the scripts directory looks for the VERSION file in its own directory, but the VERSION file is in the directory above it. This causes it to crash when attempting to install the language server.