### PR TITLE
Look for VERSION in correct place

### DIFF
--- a/scripts/installer.exs
+++ b/scripts/installer.exs
@@ -504,7 +504,7 @@ defmodule ElixirLS.Installer do
 
   defp get_release do
     version =
-      Path.expand("#{__DIR__}/VERSION")
+      Path.expand("#{__DIR__}/../VERSION")
       |> File.read!()
       |> String.trim()
 


### PR DESCRIPTION
Currently, get_release looks for VERSION in its own directory (scripts), but the VERSION file is located in the directory above scripts. This cause File.read! to fail when trying to install elixir-ls.