### PR TITLE
Fix typo in MixProjectCache documentation

### DIFF
--- a/apps/language_server/lib/language_server/mix_project_cache.ex
+++ b/apps/language_server/lib/language_server/mix_project_cache.ex
@@ -1,6 +1,6 @@
 defmodule ElixirLS.LanguageServer.MixProjectCache do
   @moduledoc """
-  This module serves as a caching layer guarantying a safe access to Mix.Project functions. Note that
+  This module serves as a caching layer guaranteeing a safe access to Mix.Project functions. Note that
   Mix.Project functions cannot be safely called during a build as dep mix projects are being pushed and
   popped
   """


### PR DESCRIPTION
## Summary
- fix a documentation typo in MixProjectCache

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848b75e5ea48321ad227f0403e0387e