### PR TITLE
Update return spec

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
+++ b/apps/debug_adapter/lib/debug_adapter/breakpoint_condition.ex
@@ -41,7 +41,7 @@ defmodule ElixirLS.DebugAdapter.BreakpointCondition do
   end
 
   @spec get_condition(module, non_neg_integer) ::
-          {Macro.Env.t(), String.t(), String.t(), String.t(), non_neg_integer}
+          {Macro.Env.t(), String.t(), String.t() | nil, String.t(), non_neg_integer}
   def get_condition(name \\ __MODULE__, number) do
     GenServer.call(name, {:get_condition, number})
   end


### PR DESCRIPTION
## Summary
- clarify the return spec for `get_condition/2`

## Testing
- `mix deps.get` *(fails: upstream connect error)*
- `mix test` *(fails: compilation error in lib/has_error.ex)*

------
https://chatgpt.com/codex/tasks/task_e_685138f4ba3883218817116cd2f66759