### PR TITLE
Fix remote pid lookup with missing snapshot

### DIFF
--- a/apps/debug_adapter/lib/debug_adapter/server.ex
+++ b/apps/debug_adapter/lib/debug_adapter/server.ex
@@ -2942,10 +2942,19 @@ defmodule ElixirLS.DebugAdapter.Server do
     rescue
       ArgumentError ->
         # remote process
-        process_name_from_snapshot(Map.fetch!(snapshot_by_pid, pid))
+        case Map.get(snapshot_by_pid, pid) do
+          nil -> nil
+          snapshot -> process_name_from_snapshot(snapshot)
+        end
     else
-      nil -> nil
-      process_info -> process_name_from_info(process_info)
+      nil ->
+        case Map.get(snapshot_by_pid, pid) do
+          nil -> nil
+          snapshot -> process_name_from_snapshot(snapshot)
+        end
+
+      process_info ->
+        process_name_from_info(process_info)
     end
   end
 


### PR DESCRIPTION
## Summary
- avoid raising when snapshot info for remote pid is missing
- return `nil` when no process info or snapshot is available
- remove incomplete remote pid unit test

## Testing
- `mix deps.get`
- `mix test apps/debug_adapter/test/server_remote_pid_test.exs` *(fails: file not found)*
- `mix test` *(aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685275458e6883218bbffcb64e61c82a