### PR TITLE
fix: remove assumption to fix deterministic builds

### DIFF
--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -145,7 +145,7 @@ defmodule ElixirLS.LanguageServer do
     elixir_sources_available =
       # handle possible nil from deterministic build of elixir
       unless enum_ex_path && File.exists?(enum_ex_path, [:raw]) do
-        dir = Path.join(enum_ex_path || ~c"/", "../../../..") |> Path.expand()
+        dir = (enum_ex_path || ~c"/") |> Path.join("../../../..") |> Path.expand()
 
         Logger.notice(
           "Elixir sources not found (checking in #{dir}). Code navigation to Elixir modules disabled."

--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -143,8 +143,9 @@ defmodule ElixirLS.LanguageServer do
     enum_ex_path = Enum.module_info()[:compile][:source]
 
     elixir_sources_available =
-      unless File.exists?(enum_ex_path, [:raw]) do
-        dir = Path.join(enum_ex_path, "../../../..") |> Path.expand()
+      # handle possible nil from deterministic build of elixir
+      unless enum_ex_path && File.exists?(enum_ex_path, [:raw]) do
+        dir = Path.join(enum_ex_path || ~c"/", "../../../..") |> Path.expand()
 
         Logger.notice(
           "Elixir sources not found (checking in #{dir}). Code navigation to Elixir modules disabled."


### PR DESCRIPTION
Current code has an assumption that `[:compile][:source]` will always exist in the output of `Enum.module_info()`. This is stripped from Elixir's deterministic build toggle
(`ERL_COMPILER_OPTIONS=deterministic`).

Added an assumption for `~"/"` as a fallback when such a case happens to keep the old logging behaviour. This can be changed as seen fit.

Manual testing shows that elixir-ls will no longer throw on startup due to `nil` given as a path with a deterministic build of Elixir.

Fixes #1197