### PR TITLE
Support includeDeclaration in references

### DIFF
--- a/apps/language_server/test/providers/references_test.exs
+++ b/apps/language_server/test/providers/references_test.exs
@@ -156,6 +156,28 @@ defmodule ElixirLS.LanguageServer.Providers.ReferencesTest do
            ]
   end
 
+  test "respects includeDeclaration flag for variables" do
+    file_path = FixtureHelpers.get_path("references_referenced.ex")
+    parser_context = ParserContextBuilder.from_path(file_path)
+    uri = SourceFile.Path.to_uri(file_path)
+    {line, char} = {4, 14}
+
+    ElixirLS.Test.TextLoc.annotate_assert(file_path, line, char, """
+        IO.puts(referenced_variable + 1)
+                  ^
+    """)
+
+    {line, char} =
+      SourceFile.lsp_position_to_elixir(parser_context.source_file.text, {line, char})
+
+    assert References.references(parser_context, uri, line, char, false, File.cwd!()) == [
+             %GenLSP.Structures.Location{
+               range: range(4, 12, 4, 31),
+               uri: uri
+             }
+           ]
+  end
+
   test "finds references to an attribute" do
     file_path = FixtureHelpers.get_path("references_referenced.ex")
     parser_context = ParserContextBuilder.from_path(file_path)


### PR DESCRIPTION
## Summary
- respect `includeDeclaration` flag in `textDocument/references`
- test variable references when `includeDeclaration` is false
- ensure definition and declaration locations are added when requested

## Testing
- `mix test apps/language_server/test/providers/references_test.exs --trace` *(fails: Can't continue due to errors on dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6872236c64688321977328c2684195be