### PR TITLE
fix asdf version detection in fish

### DIFF
--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -14,44 +14,46 @@ test -n "$ASDF_DIR"; or set ASDF_DIR "$HOME/.asdf"
 # Check if we have the asdf binary for version >= 0.16.0
 set asdf (which asdf)
 if test -n "$asdf"
-    echo "asdf executable found at $asdf. Setting ASDF_DIR=$ASDF_DIR and adding $ASDF_DATA_DIR/shims to PATH." >&2
-    # If the binary is found, set up environment for newer asdf versions
-    set -gx ASDF_DATA_DIR "$ASDF_DIR"
-    set -gx PATH "$ASDF_DATA_DIR/shims" $PATH
-else
-    # Fallback to old method for asdf version <= 0.15.x
-    set ASDF_SH "$ASDF_DIR/asdf.fish"
-    if test -f "$ASDF_SH"
+    set asdf_version (asdf --version)
+    set semver (string match -r '(\d+)\.(\d+)\.(\d+)' $asdf_version)
+    if test $semver[2] -eq 0 -a $semver[3] -lt 16
+        # Fallback to old method for asdf version <= 0.15.x
+        set ASDF_SH "$ASDF_DIR/asdf.fish"
         echo "Legacy pre v0.16.0 asdf install found at $ASDF_SH, sourcing" >&2
         # Source the old asdf.sh script for versions <= 0.15.0
         source "$ASDF_SH"
     else
-        echo "asdf not found" >&2
-        echo "Looking for mise executable" >&2
+        echo "asdf executable found at $asdf. Setting ASDF_DIR=$ASDF_DIR and adding $ASDF_DATA_DIR/shims to PATH." >&2
+        # If the binary is found, set up environment for newer asdf versions
+        set -gx ASDF_DATA_DIR "$ASDF_DIR"
+        set -gx PATH "$ASDF_DATA_DIR/shims" $PATH
+    end
+else
+    echo "asdf not found" >&2
+    echo "Looking for mise executable" >&2
 
-        set mise (which mise)
-        if test -n "$mise"
-            echo "mise executable found at $mise, activating" >&2
-            source ( "$mise" env -s fish )
+    set mise (which mise)
+    if test -n "$mise"
+        echo "mise executable found at $mise, activating" >&2
+        source ( "$mise" env -s fish )
+    else
+        echo "mise not found" >&2
+        echo "Looking for rtx executable" >&2
+
+        set rtx (which rtx)
+        if test -n "$rtx"
+            echo "rtx executable found at $rtx, activating" >&2
+            source ( "$rtx" env -s fish )
         else
-            echo "mise not found" >&2
-            echo "Looking for rtx executable" >&2
+            echo "rtx not found" >&2
+            echo "Looking for vfox executable" >&2
 
-            set rtx (which rtx)
-            if test -n "$rtx"
-                echo "rtx executable found at $rtx, activating" >&2
-                source ( "$rtx" env -s fish )
+            set vfox (which vfox)
+            if test -n "$vfox"
+                echo "vfox executable found at $vfox, activating" >&2
+                source ( "$vfox" activate fish )
             else
-                echo "rtx not found" >&2
-                echo "Looking for vfox executable" >&2
-
-                set vfox (which vfox)
-                if test -n "$vfox"
-                    echo "vfox executable found at $vfox, activating" >&2
-                    source ( "$vfox" activate fish )
-                else
-                    echo "vfox not found" >&2
-                end
+                echo "vfox not found" >&2
             end
         end
     end


### PR DESCRIPTION
Right now it assumes if you can run `asdf` then it must be a binary and thus the new version and therefore not sourcing any of the necessary files. See #1167

This fixes it for fish shell.
