### PR TITLE
don't render spark_opts metadata in function docs

### DIFF
--- a/apps/language_server/lib/language_server/markdown_utils.ex
+++ b/apps/language_server/lib/language_server/markdown_utils.ex
@@ -142,6 +142,8 @@ defmodule ElixirLS.LanguageServer.MarkdownUtils do
     "**Delegates to** #{inspect(m)}.#{f}/#{a}"
   end
 
+  defp get_metadata_entry_md({:spark_opts, _}), do: nil
+
   defp get_metadata_entry_md({key, value}) do
     "**#{key}** #{inspect(value)}"
   end


### PR DESCRIPTION
This implements the suggestion from https://github.com/elixir-lsp/elixir-ls/issues/1142#issuecomment-2546372999