### PR TITLE
Fix trailing slash handling in path_in_dir? and add tests

### DIFF
--- a/apps/language_server/lib/language_server/source_file/path.ex
+++ b/apps/language_server/lib/language_server/source_file/path.ex
@@ -147,6 +147,8 @@ defmodule ElixirLS.LanguageServer.SourceFile.Path do
 
   # This function expects absolute paths with universal separators
   def path_in_dir?(file, dir) do
+    dir = if dir == "/", do: "/", else: String.trim_trailing(dir, "/")
+
     case String.starts_with?(file, dir) do
       true ->
         # Get the grapheme after the directory in the file path

--- a/apps/language_server/test/source_file/path_test.exs
+++ b/apps/language_server/test/source_file/path_test.exs
@@ -191,4 +191,18 @@ defmodule ElixirLS.LanguageServer.SourceFile.PathTest do
       end
     end
   end
+
+  describe "path_in_dir?/2" do
+    test "matches regardless of trailing slash" do
+      assert path_in_dir?("/foo/bar.ex", "/foo")
+      assert path_in_dir?("/foo/bar.ex", "/foo/")
+      assert path_in_dir?("c:/foo/bar.ex", "c:/foo")
+      assert path_in_dir?("c:/foo/bar.ex", "c:/foo/")
+    end
+
+    test "non-matching paths" do
+      refute path_in_dir?("/foobar/baz.ex", "/foo")
+      refute path_in_dir?("/foobar/baz.ex", "/foo/")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- normalize the directory argument in `path_in_dir?/2` before comparison
- test path matching with trailing slashes

## Testing
- `mix test test/source_file/path_test.exs`

------
https://chatgpt.com/codex/tasks/task_e_685130adc9ac8321b36e7e17b55ad0a0