### PR TITLE
Remove DETS

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -140,7 +140,6 @@ defmodule ElixirLS.LanguageServer.Build do
             end)
 
           if Keyword.get(opts, :compile?) do
-            Tracer.save()
             Logger.info("Compile took #{div(us, 1000)} milliseconds")
           else
             Logger.info("Mix project load took #{div(us, 1000)} milliseconds")

--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -67,8 +67,8 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
     GenServer.start_link(__MODULE__, :ok, opts |> Keyword.put_new(:name, __MODULE__))
   end
 
-  def notify_settings_stored() do
-    GenServer.cast(__MODULE__, :notify_settings_stored)
+  def notify_settings_stored(project_dir) do
+    GenServer.cast(__MODULE__, {:notify_settings_stored, project_dir})
   end
 
   def notify_build_complete(server \\ __MODULE__) do
@@ -150,9 +150,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
   end
 
   @impl GenServer
-  def handle_cast(:notify_settings_stored, state) do
-    project_dir = :persistent_term.get(:language_server_project_dir)
-
+  def handle_cast({:notify_settings_stored, project_dir}, state) do
     # as of LSP 3.17 only one tag is defined and clients are required to silently ignore unknown tags
     # so there's no need to pass the list
     tag_support =

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -1865,9 +1865,8 @@ defmodule ElixirLS.LanguageServer.Server do
     state = create_gitignore(state)
 
     if state.mix_project? do
-      :persistent_term.put(:language_server_project_dir, state.project_dir)
-      WorkspaceSymbols.notify_settings_stored()
-      Tracer.notify_settings_stored()
+      WorkspaceSymbols.notify_settings_stored(state.project_dir)
+      Tracer.notify_settings_stored(state.project_dir)
     end
 
     JsonRpc.telemetry(

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -120,8 +120,6 @@ defmodule ElixirLS.LanguageServer.Tracer do
       sync(table_name)
     end
 
-    write_manifest(project_dir)
-
     {:noreply, state}
   end
 
@@ -485,38 +483,5 @@ defmodule ElixirLS.LanguageServer.Tracer do
     after
       :ets.safe_fixtable(table, false)
     end
-  end
-
-  defp manifest_path(project_dir) do
-    Path.join([project_dir, ".elixir_ls", "tracer_db.manifest"])
-  end
-
-  def write_manifest(project_dir) do
-    path = manifest_path(project_dir)
-    File.rm_rf!(path)
-
-    File.write!(path, "#{@version}", [:write])
-  end
-
-  def read_manifest(project_dir) do
-    with {:ok, text} <- File.read(manifest_path(project_dir)),
-         {version, ""} <- Integer.parse(text) do
-      version
-    else
-      other ->
-        IO.warn("Manifest: #{inspect(other)}")
-        nil
-    end
-  end
-
-  def manifest_version_current?(project_dir) do
-    read_manifest(project_dir) == @version
-  end
-
-  def clean_dets(project_dir) do
-    for path <-
-          Path.join([SourceFile.Path.escape_for_wildcard(project_dir), ".elixir_ls/*.dets"])
-          |> Path.wildcard(),
-        do: File.rm_rf!(path)
   end
 end

--- a/apps/language_server/lib/language_server/tracer.ex
+++ b/apps/language_server/lib/language_server/tracer.ex
@@ -20,8 +20,8 @@ defmodule ElixirLS.LanguageServer.Tracer do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
-  def notify_settings_stored() do
-    GenServer.cast(__MODULE__, :notify_settings_stored)
+  def notify_settings_stored(project_dir) do
+    GenServer.cast(__MODULE__, {:notify_settings_stored, project_dir})
   end
 
   defp get_project_dir() do
@@ -53,8 +53,7 @@ defmodule ElixirLS.LanguageServer.Tracer do
       ])
     end
 
-    project_dir = :persistent_term.get(:language_server_project_dir, nil)
-    state = %{project_dir: project_dir}
+    state = %{project_dir: nil}
 
     {:ok, state}
   end
@@ -65,9 +64,7 @@ defmodule ElixirLS.LanguageServer.Tracer do
   end
 
   @impl true
-  def handle_cast(:notify_settings_stored, state) do
-    project_dir = :persistent_term.get(:language_server_project_dir)
-
+  def handle_cast({:notify_settings_stored, project_dir}, state) do
     for table <- @tables do
       table_name = table_name(table)
       :ets.delete_all_objects(table_name)

--- a/apps/language_server/test/providers/references_test.exs
+++ b/apps/language_server/test/providers/references_test.exs
@@ -13,8 +13,8 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
     File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/calls.dets"))
     {:ok, pid} = Tracer.start_link([])
     project_path = FixtureHelpers.get_path("")
-    :persistent_term.put(:language_server_project_dir, project_path)
-    Tracer.notify_settings_stored()
+
+    Tracer.notify_settings_stored(project_path)
 
     compiler_options = Code.compiler_options()
     Build.set_compiler_options(ignore_module_conflict: true)

--- a/apps/language_server/test/providers/references_test.exs
+++ b/apps/language_server/test/providers/references_test.exs
@@ -10,7 +10,6 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
   require ElixirLS.Test.TextLoc
 
   setup_all context do
-    File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/calls.dets"))
     {:ok, pid} = Tracer.start_link([])
     project_path = FixtureHelpers.get_path("")
 

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -153,18 +153,4 @@ defmodule ElixirLS.LanguageServer.TracerTest do
       assert [] == sorted_calls()
     end
   end
-
-  describe "manifest" do
-    test "return nil when not found" do
-      project_path = FixtureHelpers.get_path("")
-      assert nil == Tracer.read_manifest(project_path)
-    end
-
-    test "reads manifest" do
-      project_path = FixtureHelpers.get_path("")
-      Tracer.write_manifest(project_path)
-
-      assert 3 == Tracer.read_manifest(project_path)
-    end
-  end
 end

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -21,23 +21,6 @@ defmodule ElixirLS.LanguageServer.TracerTest do
     assert GenServer.call(Tracer, :get_project_dir) == project_path
   end
 
-  test "saves DETS" do
-    project_path = FixtureHelpers.get_path("")
-    :persistent_term.put(:language_server_project_dir, project_path)
-    Tracer.notify_settings_stored()
-
-    Tracer.save()
-    GenServer.call(Tracer, :get_project_dir)
-
-    assert File.exists?(FixtureHelpers.get_path(".elixir_ls/calls.dets"))
-    assert File.exists?(FixtureHelpers.get_path(".elixir_ls/modules.dets"))
-  end
-
-  test "skips save if project dir not set" do
-    Tracer.save()
-    GenServer.call(Tracer, :get_project_dir)
-  end
-
   describe "call trace" do
     setup context do
       project_path = FixtureHelpers.get_path("")

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -4,9 +4,6 @@ defmodule ElixirLS.LanguageServer.TracerTest do
   alias ElixirLS.LanguageServer.Test.FixtureHelpers
 
   setup context do
-    File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/tracer_db.manifest"))
-    File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/calls.dets"))
-    File.rm_rf!(FixtureHelpers.get_path(".elixir_ls/modules.dets"))
     {:ok, _pid} = start_supervised(Tracer)
 
     {:ok, context}

--- a/apps/language_server/test/tracer_test.exs
+++ b/apps/language_server/test/tracer_test.exs
@@ -14,9 +14,8 @@ defmodule ElixirLS.LanguageServer.TracerTest do
 
   test "set project dir" do
     project_path = FixtureHelpers.get_path("")
-    :persistent_term.put(:language_server_project_dir, project_path)
 
-    Tracer.notify_settings_stored()
+    Tracer.notify_settings_stored(project_path)
 
     assert GenServer.call(Tracer, :get_project_dir) == project_path
   end
@@ -24,8 +23,7 @@ defmodule ElixirLS.LanguageServer.TracerTest do
   describe "call trace" do
     setup context do
       project_path = FixtureHelpers.get_path("")
-      :persistent_term.put(:language_server_project_dir, project_path)
-      Tracer.notify_settings_stored()
+      Tracer.notify_settings_stored(project_path)
       GenServer.call(Tracer, :get_project_dir)
 
       {:ok, context}


### PR DESCRIPTION
DETS turned out to be really unstable. After many bugfixes the best workaround was to rebuild everything on start. Since we rebuild anyway, storing DETS databases does not make sense anymore. Additionally the code crashed beam on windows in OTP 27