### PR TITLE
avoid "no fn clause matching" error in `Completion.snippet?`

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -1441,7 +1441,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
   end
 
   defp snippet?(item) do
-    item.kind == :snippet || String.match?(item.insert_text, ~r/\${?\d/u)
+    item.kind == :snippet || (item.insert_text != nil and String.match?(item.insert_text, ~r/\${?\d/u))
   end
 
   # As defined by CompletionItemTag in https://microsoft.github.io/language-server-protocol/specifications/specification-current/


### PR DESCRIPTION
`maybe_add_keywords` can return empty `insert_text` and use `text_edit` instead, resulting in "no function clause matching" error in `String.match?`.