### PR TITLE
Fix spec for text_diff_format

### DIFF
--- a/apps/language_server/lib/language_server/mix_tasks/format.ex
+++ b/apps/language_server/lib/language_server/mix_tasks/format.ex
@@ -859,7 +859,7 @@ defmodule Mix.Tasks.ElixirLSFormat do
   end
 
   @doc false
-  @spec text_diff_format(String.t(), String.t()) :: iolist()
+  @spec text_diff_format(String.t(), String.t(), keyword()) :: iolist()
   def text_diff_format(old, new, opts \\ [])
 
   def text_diff_format(code, code, _opts), do: []


### PR DESCRIPTION
## Summary
- update `text_diff_format/3` spec to mention `keyword()` opts

## Testing
- `mix format apps/language_server/lib/language_server/mix_tasks/format.ex`

------
https://chatgpt.com/codex/tasks/task_e_6851312b7d38832184045a8f320a81d7