### PR TITLE
Fix get_condition spec

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
+++ b/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
@@ -41,7 +41,7 @@ defmodule ElixirLS.DebugAdapter.BreakpointCondition do
   end
 
   @spec get_condition(module, non_neg_integer) ::
-          {Macro.Env.t(), String.t(), String.t(), String.t(), non_neg_integer}
+          {Macro.Env.t(), String.t(), String.t() | nil, String.t(), non_neg_integer}
   def get_condition(name \\ __MODULE__, number) do
     GenServer.call(name, {:get_condition, number})
   end


### PR DESCRIPTION
## Summary
- document that `get_condition/2` may return a nil log message

## Testing
- `mix format`
- `mix test` *(fails: typed_struct dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68518c140c088321b39e580d1733cc8d