### PR TITLE
don't put dot_formatter when blank string

### DIFF
--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -332,7 +332,9 @@ defmodule ElixirLS.LanguageServer.SourceFile do
   def formatter_for(_, _, _, _), do: {:error, :project_dir_not_set}
 
   defp maybe_put_dot_formatter(opts_list, opts) do
-    if dot = Keyword.get(opts, :dot_formatter) do
+    dot = opts |> Keyword.get(:dot_formatter) |> to_string() |> String.trim()
+
+    if dot != "" do
       Keyword.put(opts_list, :dot_formatter, dot)
     else
       opts_list

--- a/apps/language_server/test/providers/formatting_test.exs
+++ b/apps/language_server/test/providers/formatting_test.exs
@@ -523,4 +523,31 @@ defmodule ElixirLS.LanguageServer.Providers.FormattingTest do
                )
     end)
   end
+
+  @tag :fixture
+  test "dot_formatter is empty string" do
+    in_fixture(Path.join(__DIR__, ".."), "formatter", fn ->
+      store_mix_cache()
+      project_dir = Path.expand(".")
+      path = Path.join(project_dir, "lib/custom.ex")
+      File.write!(path, "foo 1")
+      source_file = %SourceFile{text: "foo 1", version: 1, dirty?: true}
+      uri = SourceFile.Path.to_uri(path)
+
+      assert {:ok, edits} = Formatting.format(source_file, uri, project_dir, true)
+      assert length(edits) >= 1
+
+      assert {:ok, empty_string_edits} =
+        Formatting.format(source_file, uri, project_dir, true, dot_formatter: "")
+      assert length(empty_string_edits) >= 1
+
+      assert edits == empty_string_edits
+
+      assert {:ok, newline_string_edits} =
+        Formatting.format(source_file, uri, project_dir, true, dot_formatter: "\n")
+      assert length(newline_string_edits) >= 1
+
+      assert edits == newline_string_edits
+    end)
+  end
 end


### PR DESCRIPTION
When I upgraded to elixir-ls 0.29, I noticed my format on save stopped working.

I saw this in the stack trace:
```
/Users/taylor.redden/code/my-project/lib/my_project/foo.ex: "** (Code.LoadError) could not load /Users/taylor.redden/code/my-project. Reason: eisdir
 (elixir 1.18.1) lib/code.ex:2219: Code.find_file!/2
 (elixir 1.18.1) lib/code.ex:1464: Code.eval_file/2
 (language_server 0.29.0) lib/language_server/mix_tasks/format.ex:604: Mix.Tasks.ElixirLSFormat.eval_file_with_keyword_list/1
 (language_server 0.29.0) lib/language_server/mix_tasks/format.ex:456: Mix.Tasks.ElixirLSFormat.eval_dot_formatter/2
 (language_server 0.29.0) lib/language_server/mix_tasks/format.ex:431: Mix.Tasks.ElixirLSFormat.formatter_for_file/2
 (language_server 0.29.0) lib/language_server/source_file.ex:296: ElixirLS.LanguageServer.SourceFile.formatter_for/4
 (language_server 0.29.0) lib/language_server/providers/formatting.ex:21: ElixirLS.LanguageServer.Providers.Formatting.format/5
 (language_server 0.29.0) lib/language_server/server.ex:1747:...
```

I looked at the recent changes, and noticed the addition of the dotFormatter option: 

https://github.com/elixir-lsp/vscode-elixir-ls/blob/master/package.json#L227

I wrote a test that recreated the issue:

<img width="1725" height="699" alt="Screenshot 2025-08-05 at 10 15 39 AM" src="https://github.com/user-attachments/assets/a30ad107-0044-4ecc-af05-ff98bd835b77" />

And I made a small change that should help scenarios where that dot_formatter option is a blank string.

```
  defp maybe_put_dot_formatter(opts_list, opts) do
    dot = opts |> Keyword.get(:dot_formatter) |> to_string() |> String.trim()

    if dot != "" do
      Keyword.put(opts_list, :dot_formatter, dot)
    else
      opts_list
    end
  end
```

let me know if I need to change the target branch or if you want any code changes.