### PR TITLE
Fix OTP debugger modules comment typo

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter.ex
+++ b/apps/debug_adapter/lib/debug_adapter.ex
@@ -11,7 +11,7 @@ defmodule ElixirLS.DebugAdapter do
     Launch.start_mix()
 
     if Version.match?(System.version(), ">= 1.15.0-dev") do
-      # make sue that OTP debugger modules are in code path
+      # make sure that OTP debugger modules are in code path
       # without starting the app
       Mix.ensure_application!(:debugger)
     end

--- a/apps/debug_adapter/test/test_helper.exs
+++ b/apps/debug_adapter/test/test_helper.exs
@@ -2,7 +2,7 @@
 ExUnit.start(exclude: [pending: true])
 
 if Version.match?(System.version(), ">= 1.15.0") do
-  # make sue that OTP debugger modules are in code path
+  # make sure that OTP debugger modules are in code path
   # without starting the app
   Mix.ensure_application!(:debugger)
 end


### PR DESCRIPTION
## Summary
- fix typo in debug adapter to ensure OTP debugger modules are on code path
- fix same typo in test helper

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b77cee1c8321ad67bdb39d52bf1c