### PR TITLE
Fix ElixirLS not loading correctly with Mise (rtx) and Fish

### DIFF
--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -80,7 +80,7 @@ else
                 set vfox (which vfox)
                 if test -n "$vfox"
                     echo "vfox executable found at $vfox, activating" >&2
-                    source ( "$vfox" activate fish )
+                    "$vfox" activate fish | source
                 else
                     echo "vfox not found" >&2
                     export_stdlib_path "which elixir"

--- a/scripts/launch.fish
+++ b/scripts/launch.fish
@@ -62,7 +62,7 @@ else
         set mise (which mise)
         if test -n "$mise"
             echo "mise executable found at $mise, activating" >&2
-            source ( "$mise" env -s fish )
+            "$mise" env -s fish | source
             export_stdlib_path "mise which elixir"
         else
             echo "mise not found" >&2
@@ -71,7 +71,7 @@ else
             set rtx (which rtx)
             if test -n "$rtx"
                 echo "rtx executable found at $rtx, activating" >&2
-                source ( "$rtx" env -s fish )
+                "$rtx" env -s fish | source
                 export_stdlib_path "rtx which elixir"
             else
                 echo "rtx not found" >&2


### PR DESCRIPTION
Hi :wave: 

I was struggling to get ElixirLS to load correctly with Mise and Fish and tracked it down to the launch script not executing the command outputted by  `mise env -s fish ` .

Piping the command output into `source` executes the command correctly rather than it trying to load it like a file.

Using `eval` is a possible alternative.

You probably know this already but rtx turned into mise so possibly that part of the script is redundant but not doing any harm. I have updated it to keep it consistent. 