### PR TITLE
Update README.md - Add troubleshooting tip for emacs with symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ For `eglot`, use:
 (add-to-list 'eglot-server-programs '(elixir-mode "path-to-elixir-ls/release/language_server.sh"))
 ```
 
+If you access any projects via symlinks, and the lsp crashes immediately on startup in those projects, you might need this:
+
+```elisp
+(setq find-file-visit-truename t)
+```
+
 </details>
 
 ## Supported Elixir and OTP versions


### PR DESCRIPTION
I kept getting a crash immediately on startup in projects under a symlinked path.

```
LSP :: Connected to [elixir-ls:127582/starting /path/to/project].
LSP :: Unable to autoconfigure company-mode. [2 times]
LSP :: elixir-ls:127582 initialized successfully in folders: (/path/to/project)
LSP :: Unable to autoconfigure company-mode. [2 times]
LSP :: Project directory change detected. ElixirLS will restart.
LSP :: elixir-ls has exited (finished)
LSP :: Sending to process failed with the following error: Process elixir-ls not running: finished

Server elixir-ls:127582 exited (check corresponding stderr buffer for details). Do you want to restart it? (y or n) n
```

It comes from here in the LSP source code:

https://github.com/elixir-lsp/elixir-ls/blob/3a77d8c899c9dc7f94c9b4345b2eb24f99a62c7c/apps/language_server/lib/language_server/server.ex#L2208-L2212

I don't know how to expand a symlink path in Elixir, but maybe it would be better to do that above to avoid this error without having to use the emacs setting. I suppose it might affect other editors also.

In my situation the `prev_project_dir` has the full path, and the `project_dir` has the abbreviated symlink path. Eg.

prev: `/home/fj/src/projects/elixir/foo`
new: `/home/fj/foo`

with `/home/fj/foo` symlinked to `/home/fj/src/projects/elixir/foo`
