### PR TITLE
Handle empty lists in merge_ranges_lists

### DIFF
--- a/apps/language_server/lib/language_server/range_utils.ex
+++ b/apps/language_server/lib/language_server/range_utils.ex
@@ -120,6 +120,16 @@ defmodule ElixirLS.LanguageServer.RangeUtils do
     result
   end
 
+  def merge_ranges_lists([], []), do: []
+
+  def merge_ranges_lists([], _ranges_2) do
+    raise ArgumentError, message: "ranges_1 is empty"
+  end
+
+  def merge_ranges_lists(_ranges_1, []) do
+    raise ArgumentError, message: "ranges_2 is empty"
+  end
+
   def merge_ranges_lists(ranges_1, ranges_2) do
     if hd(ranges_1) != hd(ranges_2) do
       raise ArgumentError, message: "range list do not start with the same range"

--- a/apps/language_server/test/range_utils_test.exs
+++ b/apps/language_server/test/range_utils_test.exs
@@ -526,6 +526,26 @@ defmodule ElixirLS.LanguageServer.RangeUtilsTest do
 
       assert merge_ranges_lists(range_1, range_2) == expected
     end
+
+    test "handles empty lists" do
+      assert merge_ranges_lists([], []) == []
+    end
+
+    test "raises if ranges_1 is empty" do
+      range_2 = [range(1, 1, 5, 5)]
+
+      assert_raise ArgumentError, "ranges_1 is empty", fn ->
+        merge_ranges_lists([], range_2)
+      end
+    end
+
+    test "raises if ranges_2 is empty" do
+      range_1 = [range(1, 1, 5, 5)]
+
+      assert_raise ArgumentError, "ranges_2 is empty", fn ->
+        merge_ranges_lists(range_1, [])
+      end
+    end
   end
 
   describe "deduplicate/1" do


### PR DESCRIPTION
## Summary
- guard against empty lists before calling `merge_ranges_lists/2`
- ensure ArgumentError messages for missing lists
- test empty list cases

## Testing
- `mix test` *(fails: dependencies not available)*

------
https://chatgpt.com/codex/tasks/task_e_68514885fcc8832183bf6ff06923da20