### PR TITLE
Fix spec for log message in breakpoint condition

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
+++ b/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
@@ -41,7 +41,7 @@ defmodule ElixirLS.DebugAdapter.BreakpointCondition do
   end
 
   @spec get_condition(module, non_neg_integer) ::
-          {Macro.Env.t(), String.t(), String.t(), String.t(), non_neg_integer}
+          {Macro.Env.t(), String.t(), String.t() | nil, String.t(), non_neg_integer}
   def get_condition(name \\ __MODULE__, number) do
     GenServer.call(name, {:get_condition, number})
   end


### PR DESCRIPTION
## Summary
- allow `nil` log message in `BreakpointCondition.get_condition/2`

## Testing
- `mix format apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex`
- `mix deps.get` *(fails: upstream connect error)*
- `mix test` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68513907048083218dc3a15365b68b93