### PR TITLE
Fix remote PID handling

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/server.ex
+++ b/apps/debug_adapter/lib/debug_adapter/server.ex
@@ -2942,7 +2942,10 @@ defmodule ElixirLS.DebugAdapter.Server do
     rescue
       ArgumentError ->
         # remote process
-        process_name_from_snapshot(Map.fetch!(snapshot_by_pid, pid))
+        case Map.get(snapshot_by_pid, pid) do
+          nil -> nil
+          snapshot -> process_name_from_snapshot(snapshot)
+        end
     else
       nil -> nil
       process_info -> process_name_from_info(process_info)


### PR DESCRIPTION
## Summary
- avoid crashing when a remote PID isn't present in the snapshot
- return nil when snapshot lookup fails
- remove invalid test for private function

## Testing
- `mix test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68526e20dcf08321b16168e8aad68fc1