### PR TITLE
Fix packet stream error branch

### DIFF
--- a/apps/elixir_ls_utils/lib/packet_stream.ex
+++ b/apps/elixir_ls_utils/lib/packet_stream.ex
@@ -38,8 +38,6 @@ defmodule ElixirLS.Utils.PacketStream do
           :ok
 
         {:error, reason} ->
-          "Unable to read from input device: #{inspect(reason)}"
-
           error_message =
             unless Process.alive?(pid) do
               receive do


### PR DESCRIPTION
## Summary
- remove stray error message string in PacketStream
- start error branch by building `error_message`

## Testing
- `mix test` in apps/elixir_ls_utils

------
https://chatgpt.com/codex/tasks/task_e_686ee008ad3483219236fe3a8328542e