### PR TITLE
Fix spec for notify_uris_modified

### DIFF
--- a/apps/language_server/lib/language_server/providers/workspace_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/workspace_symbols.ex
@@ -60,7 +60,7 @@ defmodule ElixirLS.LanguageServer.Providers.WorkspaceSymbols do
     end
   end
 
-  @spec notify_uris_modified([String.t()]) :: :ok | nil
+  @spec notify_uris_modified([String.t()], GenServer.server()) :: :ok | nil
   def notify_uris_modified(uris, server \\ __MODULE__) do
     unless :persistent_term.get(:language_server_test_mode, false) and
              not :persistent_term.get(:language_server_override_test_mode, false) do


### PR DESCRIPTION
## Summary
- specify the `server` argument in `notify_uris_modified/2` spec

## Testing
- `mix format` in project root and in `apps/language_server`
- `mix deps.get` *(fails: upstream connect error)*
- `mix test` *(fails: can't continue due to errors on dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685271984bfc83219b34f3c88178f91a