### PR TITLE
Fix version string quoting

### DIFF
--- a/apps/elixir_ls_utils/lib/launch.ex
+++ b/apps/elixir_ls_utils/lib/launch.ex
@@ -36,10 +36,10 @@ defmodule ElixirLS.Utils.Launch do
 
   def get_versions do
     %{
-      current_elixir_version: inspect(System.build_info()[:build]),
-      current_otp_version: inspect(System.otp_release()),
-      compile_elixir_version: inspect(@compiled_elixir_version),
-      compile_otp_version: inspect(@compiled_otp_version)
+      current_elixir_version: to_string(System.build_info()[:build]),
+      current_otp_version: to_string(System.otp_release()),
+      compile_elixir_version: to_string(@compiled_elixir_version),
+      compile_otp_version: to_string(@compiled_otp_version)
     }
   end
 

--- a/apps/elixir_ls_utils/test/launch_test.exs
+++ b/apps/elixir_ls_utils/test/launch_test.exs
@@ -1,0 +1,17 @@
+defmodule ElixirLS.Utils.LaunchTest do
+  use ExUnit.Case, async: true
+
+  test "get_versions returns plain strings" do
+    versions = ElixirLS.Utils.Launch.get_versions()
+
+    assert is_binary(versions.current_elixir_version)
+    assert is_binary(versions.current_otp_version)
+    assert is_binary(versions.compile_elixir_version)
+    assert is_binary(versions.compile_otp_version)
+
+    for value <- Map.values(versions) do
+      refute String.starts_with?(value, "\"")
+      refute String.ends_with?(value, "\"")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- use `to_string/1` instead of `inspect/1` in `get_versions/0`
- add test checking returned version strings are not quoted

## Testing
- `mix test --max-failures 1` *(fails: BREAK due to interactive test)*

------
https://chatgpt.com/codex/tasks/task_e_685136ee24108321ad7ad9a621c6834f