### PR TITLE
Relax stdlib check when detecting stdlib location

### DIFF
--- a/apps/language_server/lib/language_server.ex
+++ b/apps/language_server/lib/language_server.ex
@@ -143,16 +143,23 @@ defmodule ElixirLS.LanguageServer do
     enum_ex_path = Enum.module_info()[:compile][:source]
 
     elixir_sources_available =
-      unless File.exists?(enum_ex_path, [:raw]) do
-        dir = Path.join(enum_ex_path, "../../../..") |> Path.expand()
+      cond do
+        is_nil(enum_ex_path) ->
+          Logger.notice("Elixir sources not found. Code navigation to Elixir modules disabled.")
 
-        Logger.notice(
-          "Elixir sources not found (checking in #{dir}). Code navigation to Elixir modules disabled."
-        )
+          false
 
-        false
-      else
-        true
+        File.exists?(enum_ex_path, [:raw]) ->
+          dir = Path.join(enum_ex_path, "../../../..") |> Path.expand()
+
+          Logger.notice(
+            "Elixir sources not found (checking in #{dir}). Code navigation to Elixir modules disabled."
+          )
+
+          false
+
+        :otherwise ->
+          true
       end
 
     JsonRpc.telemetry(


### PR DESCRIPTION
This PR fixes a crash that happens if Elixir has been built with the `ERL_COMPILER_OPTIONS=deterministic` compiler flag. That flag causes the build to strip out the source tag from the compilation info of stdlib modules.

When finding the Elixir sources, we elixir-ls would crash because `enum_ex_path` is nil when the source tag isn't set and `File.exists?/2` does not support nil as its first argument.

This PR relaxes the constraint by first checking whether `enum_ex_path` is nil, in which case a different log message is printed before returning false.

Fixes #1197