### PR TITLE
Update known issues docs

### DIFF
--- a/docs/known-issues-limitations.md
+++ b/docs/known-issues-limitations.md
@@ -1,7 +1,7 @@
 # Known Issues / Limitations
 
 * `.exs` files don't return compilation errors
-* "Fetching n dependencies" sometimes get stuck (remove the `.elixir_ls` directory to fix)
+* "Fetching n dependencies" sometimes gets stuck (remove the `.elixir_ls` directory to fix)
 * Debugger doesn't work in Elixir 1.10.0 - 1.10.2 (but it should work in 1.10.3 when [this fix](https://github.com/elixir-lang/elixir/pull/9864) is released)
 * "Go to definition" does not work within the `scope` of a Phoenix router
 * On first launch dialyzer will cause high CPU usage for a considerable time


### PR DESCRIPTION
## Summary
- fix grammar in bullet about dependencies getting stuck

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0b6c63f483219eaae255731417bf