### PR TITLE
bump elixir_sense to latest commit

### DIFF
--- a/dep_versions.exs
+++ b/dep_versions.exs
@@ -1,5 +1,5 @@
 [
-  elixir_sense: "6c293f27ea3afc4f5913a7ed03a07db0fa15a0a2",
+  elixir_sense: "67f6974dedb33846a060031d5afd5430a3f583f0",
   dialyxir_vendored: "f8f64cfb6797c518294687e7c03ae817bacbc6ee",
   jason_v: "f1c10fa9c445cb9f300266122ef18671054b2330",
   erl2ex_vendored: "073ac6b9a44282e718b6050c7b27cedf9217a12a",

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir_vendored": {:git, "https://github.com/elixir-lsp/dialyxir.git", "f8f64cfb6797c518294687e7c03ae817bacbc6ee", [ref: "f8f64cfb6797c518294687e7c03ae817bacbc6ee"]},
-  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "6c293f27ea3afc4f5913a7ed03a07db0fa15a0a2", [ref: "6c293f27ea3afc4f5913a7ed03a07db0fa15a0a2"]},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "67f6974dedb33846a060031d5afd5430a3f583f0", [ref: "67f6974dedb33846a060031d5afd5430a3f583f0"]},
   "erl2ex_vendored": {:git, "https://github.com/elixir-lsp/erl2ex.git", "073ac6b9a44282e718b6050c7b27cedf9217a12a", [ref: "073ac6b9a44282e718b6050c7b27cedf9217a12a"]},
   "erlex_vendored": {:git, "https://github.com/elixir-lsp/erlex.git", "c0e448db27bcbb3f369861d13e3b0607ed37048d", [ref: "c0e448db27bcbb3f369861d13e3b0607ed37048d"]},
   "jason_v": {:git, "https://github.com/elixir-lsp/jason.git", "f1c10fa9c445cb9f300266122ef18671054b2330", [ref: "f1c10fa9c445cb9f300266122ef18671054b2330"]},


### PR DESCRIPTION
iex -v 1.17.3
erl -v 27.1.2

Due to my ElixirLS constantly crashing as soon as I open  in nvim with elixir-tools.nvim I went down some debugging and got those logs: https://gist.github.com/dennym/d2bc78af479c22c918d4408f48e465cc

While trying to find out why `eiixir_sense` is failing to compile I saw that there were recent changes to it coming from `elixir-ls` repo which haven't been yet utilized in itself.

This PR should pick up all the recent changes of `elixir_sense` and then should be also automatically available for latest elixir-tools.nvim
 
Unfortunately I currently don't have the whole setup of repositories to be able to test if it removes the error I am getting but at least this dependency is up to date again and `mix test` succeeds locally.

Edit:

On further inspection I found a way to use my custom fork with the new changes in elixir-tools.nvim and the lsp logs can be found here:
https://gist.github.com/dennym/fabc94c57f76085380cc0b891dd856c9

There seem way more warnings which can be mostly ignored but it still has issues compiling elixir_sense but this time on some some other piece.


I would love to help but do not really know where to start on this complexity. The pity is that `elixir-tool.nvim`  and/or `elixir-ls` are completely not usable when opening any elixir code.