### PR TITLE
Update support matrix, mix Elixir version to >= 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,13 @@ ElixirLS generally aims to support all supported versions of Elixir on all compa
 |      any        |     1.10     |        No         |             Latest release not compatible. Last version known to work v0.10.0    |
 |      any        |     1.11     |        No         |             Latest release not compatible. Last version known to work v0.12.0    |
 |      any        |     1.12     |        No         |             Latest release not compatible. Last version known to work v0.23.0                  |
-|     22 - 25        |       1.13      |    Unknown    |  Latest release may still work but no longer supported, Last version known to work v0.26.4          |
-|     23 - 26        |       1.14      |    Unknown    |  Latest release may still work but no longer supported, Last version known to work v0.29.3          |
-|      23         |       1.14   |        Yes        |                            None                            |
-|      24         |   1.14 - 1.16   |        Yes        |                            None                            |
-|      25         |  1.14 - 1.18  |        Yes        |                            None                            |
+|     22 - 25        |       1.13      |        No         |  Latest release not compatible. Last version known to work v0.26.4          |
+|     23 - 26        |       1.14      |        No         |  Latest release not compatible. Last version known to work v0.29.3          |
+|      24         |   1.15 - 1.16   |        Yes        |                            None                            |
+|      25         |  1.15 - 1.18  |        Yes        |                            None                            |
 | 26.0.0 - 26.0.1 |       any       |        No         | [#886](https://github.com/elixir-lsp/elixir-ls/issues/886) |
-| 26.0.2 - 26.1.2 |  1.14.5 - 1.18  |    *nix only      | [#927](https://github.com/elixir-lsp/elixir-ls/issues/927), [#1023](https://github.com/elixir-lsp/elixir-ls/issues/1023) |
-|   >= 26.2.0     |  1.14.5 - 1.18  |        Yes        |                            None                            |
+| 26.0.2 - 26.1.2 |  1.15 - 1.18  |    *nix only      | [#927](https://github.com/elixir-lsp/elixir-ls/issues/927), [#1023](https://github.com/elixir-lsp/elixir-ls/issues/1023) |
+|   >= 26.2.0     |  1.15 - 1.18  |        Yes        |                            None                            |
 |      any        |     1.15.5      |        Yes        |  Broken formatter [#975](https://github.com/elixir-lsp/elixir-ls/issues/975) |
 |      27         |    1.17 - 1.18  |        Yes        |                            None                            |
 |      28         |      1.18.4     |      Unknown    |  Elixir retracted support for OTP 28 in 1.18, Latest release may work but is not supported    |

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -15,7 +15,7 @@ defmodule ElixirLS.LanguageServer.MixProject do
     [
       app: :language_server,
       version: @version,
-      elixir: ">= 1.13.0",
+      elixir: ">= 1.15.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ElixirLS.Mixfile do
       start_permanent: Mix.env() == :prod,
       build_per_environment: false,
       deps: deps(),
-      elixir: ">= 1.13.0",
+      elixir: ">= 1.15.0",
       dialyzer: [
         plt_add_apps: [:dialyxir_vendored, :debugger, :dialyzer, :ex_unit, :hex, :mix],
         flags: [


### PR DESCRIPTION
* Update support matrix to specify no support for Elixir 1.14
* Update relevant `mix.exs` files to require Elixir >= 1.15

Fixes #1250 