### PR TITLE
Handle missing version in extra doc links

### DIFF
--- a/apps/language_server/lib/language_server/markdown_utils.ex
+++ b/apps/language_server/lib/language_server/markdown_utils.ex
@@ -368,7 +368,14 @@ defmodule ElixirLS.LanguageServer.MarkdownUtils do
       end
 
     if app_vsn do
-      {app, _vsn} = app_vsn
+      app =
+        case app_vsn do
+          {app, _vsn} ->
+            app
+
+          app when is_atom(app) or is_binary(app) ->
+            app
+        end
 
       if app in @all_otp_apps and @erlang_ex_doc? do
         # TODO not sure hos the docs will handle versions app/vsn does not work as of June 2024

--- a/apps/language_server/test/markdown_utils_test.exs
+++ b/apps/language_server/test/markdown_utils_test.exs
@@ -293,6 +293,12 @@ defmodule ElixirLS.LanguageServer.MarkdownUtilsTest do
              ) == "[Up and running](http://example.com/foo.md)"
     end
 
+    test "extra page unknown app" do
+      assert MarkdownUtils.transform_ex_doc_links(
+               "[Up](e:unknown_app:foo.md)"
+             ) == "[Up](https://hexdocs.pm/unknown_app/foo.html)"
+    end
+
     if System.otp_release() |> String.to_integer() >= 27 do
       test "erlang extra page" do
         assert MarkdownUtils.transform_ex_doc_links(


### PR DESCRIPTION
## Summary
- avoid pattern match failure for docs when version info is missing
- test generating extra doc links with unknown app

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0b227240832195c1e61ce6b12cf6