### PR TITLE
Fix MixProjectCache nil state behavior

### DIFF
--- a/apps/language_server/lib/language_server/mix_project_cache.ex
+++ b/apps/language_server/lib/language_server/mix_project_cache.ex
@@ -168,6 +168,10 @@ defmodule ElixirLS.LanguageServer.MixProjectCache do
   end
 
   @impl GenServer
+  def handle_call({:get, key}, _from, nil) do
+    {:reply, nil, nil}
+  end
+
   def handle_call({:get, key}, _from, state) do
     {:reply, Map.fetch!(state, key), state}
   end


### PR DESCRIPTION
## Summary
- avoid crashing when MixProjectCache is queried before it stores a project
- return `nil` if the project cache hasn't been loaded yet

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849333c22a88321b1044b5c33279332