### PR TITLE
Refactor token lookup logic

### DIFF
--- a/apps/language_server/lib/language_server/providers/locator_utils.ex
+++ b/apps/language_server/lib/language_server/providers/locator_utils.ex
@@ -1,0 +1,40 @@
+defmodule ElixirLS.LanguageServer.Providers.LocatorUtils do
+  @moduledoc """
+  Helper for providers resolving symbols at a given cursor position.
+  """
+
+  alias ElixirSense.Core.{Binding, Metadata, Parser, SurroundContext}
+  alias ElixirSense.Core.Normalized.Code, as: NormalizedCode
+
+  @type t :: %{
+          context: map(),
+          env: Metadata.t(),
+          metadata: Metadata.t(),
+          binding_env: any(),
+          type: any()
+        }
+
+  @spec build(String.t(), pos_integer, pos_integer, keyword()) :: t | nil
+  def build(code, line, column, options \\ []) do
+    case NormalizedCode.Fragment.surround_context(code, {line, column}) do
+      :none ->
+        nil
+
+      context ->
+        metadata =
+          Keyword.get_lazy(options, :metadata, fn ->
+            Parser.parse_string(code, true, false, {line, column})
+          end)
+
+        env = Metadata.get_cursor_env(metadata, {line, column}, {context.begin, context.end})
+
+        %{
+          context: context,
+          env: env,
+          metadata: metadata,
+          binding_env: Binding.from_env(env, metadata, context.begin),
+          type: SurroundContext.to_binding(context.context, env.module)
+        }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create `LocatorUtils.build/4` helper to parse token context
- reuse helper in definition, declaration, implementation, references and hover providers

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a708e0c0832197f834be6a47e9e5