### PR TITLE
Handle mix project cache before load

### DIFF
--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -246,11 +246,16 @@ defmodule ElixirLS.LanguageServer.SourceFile do
 
       if mix_project? do
         if MixProjectCache.loaded?() do
+          {:ok, deps_paths} = MixProjectCache.deps_paths()
+          {:ok, manifest_path} = MixProjectCache.manifest_path()
+          {:ok, config_mtime} = MixProjectCache.config_mtime()
+          {:ok, mix_project} = MixProjectCache.get()
+
           opts = [
-            deps_paths: MixProjectCache.deps_paths(),
-            manifest_path: MixProjectCache.manifest_path(),
-            config_mtime: MixProjectCache.config_mtime(),
-            mix_project: MixProjectCache.get(),
+            deps_paths: deps_paths,
+            manifest_path: manifest_path,
+            config_mtime: config_mtime,
+            mix_project: mix_project,
             root: project_dir,
             plugin_loader: fn plugins ->
               for plugin <- plugins do

--- a/apps/language_server/test/mix_project_cache_test.exs
+++ b/apps/language_server/test/mix_project_cache_test.exs
@@ -1,0 +1,16 @@
+defmodule ElixirLS.LanguageServer.MixProjectCacheTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirLS.LanguageServer.MixProjectCache
+
+  setup do
+    {:ok, pid} = start_supervised(MixProjectCache)
+    %{pid: pid}
+  end
+
+  test "returns not_loaded when state is nil", %{pid: pid} do
+    assert {:error, :not_loaded} = MixProjectCache.get()
+    assert {:error, :not_loaded} = MixProjectCache.config()
+    assert Process.alive?(pid)
+  end
+end


### PR DESCRIPTION
## Summary
- return `{:ok, value}` from `MixProjectCache` when cache is loaded
- propagate the new API in server code and source file helpers
- keep returning `{:error, :not_loaded}` when state hasn't been stored yet

## Testing
- `mix format`
- `mix test` *(fails: dependencies require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6851372b613c8321a8b129a1bd492223