### PR TITLE
Fix installer crash on Elixir 1.18.x when config_path is nil

### DIFF
--- a/scripts/installer.exs
+++ b/scripts/installer.exs
@@ -370,7 +370,10 @@ defmodule ElixirLS.Mix do
           File.cd!(install_project_dir, fn ->
             # This step needs to be mirrored in mix deps.partition
             Application.put_all_env(config, persistent: true)
-            Mix.Task.rerun("loadconfig")
+
+            if config_path do
+              Mix.Task.rerun("loadconfig")
+            end
 
             cond do
               external_lockfile ->


### PR DESCRIPTION
Aims to address https://github.com/elixir-lsp/vscode-elixir-ls/issues/528
## Problem

Launching ElixirLS from a release fails on Elixir 1.18.x and the server crashes on every start:

```
Mix.install failed with ** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1
    (elixir 1.18.3) lib/io.ex:710: IO.chardata_to_string(nil)
    (elixir 1.18.3) lib/file.ex:177: File.regular?/2
    (mix 1.18.3) lib/mix/tasks/loadconfig.ex:41: Mix.Tasks.Loadconfig.load_default/0
    scripts/installer.exs:373: anonymous fn/7 in ElixirLS.Mix.install/2
    scripts/installer.exs:617: ElixirLS.Installer.install/1
```

VS Code retries and then gives up after 5 crashes in 3 minutes.

## Root cause

`scripts/installer.exs` is a vendored copy of Elixir's `Mix.install`. After pushing the install project it runs:

```elixir
Mix.Task.rerun("loadconfig")
```

unconditionally. The release-install path (`{:tag, tag}`) does **not** pass a `:config_path` option, so `config_path` resolves to `nil`. On Elixir 1.18.x, `Mix.Tasks.Loadconfig.load_default/0` evaluates `File.regular?(config[:config_path])` — i.e. `File.regular?(nil)` — which raises `FunctionClauseError` inside `IO.chardata_to_string/1`.

Upstream Mix guards **both** the `loadconfig` and `app.config` tasks with `if config_path`. In this file only the `app.config` call was guarded — the `loadconfig` call was missed.

## Fix

Guard the `loadconfig` task exactly like the adjacent `app.config` task (and like upstream Mix):

```elixir
if config_path do
  Mix.Task.rerun("loadconfig")
end
```

## Testing

- Environment: Elixir 1.18.3 / OTP 27.3.3, macOS.
- `scripts/installer.exs` parses cleanly (`Code.string_to_quoted!/1`).
- Confirmed the unguarded call is what raised (`config_path` is `nil` on the `{:tag, tag}` path); the new guard matches upstream Mix behavior of skipping `loadconfig` when there's no config file.
