### PR TITLE
Improve characters_to_binary! error handling

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/utils.ex
+++ b/apps/debug_adapter/lib/debug_adapter/utils.ex
@@ -21,7 +21,12 @@ defmodule ElixirLS.DebugAdapter.Utils do
 
   defp characters_to_binary!(binary, from, to) do
     case :unicode.characters_to_binary(binary, from, to) do
-      result when is_binary(result) -> result
+      result when is_binary(result) ->
+        result
+
+      other ->
+        raise ArgumentError,
+          message: "could not convert characters to binary: #{inspect(other)}"
     end
   end
 

--- a/apps/debug_adapter/test/utils_test.exs
+++ b/apps/debug_adapter/test/utils_test.exs
@@ -68,5 +68,11 @@ defmodule ElixirLS.DebugAdapter.UtilsTest do
       assert 6 == Utils.dap_character_to_elixir("Hello 🙌 World", 7)
       assert 7 == Utils.dap_character_to_elixir("Hello 🙌 World", 8)
     end
+
+    test "dap_character_to_elixir invalid utf8" do
+      assert_raise ArgumentError, ~r/could not convert characters/, fn ->
+        Utils.dap_character_to_elixir(<<0x80>>, 1)
+      end
+    end
   end
 end

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -160,7 +160,12 @@ defmodule ElixirLS.LanguageServer.SourceFile do
 
   defp characters_to_binary!(binary, from, to) do
     case :unicode.characters_to_binary(binary, from, to) do
-      result when is_binary(result) -> result
+      result when is_binary(result) ->
+        result
+
+      other ->
+        raise ArgumentError,
+          message: "could not convert characters to binary: #{inspect(other)}"
     end
   end
 

--- a/apps/language_server/test/source_file_test.exs
+++ b/apps/language_server/test/source_file_test.exs
@@ -647,6 +647,14 @@ defmodule ElixirLS.LanguageServer.SourceFileTest do
     end
   end
 
+  describe "characters_to_binary!/3" do
+    test "raises for invalid utf8" do
+      assert_raise ArgumentError, ~r/could not convert characters/, fn ->
+        SourceFile.line_length_utf16(<<0x80>>)
+      end
+    end
+  end
+
   describe "positions" do
     test "lsp_position_to_elixir empty" do
       assert {1, 1} == SourceFile.lsp_position_to_elixir("", {0, 0})


### PR DESCRIPTION
## Summary
- tighten error handling for characters_to_binary!/3
- test that invalid UTF8 input raises

## Testing
- `mix test test/source_file_test.exs --seed 0 --no-deps-check` in apps/language_server
- `mix test test/utils_test.exs --seed 0` in apps/debug_adapter

------
https://chatgpt.com/codex/tasks/task_e_685130c635fc83218ba1f36ceab68bc3