### PR TITLE
Fix re-registering standard error process

### DIFF
--- a/apps/elixir_ls_utils/lib/wire_protocol.ex
+++ b/apps/elixir_ls_utils/lib/wire_protocol.ex
@@ -77,7 +77,7 @@ defmodule ElixirLS.Utils.WireProtocol do
         raw_standard_error = Process.whereis(:raw_standard_error)
         Process.unregister(:raw_standard_error)
         Process.register(raw_standard_error, :standard_error)
-        raw_user
+        raw_standard_error
       rescue
         ArgumentError -> nil
       end


### PR DESCRIPTION
## Summary
- return the correct process when restoring intercepted standard error

## Testing
- `mix format apps/elixir_ls_utils/lib/wire_protocol.ex` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b7068acc8321bdde6e2843912145