### PR TITLE
Fix register_condition spec

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
+++ b/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
@@ -20,7 +20,7 @@ defmodule ElixirLS.DebugAdapter.BreakpointCondition do
           Macro.Env.t(),
           String.t(),
           String.t() | nil,
-          non_neg_integer
+          String.t()
         ) ::
           {:ok, {module, atom}} | {:error, :limit_reached}
   def register_condition(name \\ __MODULE__, module, line, env, condition, log_message, hit_count) do

--- a/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
+++ b/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
@@ -17,9 +17,10 @@ defmodule ElixirLS.DebugAdapter.BreakpointCondition do
           module,
           module,
           non_neg_integer,
+          Macro.Env.t(),
           String.t(),
           String.t() | nil,
-          String.t()
+          non_neg_integer
         ) ::
           {:ok, {module, atom}} | {:error, :limit_reached}
   def register_condition(name \\ __MODULE__, module, line, env, condition, log_message, hit_count) do


### PR DESCRIPTION
## Summary
- adjust `register_condition/7` spec so all args are defined and `hit_count` is typed as `non_neg_integer`

## Testing
- `mix format` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848b74c9370832188801bce9dfd7394