### PR TITLE
Fix cancellation error key name

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/server.ex
+++ b/apps/debug_adapter/lib/debug_adapter/server.ex
@@ -737,9 +737,9 @@ defmodule ElixirLS.DebugAdapter.Server do
       else
         raise ServerError,
           message: "invalidRequest",
-          format: "Request or progress {reguestOrProgressId} cannot be cancelled",
+          format: "Request or progress {requestOrProgressId} cannot be cancelled",
           variables: %{
-            "reguestOrProgressId" => inspect(request_or_progress_id)
+            "requestOrProgressId" => inspect(request_or_progress_id)
           },
           send_telemetry: false
       end

--- a/apps/debug_adapter/test/debugger_test.exs
+++ b/apps/debug_adapter/test/debugger_test.exs
@@ -3886,8 +3886,8 @@ defmodule ElixirLS.DebugAdapter.ServerTest do
           2,
           "cancel",
           "invalidRequest",
-          "Request or progress {reguestOrProgressId} cannot be cancelled",
-          %{"reguestOrProgressId" => "1"},
+          "Request or progress {requestOrProgressId} cannot be cancelled",
+          %{"requestOrProgressId" => "1"},
           _,
           _
         )


### PR DESCRIPTION
## Summary
- use `requestOrProgressId` in the cancellation error message
- update test expectation accordingly

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848b24887fc832192e40cf682c144fe