### PR TITLE
Add error dictionary for DAP errors

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/error_dictionary.ex
+++ b/apps/debug_adapter/lib/debug_adapter/error_dictionary.ex
@@ -1,0 +1,23 @@
+defmodule ElixirLS.DebugAdapter.ErrorDictionary do
+  @moduledoc """
+  Provides mapping from error names to unique integer codes for DAP error messages.
+  """
+
+  @codes %{
+    "internalServerError" => 1,
+    "cancelled" => 2,
+    "invalidRequest" => 3,
+    "launchError" => 4,
+    "attachError" => 5,
+    "invalidArgument" => 6,
+    "evaluateError" => 7,
+    "argumentError" => 8,
+    "runtimeError" => 9,
+    "notSupported" => 10
+  }
+
+  @spec code(String.t()) :: integer()
+  def code(name) do
+    Map.fetch!(@codes, name)
+  end
+end

--- a/apps/debug_adapter/lib/debug_adapter/output.ex
+++ b/apps/debug_adapter/lib/debug_adapter/output.ex
@@ -24,6 +24,7 @@ defmodule ElixirLS.DebugAdapter.Output do
   def send_error_response(
         server \\ __MODULE__,
         request_packet,
+        error_code,
         message,
         format,
         variables,
@@ -32,8 +33,8 @@ defmodule ElixirLS.DebugAdapter.Output do
       ) do
     GenServer.call(
       server,
-      {:send_error_response, request_packet, message, format, variables, send_telemetry,
-       show_user},
+      {:send_error_response, request_packet, error_code, message, format, variables,
+       send_telemetry, show_user},
       :infinity
     )
   end
@@ -142,8 +143,8 @@ defmodule ElixirLS.DebugAdapter.Output do
   end
 
   def handle_call(
-        {:send_error_response, request_packet, message, format, variables, send_telemetry,
-         show_user},
+        {:send_error_response, request_packet, error_code, message, format, variables,
+         send_telemetry, show_user},
         _from,
         seq
       ) do
@@ -159,8 +160,7 @@ defmodule ElixirLS.DebugAdapter.Output do
           message: message,
           body: %{
             error: %GenDAP.Structures.Message{
-              # TODO unique ids
-              id: 1,
+              id: error_code,
               format: format,
               variables: variables,
               send_telemetry: send_telemetry,

--- a/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
+++ b/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
@@ -61,8 +61,8 @@ defmodule ElixirLS.DebugAdapter.Protocol.Basic do
     message_value = Macro.expand_once(message, __CALLER__)
     error_id =
       case message_value do
-        value when is_binary(value) -> ErrorDictionary.code(value)
-        _ -> quote(do: ErrorDictionary.code(unquote(message)))
+        value when is_binary(value) -> ElixirLS.DebugAdapter.ErrorDictionary.code(value)
+        _ -> quote(do: ElixirLS.DebugAdapter.ErrorDictionary.code(unquote(message)))
       end
 
     quote do

--- a/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
+++ b/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
@@ -58,6 +58,13 @@ defmodule ElixirLS.DebugAdapter.Protocol.Basic do
              send_telemetry,
              show_user
            ) do
+    message_value = Macro.expand_once(message, __CALLER__)
+    error_id =
+      case message_value do
+        value when is_binary(value) -> ErrorDictionary.code(value)
+        _ -> quote(do: ErrorDictionary.code(unquote(message)))
+      end
+
     quote do
       %{
         "type" => "response",
@@ -68,7 +75,7 @@ defmodule ElixirLS.DebugAdapter.Protocol.Basic do
         "message" => unquote(message),
         "body" => %{
           "error" => %{
-            "id" => ElixirLS.DebugAdapter.ErrorDictionary.code(unquote(message)),
+            "id" => unquote(error_id),
             "format" => unquote(format),
             "variables" => unquote(variables),
             "showUser" => unquote(show_user),

--- a/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
+++ b/apps/debug_adapter/lib/debug_adapter/protocol.basic.ex
@@ -68,7 +68,7 @@ defmodule ElixirLS.DebugAdapter.Protocol.Basic do
         "message" => unquote(message),
         "body" => %{
           "error" => %{
-            "id" => unquote(seq),
+            "id" => ElixirLS.DebugAdapter.ErrorDictionary.code(unquote(message)),
             "format" => unquote(format),
             "variables" => unquote(variables),
             "showUser" => unquote(show_user),

--- a/apps/debug_adapter/test/output_test.exs
+++ b/apps/debug_adapter/test/output_test.exs
@@ -1,0 +1,29 @@
+defmodule ElixirLS.DebugAdapter.OutputTest do
+  use ExUnit.Case, async: true
+  import ElixirLS.DebugAdapter.Protocol.Basic
+
+  alias ElixirLS.DebugAdapter.Output
+
+  setup do
+    {:ok, capture} = ElixirLS.Utils.PacketCapture.start_link(self())
+    {:ok, output} = Output.start(:output_test)
+    Process.group_leader(output, capture)
+
+    on_exit(fn ->
+      if Process.alive?(output), do: GenServer.stop(output)
+    end)
+
+    {:ok, %{output: output}}
+  end
+
+  test "error response uses provided id", %{output: output} do
+    req = request(1, "cmd")
+    Output.send_error_response(output, req, 42, "err", "fmt", %{}, false, false)
+
+    assert_receive %{
+      "body" => %{"error" => %{"id" => 42}},
+      "seq" => 1,
+      "request_seq" => 1
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- introduce `ErrorDictionary` mapping known error names to fixed codes
- update `Output` to accept explicit error codes
- use error codes in `Protocol.Basic.error_response`
- propagate error codes in `Server` when sending error responses
- adjust `OutputTest` for new API

## Testing
- `mix deps.get`
- `mix test` *(failed: dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_685148749af88321ae863bbdbf2484d3