### PR TITLE
Use correct activation command for Mise

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -53,7 +53,7 @@ else
   if which mise >/dev/null
   then
     >&2 echo "mise executable found in $(which mise), activating"
-    eval "$($(which mise) env -s "$preferred_shell")"
+    eval "$($(which mise) activate "$preferred_shell")"
   else
     >&2 echo "mise not found"
     >&2 echo "Looking for rtx executable"


### PR DESCRIPTION
I'm not sure what the history of this is, but for current versions of Mise, `mise env` doesn't activate it in the environment; this updates to the correct command.